### PR TITLE
feat(nginx): add environment variable to disable IPv6 listen bindings (#102)

### DIFF
--- a/api/internal/nginx/default_server_config.go
+++ b/api/internal/nginx/default_server_config.go
@@ -16,8 +16,8 @@ const defaultServerTemplate = `# Default server - catch-all for unmatched reques
 
 # HTTP default server
 server {
-    listen {{.HTTPPort}} default_server;
-    listen [::]:{{.HTTPPort}} default_server;
+    listen {{.HTTPPort}} default_server;{{if not .DisableIPv6}}
+    listen [::]:{{.HTTPPort}} default_server;{{end}}
     server_name _;
 
     # Disable WAF for default server (health check, ACME, etc.)
@@ -104,8 +104,8 @@ server {
 
 # HTTPS default server - reject SSL handshake for unknown/disabled hosts
 server {
-    listen {{.HTTPSPort}} ssl default_server;
-    listen [::]:{{.HTTPSPort}} ssl default_server;
+    listen {{.HTTPSPort}} ssl default_server;{{if not .DisableIPv6}}
+    listen [::]:{{.HTTPSPort}} ssl default_server;{{end}}
     server_name _;
 
     # Reject SSL handshake immediately - no certificate warning, just connection reset
@@ -115,10 +115,11 @@ server {
 
 // DefaultServerConfigData holds data for default server config generation
 type DefaultServerConfigData struct {
-	Action    string // allow, block_403, block_444
-	HTTPPort  string // HTTP listen port (default: 80)
-	HTTPSPort string // HTTPS listen port (default: 443)
-	APIURL    string // API URL for nginx to reach API (default: http://127.0.0.1:9080)
+	Action      string // allow, block_403, block_444
+	HTTPPort    string // HTTP listen port (default: 80)
+	HTTPSPort   string // HTTPS listen port (default: 443)
+	APIURL      string // API URL for nginx to reach API (default: http://127.0.0.1:9080)
+	DisableIPv6 bool
 }
 
 // GenerateDefaultServerConfig generates the default server config based on settings
@@ -136,10 +137,11 @@ func (m *Manager) GenerateDefaultServerConfig(ctx context.Context, action string
 	}
 
 	data := DefaultServerConfigData{
-		Action:    action,
-		HTTPPort:  m.httpPort,
-		HTTPSPort: m.httpsPort,
-		APIURL:    m.apiURL,
+		Action:      action,
+		HTTPPort:    m.httpPort,
+		HTTPSPort:   m.httpsPort,
+		APIURL:      m.apiURL,
+		DisableIPv6: m.disableIPv6,
 	}
 
 	var buf bytes.Buffer

--- a/api/internal/nginx/manager.go
+++ b/api/internal/nginx/manager.go
@@ -32,6 +32,7 @@ type Manager struct {
 	httpsPort      string // HTTPS listen port (default: 443)
 	apiURL         string // API URL for nginx to reach API (default: http://127.0.0.1:9080)
 	dnsResolver    string // DNS resolver for nginx (default: 127.0.0.53 8.8.8.8)
+	disableIPv6    bool   // If true, disables IPv6 listen directives
 }
 
 func NewManager(configPath, certsPath string) *Manager {
@@ -71,6 +72,9 @@ func NewManager(configPath, certsPath string) *Manager {
 		dnsResolver = "127.0.0.53 8.8.8.8"
 	}
 
+	// Disable IPv6 listen directives
+	disableIPv6 := os.Getenv("DISABLE_IPV6") == "true" || os.Getenv("NGINX_DISABLE_IPV6") == "true"
+
 	return &Manager{
 		configPath:     configPath,
 		certsPath:      certsPath,
@@ -81,6 +85,7 @@ func NewManager(configPath, certsPath string) *Manager {
 		httpsPort:      httpsPort,
 		apiURL:         apiURL,
 		dnsResolver:    dnsResolver,
+		disableIPv6:    disableIPv6,
 	}
 }
 
@@ -412,6 +417,7 @@ func (m *Manager) GenerateConfigFull(ctx context.Context, data ProxyHostConfigDa
 	// Set listen ports from manager config
 	data.HTTPPort = m.httpPort
 	data.HTTPSPort = m.httpsPort
+	data.DisableIPv6 = m.disableIPv6
 
 	// Get API host from environment or default (host network mode)
 	apiHostValue := os.Getenv("API_HOST")

--- a/api/internal/nginx/proxy_host_template.go
+++ b/api/internal/nginx/proxy_host_template.go
@@ -89,8 +89,8 @@ upstream {{.Upstream.Name}} {
 
 {{if .Host.Enabled}}
 server {
-    listen {{.HTTPPort}};
-    listen [::]:{{.HTTPPort}};
+    listen {{.HTTPPort}};{{if not .DisableIPv6}}
+    listen [::]:{{.HTTPPort}};{{end}}
     server_name {{join .Host.DomainNames " "}};
 
     # Initialize tracking variables
@@ -938,16 +938,16 @@ server {
 
 {{if .Host.SSLEnabled}}
 server {
-    listen {{.HTTPSPort}} ssl;
-    listen [::]:{{.HTTPSPort}} ssl;
+    listen {{.HTTPSPort}} ssl;{{if not .DisableIPv6}}
+    listen [::]:{{.HTTPSPort}} ssl;{{end}}
 {{if .Host.SSLHTTP2}}
     # HTTP/2 over TCP (new directive style)
     http2 on;
 {{end}}
 {{if .Host.SSLHTTP3}}
     # HTTP/3 over QUIC (UDP)
-    listen {{.HTTPSPort}} quic;
-    listen [::]:{{.HTTPSPort}} quic;
+    listen {{.HTTPSPort}} quic;{{if not .DisableIPv6}}
+    listen [::]:{{.HTTPSPort}} quic;{{end}}
 {{end}}
     server_name {{join .Host.DomainNames " "}};
 
@@ -1761,4 +1761,5 @@ type ProxyHostConfigData struct {
 	GlobalTrustedIPs              []string              // Global trusted IPs that bypass all security (from system settings)
 	HTTPPort                      string                // HTTP listen port (default: 80)
 	HTTPSPort                     string                // HTTPS listen port (default: 443)
+	DisableIPv6                   bool                  // If true, removes [::] bindings
 }

--- a/api/internal/nginx/redirect_config.go
+++ b/api/internal/nginx/redirect_config.go
@@ -15,9 +15,10 @@ import (
 
 // RedirectHostConfigData holds data for redirect host config generation
 type RedirectHostConfigData struct {
-	Host      *model.RedirectHost
-	HTTPPort  string
-	HTTPSPort string
+	Host        *model.RedirectHost
+	HTTPPort    string
+	HTTPSPort   string
+	DisableIPv6 bool
 }
 
 // Redirect host config template
@@ -29,8 +30,8 @@ const redirectHostTemplate = `# nginx-guard generated redirect config
 
 {{if .Host.Enabled}}
 server {
-    listen {{.HTTPPort}};
-    listen [::]:{{.HTTPPort}};
+    listen {{.HTTPPort}};{{if not .DisableIPv6}}
+    listen [::]:{{.HTTPPort}};{{end}}
     server_name {{join .Host.DomainNames " "}};
 
     # Disable WAF for redirect host
@@ -67,11 +68,11 @@ server {
 
 {{if .Host.SSLEnabled}}
 server {
-    listen {{.HTTPSPort}} ssl;
-    listen [::]:{{.HTTPSPort}} ssl;
+    listen {{.HTTPSPort}} ssl;{{if not .DisableIPv6}}
+    listen [::]:{{.HTTPSPort}} ssl;{{end}}
     http2 on;
-    listen {{.HTTPSPort}} quic;
-    listen [::]:{{.HTTPSPort}} quic;
+    listen {{.HTTPSPort}} quic;{{if not .DisableIPv6}}
+    listen [::]:{{.HTTPSPort}} quic;{{end}}
     server_name {{join .Host.DomainNames " "}};
 
     # Disable WAF for redirect host
@@ -124,9 +125,10 @@ func (m *Manager) GenerateRedirectConfig(ctx context.Context, host *model.Redire
 	}
 
 	data := RedirectHostConfigData{
-		Host:      host,
-		HTTPPort:  m.httpPort,
-		HTTPSPort: m.httpsPort,
+		Host:        host,
+		HTTPPort:    m.httpPort,
+		HTTPSPort:   m.httpsPort,
+		DisableIPv6: m.disableIPv6,
 	}
 
 	var buf bytes.Buffer

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -96,6 +96,7 @@ services:
       API_HOST_PORT: ${API_HOST_PORT:-9080}
       # API host for nginx config generation
       API_HOST: ${API_HOST:-127.0.0.1:${API_HOST_PORT:-9080}}
+      DISABLE_IPV6: ${DISABLE_IPV6:-false}
     ports:
       # API host port - MUST NOT conflict with NGINX_HTTP_PORT
       - "127.0.0.1:${API_HOST_PORT:-9080}:8080"

--- a/docker-compose.e2e-test.yml
+++ b/docker-compose.e2e-test.yml
@@ -84,6 +84,7 @@ services:
       NGINX_HTTPS_PORT: "18443"
       API_HOST_PORT: "19080"
       API_HOST: "127.0.0.1:19080"
+      DISABLE_IPV6: ${DISABLE_IPV6:-false}
     ports:
       - "19080:8080"
     depends_on:

--- a/docker-compose.release-test-host.yml
+++ b/docker-compose.release-test-host.yml
@@ -68,6 +68,7 @@ services:
       NGINX_HTTPS_PORT: ${NGINX_HTTPS_PORT:-28443}
       API_HOST_PORT: ${API_HOST_PORT:-29080}
       API_HOST: 127.0.0.1:${API_HOST_PORT:-29080}
+      DISABLE_IPV6: ${DISABLE_IPV6:-false}
     ports:
       - "${API_HOST_PORT:-29080}:8080"  # Bind to all interfaces for test access
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,6 +88,7 @@ services:
       API_HOST_PORT: ${API_HOST_PORT:-9080}
       # API host for nginx config generation
       API_HOST: ${API_HOST:-127.0.0.1:${API_HOST_PORT:-9080}}
+      DISABLE_IPV6: ${DISABLE_IPV6:-false}
     ports:
       # API host port - MUST NOT conflict with NGINX_HTTP_PORT
       - "127.0.0.1:${API_HOST_PORT:-9080}:8080"

--- a/env.example
+++ b/env.example
@@ -50,3 +50,6 @@ DB_NAME=nginx_proxy_guard
 
 # DNS resolver for nginx (space-separated, default: 127.0.0.53 8.8.8.8)
 # DNS_RESOLVER=127.0.0.53 8.8.8.8
+
+# Disable IPv6 listen bindings in Nginx configuration (true/false)
+# DISABLE_IPV6=false


### PR DESCRIPTION
fixed #102 

IPv6 비활성화 환경설정을 추가합니다.
제미나이에게 시키니 이렇게 수정해줬습니다.
잘못된 부분이 있다면 직접 수정하셔도 되고, 지적해주시면 제가 확인해보도록 하겠습니다.

- Parse `DISABLE_IPV6` (or `NGINX_DISABLE_IPV6`) env var in api Manager (`manager.go`).
- Conditionally render `listen [::]` directives in Nginx templates (`proxy_host_template.go`, `redirect_config.go`, `default_server_config.go`).
- Update all config data structures to include `DisableIPv6` boolean flag.
- Add `DISABLE_IPV6` configuration description to `env.example`.
- Expose `DISABLE_IPV6: ${DISABLE_IPV6:-false}` to API service in docker-compose templates (`dev`, `e2e-test`, `release-test-host`, `yml`).

This change provides a way to dynamically exclude IPv6 bindings from the generated `.conf` files for IPv4-only environments.

------------------------------------------------------------------------------------------------------------------------------------------

- api Manager(`manager.go`)에서 `DISABLE_IPV6` 또는 `NGINX_DISABLE_IPV6` 환경변수를 파싱하도록 로직 추가
- Nginx 템플릿(`proxy_host`, `redirect_config`, `default_server_config`) 내부의 `listen [::]` 구문을 조건부(DisableIPv6)로 렌더링하도록 수정
- 모든 Config 구조체에 `DisableIPv6` 상태 변수 추가
- `env.example` 파일에 `DISABLE_IPV6` 설정 관련 주석 추가
- 전체 `docker-compose` 파일의 `api` 서비스 환경 변수에 `DISABLE_IPV6: ${DISABLE_IPV6:-false}` 추가 적용

이 커밋을 통해 IPv4 전용 환경에서 불필요한 IPv6 포트 바인딩 없이 `.conf` 파일을 동적으로 생성할 수 있도록 합니다.

