### PR TITLE
test: add characterization tests for config generation

### DIFF
--- a/api/internal/nginx/advanced_config_characterization_test.go
+++ b/api/internal/nginx/advanced_config_characterization_test.go
@@ -1,0 +1,210 @@
+package nginx
+
+// Characterization tests for parseAdvancedConfigDirectives.
+//
+// These tests freeze CURRENT parser behavior — not what nginx spec says.
+// The parser is intentionally simple: a single regex
+//
+//   (?m)^\s*([a-z_]+)\s+
+//
+// that finds lines (or start-of-line after optional indentation) whose first
+// token is a lowercase identifier followed by whitespace. It returns the SET
+// of first-token names. Known characterization points captured below:
+//
+//   - Nested tokens count too: "location", "if", "return", "rewrite" all show
+//     up as "directives" even though they are nginx blocks/statements.
+//   - Multiple directives on a single line (semicolon-separated) only yield
+//     the FIRST one; the parser does not split on ';'.
+//   - Only leading-line tokens are matched; inline tokens after ';' on the
+//     same line are ignored. (This is a known quirk — do not "fix" here.)
+//   - Uppercase input yields NOTHING because the regex is [a-z_]+ only.
+//   - Commented-out lines ("# name …") are ignored (because '#' is not in
+//     [a-z_]+ and it's non-whitespace, so the match is anchored to the `#`
+//     and fails).
+//   - Malformed tokens that lack a trailing space (e.g. "foo;") are NOT
+//     captured because the regex requires a whitespace character after the
+//     identifier.
+
+import (
+	"sort"
+	"testing"
+)
+
+func TestParseAdvancedConfigDirectives_Characterization(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  []string
+	}{
+		// 1. Empty input.
+		{
+			name:  "empty_input",
+			input: "",
+			want:  nil,
+		},
+		// 2. Single directive.
+		{
+			name:  "single_directive",
+			input: "proxy_read_timeout 60s;",
+			want:  []string{"proxy_read_timeout"},
+		},
+		// 3. Two directives on separate lines.
+		{
+			name:  "two_directives",
+			input: "proxy_read_timeout 60s;\nproxy_send_timeout 30s;",
+			want:  []string{"proxy_read_timeout", "proxy_send_timeout"},
+		},
+		// 4. Leading whitespace (spaces).
+		{
+			name:  "leading_whitespace_spaces",
+			input: "    proxy_read_timeout 60s;",
+			want:  []string{"proxy_read_timeout"},
+		},
+		// 5. Leading whitespace (tab).
+		{
+			name:  "leading_whitespace_tab",
+			input: "\tproxy_read_timeout 60s;",
+			want:  []string{"proxy_read_timeout"},
+		},
+		// 6. Single-line comment (pure comment line is ignored).
+		{
+			name:  "single_line_comment",
+			input: "# this is a comment\nproxy_read_timeout 60s;",
+			want:  []string{"proxy_read_timeout"},
+		},
+		// 7. Inline comment after directive (directive still captured).
+		{
+			name:  "inline_comment",
+			input: "proxy_read_timeout 60s; # inline comment",
+			want:  []string{"proxy_read_timeout"},
+		},
+		// 8. Blank lines before / after.
+		{
+			name:  "blank_lines",
+			input: "\n\nproxy_read_timeout 60s;\n\n",
+			want:  []string{"proxy_read_timeout"},
+		},
+		// 9. Multi-line (multiple) comments.
+		{
+			name:  "multi_line_comments",
+			input: "# c1\n# c2\n# c3\nproxy_read_timeout 60s;",
+			want:  []string{"proxy_read_timeout"},
+		},
+		// 10. Directives inside a location block — BOTH "location" and the
+		//     inner directive are captured.
+		{
+			name:  "inside_location_block",
+			input: "location / {\n    proxy_read_timeout 60s;\n}",
+			want:  []string{"location", "proxy_read_timeout"},
+		},
+		// 11. if block — "if" and "return" are both captured.
+		{
+			name:  "if_block",
+			input: "if ($request_uri ~ \"/blocked\") {\n    return 403;\n}",
+			want:  []string{"if", "return"},
+		},
+		// 12. Multiple directives on a single line — only the FIRST is
+		//     captured (the parser is line-oriented, not semicolon-aware).
+		{
+			name:  "multiple_same_line",
+			input: "proxy_read_timeout 60s; proxy_send_timeout 30s;",
+			want:  []string{"proxy_read_timeout"},
+		},
+		// 13. Duplicate directive across lines — set behavior, single entry.
+		{
+			name:  "duplicate_directive",
+			input: "proxy_read_timeout 60s;\nproxy_read_timeout 90s;",
+			want:  []string{"proxy_read_timeout"},
+		},
+		// 14. Directive with missing semicolon — still captured (the parser
+		//     looks at start-of-line, not statement boundary).
+		{
+			name:  "missing_semicolon",
+			input: "proxy_read_timeout 60s\nproxy_send_timeout 30s;",
+			want:  []string{"proxy_read_timeout", "proxy_send_timeout"},
+		},
+		// 15. Case sensitivity — uppercase input yields NOTHING, because the
+		//     regex class is [a-z_] only. This is a known characterization
+		//     point: nginx itself is case-sensitive and lowercase-by-convention.
+		{
+			name:  "uppercase_not_matched",
+			input: "Proxy_Read_Timeout 60s;\nCLIENT_MAX_BODY_SIZE 100m;",
+			want:  nil,
+		},
+		// 16. Complex value with a quoted string containing ';'.
+		{
+			name:  "complex_value_quoted",
+			input: `add_header X-Custom "complex; value";`,
+			want:  []string{"add_header"},
+		},
+		// 17. rewrite directive.
+		{
+			name:  "rewrite_directive",
+			input: "rewrite ^/old/(.*)$ /new/$1 permanent;",
+			want:  []string{"rewrite"},
+		},
+		// 18. Nested location block — "location" + inner directive.
+		{
+			name:  "nested_location_block",
+			input: "location / {\n    location /api {\n        proxy_read_timeout 60s;\n    }\n}",
+			want:  []string{"location", "proxy_read_timeout"},
+		},
+		// 19. Commented-out directive + real directive.
+		{
+			name:  "commented_out_and_real",
+			input: "# proxy_read_timeout 60s;\nproxy_send_timeout 30s;",
+			want:  []string{"proxy_send_timeout"},
+		},
+		// 20. Malformed line (no trailing whitespace after token) mixed with
+		//     a valid directive. The malformed "xxxx;" token is NOT captured
+		//     because the regex requires \s+ after the name.
+		{
+			name:  "malformed_line_and_real",
+			input: "xxxx;\nproxy_read_timeout 60s;",
+			want:  []string{"proxy_read_timeout"},
+		},
+	}
+
+	if len(cases) != 20 {
+		t.Fatalf("test suite expects exactly 20 cases, got %d", len(cases))
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseAdvancedConfigDirectives(tc.input)
+			gotKeys := sortedKeys(got)
+			want := append([]string(nil), tc.want...)
+			sort.Strings(want)
+			if !stringSliceEqual(gotKeys, want) {
+				t.Errorf("directive set mismatch\n input: %q\n got:   %v\n want:  %v", tc.input, gotKeys, want)
+			}
+		})
+	}
+}
+
+// sortedKeys returns a sorted slice of map keys. The returned slice is nil for
+// an empty map so it compares equal to nil with stringSliceEqual.
+func sortedKeys(m map[string]bool) []string {
+	if len(m) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func stringSliceEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/api/internal/nginx/proxy_host_template_characterization_test.go
+++ b/api/internal/nginx/proxy_host_template_characterization_test.go
@@ -1,0 +1,316 @@
+package nginx
+
+// Characterization tests for the proxy_host template.
+//
+// These tests freeze CURRENT behavior via golden files to protect later
+// refactors (Phases 3-6 of the codebase cleanup). They are NOT specifications
+// of correct behavior — if something looks odd in a golden file, preserve it
+// and note the discrepancy; do not "fix" it here.
+//
+// Run with `-update-golden` to regenerate fixtures after a deliberate change.
+
+import (
+	"bytes"
+	"context"
+	"flag"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+	"text/template"
+	"time"
+
+	"nginx-proxy-guard/internal/model"
+)
+
+var updateGolden = flag.Bool("update-golden", false, "update golden files")
+
+// renderProxyHostConfig renders the proxy host config into w without any
+// filesystem side effects. This is a test-only helper that mirrors the core
+// rendering path of (*Manager).GenerateConfigFull, but skips the SSL cert
+// existence check, the cloud-IP include generation, and the atomic file write.
+//
+// Keep in sync with the template wiring in manager.go:
+//   - Funcs: GetTemplateFuncMap plus dnsResolver + upstreamScheme
+//   - Pre-processing: AdvancedConfig directive parsing + server/location split
+//   - Listen ports, IPv6 flag, and apiHost injection
+func renderProxyHostConfig(_ context.Context, w *bytes.Buffer, data ProxyHostConfigData) error {
+	// Mirror manager.GenerateConfigFull defaults.
+	if data.HTTPPort == "" {
+		data.HTTPPort = "80"
+	}
+	if data.HTTPSPort == "" {
+		data.HTTPSPort = "443"
+	}
+
+	apiHostValue := "127.0.0.1:9080"
+	dnsResolverValue := "127.0.0.53 8.8.8.8"
+
+	funcMap := GetTemplateFuncMap(apiHostValue)
+	funcMap["dnsResolver"] = func() string { return dnsResolverValue }
+	funcMap["upstreamScheme"] = func(u *model.Upstream) string {
+		if u == nil {
+			return "http"
+		}
+		return model.NormalizeUpstreamScheme(u.Scheme)
+	}
+
+	// Mirror AdvancedConfig preprocessing from manager.GenerateConfigFull.
+	if data.Host != nil && data.Host.AdvancedConfig != "" {
+		locationPattern := regexp.MustCompile(`(?m)^\s*location\s+/\s*\{`)
+		data.HasCustomLocationRoot = locationPattern.MatchString(data.Host.AdvancedConfig)
+		anyLocationPattern := regexp.MustCompile(`(?m)^\s*location\s+`)
+		data.AdvancedConfigHasLocation = anyLocationPattern.MatchString(data.Host.AdvancedConfig)
+		data.AdvancedConfigDirectives = parseAdvancedConfigDirectives(data.Host.AdvancedConfig)
+		serverPart, locationPart := splitAdvancedConfigByContext(data.Host.AdvancedConfig)
+		data.AdvancedConfigServerLevel = serverPart
+		data.AdvancedConfigLocationLevel = locationPart
+	}
+
+	tmpl, err := template.New("proxy_host").Funcs(funcMap).Parse(proxyHostTemplate)
+	if err != nil {
+		return err
+	}
+	return tmpl.Execute(w, data)
+}
+
+// ---- Fixtures ---------------------------------------------------------------
+//
+// All fixtures use pinned IDs for deterministic golden output.
+// Timestamps are fixed to 2024-01-01 UTC. UUIDs follow the pattern
+// 00000000-0000-0000-0000-00000000000N for easy grepping.
+
+var fixtureNow = time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+
+func baseGlobalSettings() *model.GlobalSettings {
+	// Zero-valued to keep golden output minimal; the template mostly gates on
+	// numeric > 0 and non-empty string checks, so zero values largely suppress
+	// the global-settings overrides.
+	return &model.GlobalSettings{
+		ID:        "00000000-0000-0000-0000-000000000100",
+		CreatedAt: fixtureNow,
+		UpdatedAt: fixtureNow,
+	}
+}
+
+func baseHost(id, forwardHost string, enabled bool) *model.ProxyHost {
+	return &model.ProxyHost{
+		ID:            id,
+		DomainNames:   []string{"example.com"},
+		ForwardScheme: "http",
+		ForwardHost:   forwardHost,
+		ForwardPort:   8080,
+		Enabled:       enabled,
+		CreatedAt:     fixtureNow,
+		UpdatedAt:     fixtureNow,
+	}
+}
+
+// 1) http_only: basic HTTP proxy, SSL off, forwards example.com → 192.168.1.10:8080.
+func fixtureHTTPOnly() ProxyHostConfigData {
+	host := baseHost("00000000-0000-0000-0000-000000000001", "192.168.1.10", true)
+	host.DomainNames = []string{"example.com"}
+	return ProxyHostConfigData{
+		Host:           host,
+		GlobalSettings: baseGlobalSettings(),
+	}
+}
+
+// 2) https_force: SSL enabled, ForceHTTPS, HTTP/2, explicit certificate ID.
+func fixtureHTTPSForce() ProxyHostConfigData {
+	host := baseHost("00000000-0000-0000-0000-000000000002", "192.168.1.20", true)
+	host.DomainNames = []string{"secure.example.com"}
+	host.SSLEnabled = true
+	host.SSLForceHTTPS = true
+	host.SSLHTTP2 = true
+	certID := "00000000-0000-0000-0000-00000000cert"
+	host.CertificateID = &certID
+	return ProxyHostConfigData{
+		Host:           host,
+		GlobalSettings: baseGlobalSettings(),
+	}
+}
+
+// 3) waf_blocking: WAF enabled, blocking mode, paranoia 2, anomaly 5.
+//
+// Exclusions are NOT rendered into the proxy host config itself — they are
+// written to a separate modsec/host_{id}.conf by GenerateHostWAFConfig. The
+// main template only toggles modsecurity on/off and references the file path.
+// The "3 exclusions" part of this case exists for completeness (the data shape
+// a caller would pass) but the golden file reflects only what the proxy host
+// template emits.
+func fixtureWAFBlocking() ProxyHostConfigData {
+	host := baseHost("00000000-0000-0000-0000-000000000003", "192.168.1.30", true)
+	host.DomainNames = []string{"waf.example.com"}
+	host.WAFEnabled = true
+	host.WAFMode = "blocking"
+	host.WAFParanoiaLevel = 2
+	host.WAFAnomalyThreshold = 5
+	return ProxyHostConfigData{
+		Host:           host,
+		GlobalSettings: baseGlobalSettings(),
+	}
+}
+
+// 4) cache_enabled: proxy cache on with a valid TTL.
+func fixtureCacheEnabled() ProxyHostConfigData {
+	host := baseHost("00000000-0000-0000-0000-000000000004", "192.168.1.40", true)
+	host.DomainNames = []string{"cache.example.com"}
+	host.CacheEnabled = true
+	host.CacheStaticOnly = true
+	host.CacheTTL = "1h"
+	return ProxyHostConfigData{
+		Host:           host,
+		GlobalSettings: baseGlobalSettings(),
+	}
+}
+
+// 5) advanced_config_conflict: user supplies proxy_connect_timeout in
+// AdvancedConfig; template auto-generated proxy_connect_timeout must be
+// suppressed via the hasDirective gate.
+func fixtureAdvancedConfigConflict() ProxyHostConfigData {
+	host := baseHost("00000000-0000-0000-0000-000000000005", "192.168.1.50", true)
+	host.DomainNames = []string{"advanced.example.com"}
+	host.AdvancedConfig = "proxy_connect_timeout 10s;\n"
+	// Give the template a nonzero value so we can verify it is suppressed.
+	host.ProxyConnectTimeout = 60
+	return ProxyHostConfigData{
+		Host:           host,
+		GlobalSettings: baseGlobalSettings(),
+	}
+}
+
+// 6) upstream_load_balance: upstream with least_conn + 3 backends.
+func fixtureUpstreamLB() ProxyHostConfigData {
+	host := baseHost("00000000-0000-0000-0000-000000000006", "unused-direct-host", true)
+	host.DomainNames = []string{"lb.example.com"}
+	// When Upstream has servers, the template routes to upstream instead of
+	// ForwardHost:ForwardPort, but the forward fields remain in the data.
+	return ProxyHostConfigData{
+		Host:           host,
+		GlobalSettings: baseGlobalSettings(),
+		Upstream: &model.Upstream{
+			ID:          "00000000-0000-0000-0000-00000000upst",
+			ProxyHostID: host.ID,
+			Name:        "backend_pool",
+			Scheme:      "http",
+			LoadBalance: "least_conn",
+			Servers: []model.UpstreamServer{
+				{Address: "10.0.0.1", Port: 8080, Weight: 1, MaxFails: 0, FailTimeout: 0},
+				{Address: "10.0.0.2", Port: 8080, Weight: 1, MaxFails: 0, FailTimeout: 0},
+				{Address: "10.0.0.3", Port: 8080, Weight: 1, MaxFails: 0, FailTimeout: 0},
+			},
+			CreatedAt: fixtureNow,
+			UpdatedAt: fixtureNow,
+		},
+	}
+}
+
+// ---- Tests ------------------------------------------------------------------
+
+func TestProxyHostTemplate_Characterization(t *testing.T) {
+	cases := []struct {
+		name string
+		data ProxyHostConfigData
+	}{
+		{name: "http_only", data: fixtureHTTPOnly()},
+		{name: "https_force", data: fixtureHTTPSForce()},
+		{name: "waf_blocking", data: fixtureWAFBlocking()},
+		{name: "cache_enabled", data: fixtureCacheEnabled()},
+		{name: "advanced_config_conflict", data: fixtureAdvancedConfigConflict()},
+		{name: "upstream_load_balance", data: fixtureUpstreamLB()},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			if err := renderProxyHostConfig(context.Background(), &buf, tc.data); err != nil {
+				t.Fatalf("render failed: %v", err)
+			}
+			compareGolden(t, "proxy_host_"+tc.name+".conf", buf.Bytes())
+		})
+	}
+}
+
+func compareGolden(t *testing.T, name string, got []byte) {
+	t.Helper()
+	path := filepath.Join("testdata", "golden", name)
+
+	if *updateGolden {
+		if err := os.WriteFile(path, got, 0644); err != nil {
+			t.Fatalf("write golden: %v", err)
+		}
+		t.Logf("updated golden file: %s", path)
+		return
+	}
+
+	want, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read golden %s: %v (run with -update-golden to create)", path, err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Errorf("golden mismatch for %s\n--- diff preview ---\n%s", name, diffPreview(want, got))
+	}
+}
+
+// diffPreview returns a short head-of-diff for debugging without dumping
+// thousands of lines on a mismatch.
+func diffPreview(want, got []byte) string {
+	wantLines := strings.Split(string(want), "\n")
+	gotLines := strings.Split(string(got), "\n")
+	max := len(wantLines)
+	if len(gotLines) > max {
+		max = len(gotLines)
+	}
+	var sb strings.Builder
+	shown := 0
+	for i := 0; i < max && shown < 10; i++ {
+		var wl, gl string
+		if i < len(wantLines) {
+			wl = wantLines[i]
+		}
+		if i < len(gotLines) {
+			gl = gotLines[i]
+		}
+		if wl != gl {
+			sb.WriteString("want[")
+			sb.WriteString(itoa(i))
+			sb.WriteString("]: ")
+			sb.WriteString(wl)
+			sb.WriteString("\n got[")
+			sb.WriteString(itoa(i))
+			sb.WriteString("]: ")
+			sb.WriteString(gl)
+			sb.WriteString("\n")
+			shown++
+		}
+	}
+	if shown == 0 {
+		return "(no line diffs; trailing-byte or whitespace diff)"
+	}
+	return sb.String()
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	var buf [20]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if neg {
+		i--
+		buf[i] = '-'
+	}
+	return string(buf[i:])
+}

--- a/api/internal/nginx/testdata/golden/proxy_host_advanced_config_conflict.conf
+++ b/api/internal/nginx/testdata/golden/proxy_host_advanced_config_conflict.conf
@@ -1,0 +1,153 @@
+# nginx-guard generated config
+# Proxy Host ID: 00000000-0000-0000-0000-000000000005
+# Domain(s): advanced.example.com
+# WAF: disabled
+# HTTP/3: disabled
+# Access List: none
+# Geo Restriction: none
+# Rate Limit: none
+# Upstream: none
+# Generated at: auto-generated
+
+
+
+
+
+
+
+
+
+
+
+
+server {
+    listen 80;
+    server_name advanced.example.com;
+
+    # Initialize tracking variables
+    set $block_reason_var "-";
+    set $bot_category_var "-";
+    set $geo_blocked 0;
+    set $is_search_bot 0;
+
+    # NPM-compatible variables for custom config
+    set $forward_scheme http;
+    set $server "192.168.1.50";
+    set $port 8080;
+
+    # Resolver for dynamic proxy_pass with variables
+    resolver 127.0.0.53 8.8.8.8 valid=30s;
+
+
+
+    
+
+    # Skip security checks for ACME HTTP-01 Challenge
+    set $skip_security_for_acme 0;
+    if ($request_uri ~ "^/.well-known/acme-challenge/") {
+        set $skip_security_for_acme 1;
+    }
+    # Also skip for challenge page to prevent redirect loops
+    if ($request_uri ~ "^/api/v1/challenge/") {
+        set $skip_security_for_acme 1;
+    }
+
+    # ACME HTTP-01 Challenge support (bypass all security checks)
+    location /.well-known/acme-challenge/ {
+        # Allow all access for certificate validation
+        allow all;
+        root /etc/nginx/acme-challenge;
+        try_files $uri =404;
+    }
+
+    # Custom error pages for upstream errors
+    error_page 502 /error_502.html;
+    error_page 503 /error_503.html;
+    error_page 504 /error_504.html;
+    location = /error_502.html { internal; root /etc/nginx/html; try_files /502.html =502; }
+    location = /error_503.html { internal; root /etc/nginx/html; try_files /503.html =503; }
+    location = /error_504.html { internal; root /etc/nginx/html; try_files /504.html =504; }
+
+    # Custom error page for security blocks (WAF, block_exploits, geo restriction, bot filter, etc.)
+    error_page 403 @blocked;
+    location @blocked {
+        root /etc/nginx/html;
+        default_type text/html;
+        try_files /403.html =403;
+    }
+
+
+
+
+    # WAF disabled for this host (override global modsecurity on)
+    modsecurity off;
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+    location / {
+
+        proxy_pass http://192.168.1.50:8080;
+        include /etc/nginx/includes/proxy_params.conf;
+        
+        # Proxy settings (Host-level overrides Global)
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        # Proxy buffer settings (from Global Settings)
+        
+        
+        
+        
+        
+        # Bandwidth limiting (from Global Settings)
+        
+        
+        
+        
+        
+
+        # Custom configuration
+        proxy_connect_timeout 10s;
+
+    }
+
+
+
+
+
+
+
+
+
+}
+
+
+

--- a/api/internal/nginx/testdata/golden/proxy_host_cache_enabled.conf
+++ b/api/internal/nginx/testdata/golden/proxy_host_cache_enabled.conf
@@ -1,0 +1,166 @@
+# nginx-guard generated config
+# Proxy Host ID: 00000000-0000-0000-0000-000000000004
+# Domain(s): cache.example.com
+# WAF: disabled
+# HTTP/3: disabled
+# Access List: none
+# Geo Restriction: none
+# Rate Limit: none
+# Upstream: none
+# Generated at: auto-generated
+
+
+
+
+
+
+
+
+
+
+
+
+server {
+    listen 80;
+    server_name cache.example.com;
+
+    # Initialize tracking variables
+    set $block_reason_var "-";
+    set $bot_category_var "-";
+    set $geo_blocked 0;
+    set $is_search_bot 0;
+
+    # NPM-compatible variables for custom config
+    set $forward_scheme http;
+    set $server "192.168.1.40";
+    set $port 8080;
+
+    # Resolver for dynamic proxy_pass with variables
+    resolver 127.0.0.53 8.8.8.8 valid=30s;
+
+
+
+    
+
+    # Skip security checks for ACME HTTP-01 Challenge
+    set $skip_security_for_acme 0;
+    if ($request_uri ~ "^/.well-known/acme-challenge/") {
+        set $skip_security_for_acme 1;
+    }
+    # Also skip for challenge page to prevent redirect loops
+    if ($request_uri ~ "^/api/v1/challenge/") {
+        set $skip_security_for_acme 1;
+    }
+
+    # ACME HTTP-01 Challenge support (bypass all security checks)
+    location /.well-known/acme-challenge/ {
+        # Allow all access for certificate validation
+        allow all;
+        root /etc/nginx/acme-challenge;
+        try_files $uri =404;
+    }
+
+    # Custom error pages for upstream errors
+    error_page 502 /error_502.html;
+    error_page 503 /error_503.html;
+    error_page 504 /error_504.html;
+    location = /error_502.html { internal; root /etc/nginx/html; try_files /502.html =502; }
+    location = /error_503.html { internal; root /etc/nginx/html; try_files /503.html =503; }
+    location = /error_504.html { internal; root /etc/nginx/html; try_files /504.html =504; }
+
+    # Custom error page for security blocks (WAF, block_exploits, geo restriction, bot filter, etc.)
+    error_page 403 @blocked;
+    location @blocked {
+        root /etc/nginx/html;
+        default_type text/html;
+        try_files /403.html =403;
+    }
+
+
+
+
+    # WAF disabled for this host (override global modsecurity on)
+    modsecurity off;
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+    location / {
+
+        proxy_pass http://192.168.1.40:8080;
+        include /etc/nginx/includes/proxy_params.conf;
+        
+        # Proxy settings (Host-level overrides Global)
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        # Proxy buffer settings (from Global Settings)
+        
+        
+        
+        
+        
+        # Bandwidth limiting (from Global Settings)
+        
+        
+        
+        
+        
+        # Caching
+        
+        # Static assets only - bypass cache for API and dynamic content
+        set $cache_bypass 1;
+        if ($request_uri ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot|webp|avif|mp4|webm|pdf)$) {
+            set $cache_bypass 0;
+        }
+        proxy_no_cache $cache_bypass;
+        proxy_cache_bypass $cache_bypass $http_pragma $http_authorization;
+        
+        proxy_cache proxy_cache;
+        proxy_cache_key $scheme$host$request_uri;
+        proxy_cache_valid 200 301 302 1h;
+        proxy_cache_use_stale error timeout http_500 http_502 http_503 http_504;
+        add_header X-Cache-Status $upstream_cache_status always;
+        
+
+    }
+
+
+
+
+
+
+
+
+
+}
+
+
+

--- a/api/internal/nginx/testdata/golden/proxy_host_http_only.conf
+++ b/api/internal/nginx/testdata/golden/proxy_host_http_only.conf
@@ -1,0 +1,150 @@
+# nginx-guard generated config
+# Proxy Host ID: 00000000-0000-0000-0000-000000000001
+# Domain(s): example.com
+# WAF: disabled
+# HTTP/3: disabled
+# Access List: none
+# Geo Restriction: none
+# Rate Limit: none
+# Upstream: none
+# Generated at: auto-generated
+
+
+
+
+
+
+
+
+
+
+
+
+server {
+    listen 80;
+    server_name example.com;
+
+    # Initialize tracking variables
+    set $block_reason_var "-";
+    set $bot_category_var "-";
+    set $geo_blocked 0;
+    set $is_search_bot 0;
+
+    # NPM-compatible variables for custom config
+    set $forward_scheme http;
+    set $server "192.168.1.10";
+    set $port 8080;
+
+    # Resolver for dynamic proxy_pass with variables
+    resolver 127.0.0.53 8.8.8.8 valid=30s;
+
+
+
+    
+
+    # Skip security checks for ACME HTTP-01 Challenge
+    set $skip_security_for_acme 0;
+    if ($request_uri ~ "^/.well-known/acme-challenge/") {
+        set $skip_security_for_acme 1;
+    }
+    # Also skip for challenge page to prevent redirect loops
+    if ($request_uri ~ "^/api/v1/challenge/") {
+        set $skip_security_for_acme 1;
+    }
+
+    # ACME HTTP-01 Challenge support (bypass all security checks)
+    location /.well-known/acme-challenge/ {
+        # Allow all access for certificate validation
+        allow all;
+        root /etc/nginx/acme-challenge;
+        try_files $uri =404;
+    }
+
+    # Custom error pages for upstream errors
+    error_page 502 /error_502.html;
+    error_page 503 /error_503.html;
+    error_page 504 /error_504.html;
+    location = /error_502.html { internal; root /etc/nginx/html; try_files /502.html =502; }
+    location = /error_503.html { internal; root /etc/nginx/html; try_files /503.html =503; }
+    location = /error_504.html { internal; root /etc/nginx/html; try_files /504.html =504; }
+
+    # Custom error page for security blocks (WAF, block_exploits, geo restriction, bot filter, etc.)
+    error_page 403 @blocked;
+    location @blocked {
+        root /etc/nginx/html;
+        default_type text/html;
+        try_files /403.html =403;
+    }
+
+
+
+
+    # WAF disabled for this host (override global modsecurity on)
+    modsecurity off;
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+    location / {
+
+        proxy_pass http://192.168.1.10:8080;
+        include /etc/nginx/includes/proxy_params.conf;
+        
+        # Proxy settings (Host-level overrides Global)
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        # Proxy buffer settings (from Global Settings)
+        
+        
+        
+        
+        
+        # Bandwidth limiting (from Global Settings)
+        
+        
+        
+        
+        
+
+    }
+
+
+
+
+
+
+
+
+
+}
+
+
+

--- a/api/internal/nginx/testdata/golden/proxy_host_https_force.conf
+++ b/api/internal/nginx/testdata/golden/proxy_host_https_force.conf
@@ -1,0 +1,265 @@
+# nginx-guard generated config
+# Proxy Host ID: 00000000-0000-0000-0000-000000000002
+# Domain(s): secure.example.com
+# WAF: disabled
+# HTTP/3: disabled
+# Access List: none
+# Geo Restriction: none
+# Rate Limit: none
+# Upstream: none
+# Generated at: auto-generated
+
+
+
+
+
+
+
+
+
+
+
+
+server {
+    listen 80;
+    server_name secure.example.com;
+
+    # Initialize tracking variables
+    set $block_reason_var "-";
+    set $bot_category_var "-";
+    set $geo_blocked 0;
+    set $is_search_bot 0;
+
+    # NPM-compatible variables for custom config
+    set $forward_scheme http;
+    set $server "192.168.1.20";
+    set $port 8080;
+
+    # Resolver for dynamic proxy_pass with variables
+    resolver 127.0.0.53 8.8.8.8 valid=30s;
+
+
+
+    
+
+    # Skip security checks for ACME HTTP-01 Challenge
+    set $skip_security_for_acme 0;
+    if ($request_uri ~ "^/.well-known/acme-challenge/") {
+        set $skip_security_for_acme 1;
+    }
+    # Also skip for challenge page to prevent redirect loops
+    if ($request_uri ~ "^/api/v1/challenge/") {
+        set $skip_security_for_acme 1;
+    }
+
+    # ACME HTTP-01 Challenge support (bypass all security checks)
+    location /.well-known/acme-challenge/ {
+        # Allow all access for certificate validation
+        allow all;
+        root /etc/nginx/acme-challenge;
+        try_files $uri =404;
+    }
+
+    # Custom error pages for upstream errors
+    error_page 502 /error_502.html;
+    error_page 503 /error_503.html;
+    error_page 504 /error_504.html;
+    location = /error_502.html { internal; root /etc/nginx/html; try_files /502.html =502; }
+    location = /error_503.html { internal; root /etc/nginx/html; try_files /503.html =503; }
+    location = /error_504.html { internal; root /etc/nginx/html; try_files /504.html =504; }
+
+    # Custom error page for security blocks (WAF, block_exploits, geo restriction, bot filter, etc.)
+    error_page 403 @blocked;
+    location @blocked {
+        root /etc/nginx/html;
+        default_type text/html;
+        try_files /403.html =403;
+    }
+
+
+
+
+    # WAF disabled for this host (override global modsecurity on)
+    modsecurity off;
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+    # Redirect HTTP to HTTPS
+    
+
+    location / {
+        return 301 https://$host$request_uri;
+    }
+
+
+    
+
+
+
+
+
+
+
+}
+
+
+server {
+    listen 443 ssl;
+
+    # HTTP/2 over TCP (new directive style)
+    http2 on;
+
+
+    server_name secure.example.com;
+
+    # Initialize tracking variables
+    set $block_reason_var "-";
+    set $bot_category_var "-";
+    set $geo_blocked 0;
+    set $is_search_bot 0;
+
+    # NPM-compatible variables for custom config
+    set $forward_scheme http;
+    set $server "192.168.1.20";
+    set $port 8080;
+
+    # Resolver for dynamic proxy_pass with variables
+    resolver 127.0.0.53 8.8.8.8 valid=30s;
+
+
+
+    
+
+    # Skip security checks for ACME HTTP-01 Challenge (not typically used on HTTPS, but for consistency)
+    set $skip_security_for_acme 0;
+    if ($request_uri ~ "^/.well-known/acme-challenge/") {
+        set $skip_security_for_acme 1;
+    }
+    # Also skip for challenge page to prevent redirect loops
+    if ($request_uri ~ "^/api/v1/challenge/") {
+        set $skip_security_for_acme 1;
+    }
+
+    # SSL configuration
+    ssl_certificate /etc/nginx/certs/00000000-0000-0000-0000-00000000cert/fullchain.pem;
+    ssl_certificate_key /etc/nginx/certs/00000000-0000-0000-0000-00000000cert/privkey.pem;
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_prefer_server_ciphers off;
+    ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305;
+    ssl_ecdh_curve X25519MLKEM768:X25519:secp256r1:secp384r1;
+
+
+    # Custom error pages for upstream errors
+    error_page 502 /error_502.html;
+    error_page 503 /error_503.html;
+    error_page 504 /error_504.html;
+    location = /error_502.html { internal; root /etc/nginx/html; try_files /502.html =502; }
+    location = /error_503.html { internal; root /etc/nginx/html; try_files /503.html =503; }
+    location = /error_504.html { internal; root /etc/nginx/html; try_files /504.html =504; }
+
+    # Custom error page for security blocks (WAF, block_exploits, geo restriction, bot filter, etc.)
+    error_page 403 @blocked;
+    location @blocked {
+        root /etc/nginx/html;
+        default_type text/html;
+        try_files /403.html =403;
+    }
+
+
+
+
+    # WAF disabled for this host (override global modsecurity on)
+    modsecurity off;
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+    location / {
+
+        proxy_pass http://192.168.1.20:8080;
+        include /etc/nginx/includes/proxy_params.conf;
+        
+        # Proxy settings (Host-level overrides Global)
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        # Proxy buffer settings (from Global Settings)
+        
+        
+        
+        
+        
+        # Bandwidth limiting (from Global Settings)
+        
+        
+        
+        
+        
+        # Clear Alt-Svc cache when HTTP/3 is disabled (helps Safari recover faster)
+        add_header Alt-Svc 'clear' always;
+        
+        
+        
+
+    }
+
+
+
+
+
+
+
+
+
+}
+
+

--- a/api/internal/nginx/testdata/golden/proxy_host_upstream_load_balance.conf
+++ b/api/internal/nginx/testdata/golden/proxy_host_upstream_load_balance.conf
@@ -1,0 +1,165 @@
+# nginx-guard generated config
+# Proxy Host ID: 00000000-0000-0000-0000-000000000006
+# Domain(s): lb.example.com
+# WAF: disabled
+# HTTP/3: disabled
+# Access List: none
+# Geo Restriction: none
+# Rate Limit: none
+# Upstream: backend_pool (http, least_conn)
+# Generated at: auto-generated
+
+
+
+
+
+
+
+
+
+
+# Upstream definition for load balancing
+upstream backend_pool {
+
+    least_conn;
+
+
+    server 10.0.0.1:8080;
+
+    server 10.0.0.2:8080;
+
+    server 10.0.0.3:8080;
+
+
+}
+
+
+
+server {
+    listen 80;
+    server_name lb.example.com;
+
+    # Initialize tracking variables
+    set $block_reason_var "-";
+    set $bot_category_var "-";
+    set $geo_blocked 0;
+    set $is_search_bot 0;
+
+    # NPM-compatible variables for custom config
+    set $forward_scheme http;
+    set $server "unused-direct-host";
+    set $port 8080;
+
+    # Resolver for dynamic proxy_pass with variables
+    resolver 127.0.0.53 8.8.8.8 valid=30s;
+
+
+
+    
+
+    # Skip security checks for ACME HTTP-01 Challenge
+    set $skip_security_for_acme 0;
+    if ($request_uri ~ "^/.well-known/acme-challenge/") {
+        set $skip_security_for_acme 1;
+    }
+    # Also skip for challenge page to prevent redirect loops
+    if ($request_uri ~ "^/api/v1/challenge/") {
+        set $skip_security_for_acme 1;
+    }
+
+    # ACME HTTP-01 Challenge support (bypass all security checks)
+    location /.well-known/acme-challenge/ {
+        # Allow all access for certificate validation
+        allow all;
+        root /etc/nginx/acme-challenge;
+        try_files $uri =404;
+    }
+
+    # Custom error pages for upstream errors
+    error_page 502 /error_502.html;
+    error_page 503 /error_503.html;
+    error_page 504 /error_504.html;
+    location = /error_502.html { internal; root /etc/nginx/html; try_files /502.html =502; }
+    location = /error_503.html { internal; root /etc/nginx/html; try_files /503.html =503; }
+    location = /error_504.html { internal; root /etc/nginx/html; try_files /504.html =504; }
+
+    # Custom error page for security blocks (WAF, block_exploits, geo restriction, bot filter, etc.)
+    error_page 403 @blocked;
+    location @blocked {
+        root /etc/nginx/html;
+        default_type text/html;
+        try_files /403.html =403;
+    }
+
+
+
+
+    # WAF disabled for this host (override global modsecurity on)
+    modsecurity off;
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+    location / {
+
+        proxy_pass http://backend_pool;
+        include /etc/nginx/includes/proxy_params.conf;
+        
+        # Proxy settings (Host-level overrides Global)
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        # Proxy buffer settings (from Global Settings)
+        
+        
+        
+        
+        
+        # Bandwidth limiting (from Global Settings)
+        
+        
+        
+        
+        
+
+    }
+
+
+
+
+
+
+
+
+
+}
+
+
+

--- a/api/internal/nginx/testdata/golden/proxy_host_waf_blocking.conf
+++ b/api/internal/nginx/testdata/golden/proxy_host_waf_blocking.conf
@@ -1,0 +1,153 @@
+# nginx-guard generated config
+# Proxy Host ID: 00000000-0000-0000-0000-000000000003
+# Domain(s): waf.example.com
+# WAF: blocking
+# HTTP/3: disabled
+# Access List: none
+# Geo Restriction: none
+# Rate Limit: none
+# Upstream: none
+# Generated at: auto-generated
+
+
+
+
+
+
+
+
+
+
+
+
+server {
+    listen 80;
+    server_name waf.example.com;
+
+    # Initialize tracking variables
+    set $block_reason_var "-";
+    set $bot_category_var "-";
+    set $geo_blocked 0;
+    set $is_search_bot 0;
+
+    # NPM-compatible variables for custom config
+    set $forward_scheme http;
+    set $server "192.168.1.30";
+    set $port 8080;
+
+    # Resolver for dynamic proxy_pass with variables
+    resolver 127.0.0.53 8.8.8.8 valid=30s;
+
+
+
+    
+
+    # Skip security checks for ACME HTTP-01 Challenge
+    set $skip_security_for_acme 0;
+    if ($request_uri ~ "^/.well-known/acme-challenge/") {
+        set $skip_security_for_acme 1;
+    }
+    # Also skip for challenge page to prevent redirect loops
+    if ($request_uri ~ "^/api/v1/challenge/") {
+        set $skip_security_for_acme 1;
+    }
+
+    # ACME HTTP-01 Challenge support (bypass all security checks)
+    location /.well-known/acme-challenge/ {
+        # Allow all access for certificate validation
+        allow all;
+        root /etc/nginx/acme-challenge;
+        try_files $uri =404;
+    }
+
+    # Custom error pages for upstream errors
+    error_page 502 /error_502.html;
+    error_page 503 /error_503.html;
+    error_page 504 /error_504.html;
+    location = /error_502.html { internal; root /etc/nginx/html; try_files /502.html =502; }
+    location = /error_503.html { internal; root /etc/nginx/html; try_files /503.html =503; }
+    location = /error_504.html { internal; root /etc/nginx/html; try_files /504.html =504; }
+
+    # Custom error page for security blocks (WAF, block_exploits, geo restriction, bot filter, etc.)
+    error_page 403 @blocked;
+    location @blocked {
+        root /etc/nginx/html;
+        default_type text/html;
+        try_files /403.html =403;
+    }
+
+
+
+
+    # WAF (ModSecurity) - blocking mode
+    # CRS rules are loaded globally; per-host tuning is applied via rules_file
+    more_set_input_headers "Host: $host";
+    modsecurity on;
+    modsecurity_rules_file /etc/nginx/modsec/host_00000000-0000-0000-0000-000000000003.conf;
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+    location / {
+
+        proxy_pass http://192.168.1.30:8080;
+        include /etc/nginx/includes/proxy_params.conf;
+        
+        # Proxy settings (Host-level overrides Global)
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        # Proxy buffer settings (from Global Settings)
+        
+        
+        
+        
+        
+        # Bandwidth limiting (from Global Settings)
+        
+        
+        
+        
+        
+
+    }
+
+
+
+
+
+
+
+
+
+}
+
+
+

--- a/api/internal/service/proxy_host_config.go
+++ b/api/internal/service/proxy_host_config.go
@@ -9,7 +9,9 @@ import (
 	"nginx-proxy-guard/internal/nginx"
 )
 
-// getMergedWAFExclusions gets host-specific exclusions and merges with global exclusions
+// getMergedWAFExclusions gets host-specific exclusions and merges with global exclusions.
+// The pure merge logic lives in mergeWAFExclusions (see waf_merge.go) so it can be unit tested
+// without a database dependency.
 func (s *ProxyHostService) getMergedWAFExclusions(ctx context.Context, hostID string) ([]model.WAFRuleExclusion, error) {
 	// Get host-specific exclusions
 	hostExclusions, err := s.wafRepo.GetExclusionsByProxyHost(ctx, hostID)
@@ -23,33 +25,7 @@ func (s *ProxyHostService) getMergedWAFExclusions(ctx context.Context, hostID st
 		return nil, err
 	}
 
-	// Create a map of host exclusions to avoid duplicates
-	hostExclusionMap := make(map[int]bool)
-	for _, ex := range hostExclusions {
-		hostExclusionMap[ex.RuleID] = true
-	}
-
-	// Merge: start with host exclusions
-	merged := make([]model.WAFRuleExclusion, len(hostExclusions))
-	copy(merged, hostExclusions)
-
-	// Add global exclusions that are not already in host exclusions
-	for _, gex := range globalExclusions {
-		if !hostExclusionMap[gex.RuleID] {
-			merged = append(merged, model.WAFRuleExclusion{
-				ID:              gex.ID,
-				ProxyHostID:     "global",
-				RuleID:          gex.RuleID,
-				RuleCategory:    gex.RuleCategory,
-				RuleDescription: gex.RuleDescription,
-				Reason:          gex.Reason + " (global)",
-				DisabledBy:      gex.DisabledBy,
-				CreatedAt:       gex.CreatedAt,
-			})
-		}
-	}
-
-	return merged, nil
+	return mergeWAFExclusions(hostExclusions, globalExclusions), nil
 }
 
 // getAccessControlData fetches access list and geo restriction for a host

--- a/api/internal/service/proxy_host_sync.go
+++ b/api/internal/service/proxy_host_sync.go
@@ -158,47 +158,14 @@ func (s *ProxyHostService) SyncAllConfigsWithDetails(ctx context.Context) (*Sync
 		result.Hosts = append(result.Hosts, hostResult)
 	}
 
-	// Test nginx config — on failure, remove the failing host's config and retry
+	// Test nginx config — on failure, run the auto-recovery loop that
+	// iteratively removes the config of hosts nginx reports as failing.
+	// See runAutoRecovery (sync_auto_recovery.go) for the loop details.
 	if err := s.nginx.TestConfig(ctx); err != nil {
-		testErr := err
-		recovered := false
-
-		// Try to recover by removing failing host configs one at a time
-		for attempt := 0; attempt < 5; attempt++ {
-			failingDomain := parseNginxErrorForHost(testErr.Error())
-			if failingDomain == "" {
-				break
-			}
-			hostIdx := findHostByDomain(result.Hosts, failingDomain)
-			if hostIdx < 0 {
-				break
-			}
-			// Mark the host as failed
-			if result.Hosts[hostIdx].Success {
-				result.Hosts[hostIdx].Success = false
-				result.Hosts[hostIdx].Error = testErr.Error()
-				result.SuccessCount--
-				result.FailedCount++
-			}
-			// Remove the failing host's config and WAF config to recover nginx
-			failingHost := findHostByID(hosts, result.Hosts[hostIdx].HostID)
-			if failingHost != nil {
-				log.Printf("[SyncConfigs] Removing failing config for %s to recover nginx", result.Hosts[hostIdx].DomainNames)
-				_ = s.nginx.RemoveConfig(ctx, failingHost)
-				_ = s.nginx.RemoveHostWAFConfig(ctx, failingHost.ID)
-			}
-			// Retry nginx test
-			if retryErr := s.nginx.TestConfig(ctx); retryErr != nil {
-				testErr = retryErr
-				continue
-			}
-			recovered = true
-			break
-		}
-
+		recovered, lastErr := runAutoRecovery(ctx, s.nginx, hosts, result, err)
 		if !recovered {
 			result.TestSuccess = false
-			result.TestError = testErr.Error()
+			result.TestError = lastErr.Error()
 			return result, nil
 		}
 	}

--- a/api/internal/service/sync_auto_recovery.go
+++ b/api/internal/service/sync_auto_recovery.go
@@ -1,0 +1,80 @@
+package service
+
+import (
+	"context"
+	"log"
+
+	"nginx-proxy-guard/internal/model"
+)
+
+// autoRecoveryNginx is the subset of NginxManager used by runAutoRecovery. Using
+// the narrower interface lets unit tests provide a fake without implementing
+// the full NginxManager surface.
+type autoRecoveryNginx interface {
+	TestConfig(ctx context.Context) error
+	RemoveConfig(ctx context.Context, host *model.ProxyHost) error
+	RemoveHostWAFConfig(ctx context.Context, hostID string) error
+}
+
+// runAutoRecovery attempts to make nginx's config test pass by iteratively
+// removing the config of hosts that nginx reports as failing. Behavior notes,
+// preserved as characterization points:
+//
+//   - Retry budget: up to 5 attempts per call (one initial failure +
+//     up to 5 removal-and-retry cycles).
+//   - Error → host matching is string-based via parseNginxErrorForHost
+//     (matches the proxy_host_<domain>.conf filename) and findHostByDomain.
+//   - A host marked !Success does NOT decrement SuccessCount a second time.
+//   - If the failing domain can't be mapped to a host in result.Hosts, the
+//     loop exits early and recovered=false.
+//   - WAF config removal (RemoveHostWAFConfig) is always attempted for a
+//     failing host, even if WAF was disabled for it.
+//   - Errors from RemoveConfig / RemoveHostWAFConfig are intentionally
+//     ignored — we've already decided this host is toxic to nginx.
+//
+// The extracted function returns (recovered, lastTestError). The caller is
+// responsible for writing the final TestSuccess / TestError fields on the
+// SyncAllResult.
+//
+// This was extracted out of SyncAllConfigsWithDetails purely for testability;
+// the original in-place loop is replaced by a call to this function.
+func runAutoRecovery(
+	ctx context.Context,
+	nm autoRecoveryNginx,
+	hosts []model.ProxyHost,
+	result *SyncAllResult,
+	initialErr error,
+) (recovered bool, lastErr error) {
+	testErr := initialErr
+	for attempt := 0; attempt < 5; attempt++ {
+		failingDomain := parseNginxErrorForHost(testErr.Error())
+		if failingDomain == "" {
+			break
+		}
+		hostIdx := findHostByDomain(result.Hosts, failingDomain)
+		if hostIdx < 0 {
+			break
+		}
+		// Mark the host as failed
+		if result.Hosts[hostIdx].Success {
+			result.Hosts[hostIdx].Success = false
+			result.Hosts[hostIdx].Error = testErr.Error()
+			result.SuccessCount--
+			result.FailedCount++
+		}
+		// Remove the failing host's config and WAF config to recover nginx
+		failingHost := findHostByID(hosts, result.Hosts[hostIdx].HostID)
+		if failingHost != nil {
+			log.Printf("[SyncConfigs] Removing failing config for %s to recover nginx", result.Hosts[hostIdx].DomainNames)
+			_ = nm.RemoveConfig(ctx, failingHost)
+			_ = nm.RemoveHostWAFConfig(ctx, failingHost.ID)
+		}
+		// Retry nginx test
+		if retryErr := nm.TestConfig(ctx); retryErr != nil {
+			testErr = retryErr
+			continue
+		}
+		return true, nil
+	}
+	return false, testErr
+}

--- a/api/internal/service/sync_auto_recovery_characterization_test.go
+++ b/api/internal/service/sync_auto_recovery_characterization_test.go
@@ -1,0 +1,318 @@
+package service
+
+// Characterization tests for the SyncAllConfigs auto-recovery loop.
+//
+// The loop was extracted from SyncAllConfigsWithDetails into runAutoRecovery
+// (see sync_auto_recovery.go) so it could be tested without a database.
+// These tests pin CURRENT behavior — most importantly the 5-attempt retry
+// budget, the "domain comes from nginx error text" mechanism, and the fact
+// that a host removed during recovery is not re-removed.
+//
+// A fake NginxManager (fakeAutoRecoveryNginx) stands in for the real one.
+// Its TestConfig returns an error whose text references a specific host's
+// config filename (proxy_host_<domain>.conf) matching the pattern that
+// parseNginxErrorForHost expects, and its RemoveConfig / RemoveHostWAFConfig
+// simply track what was removed. The fake intentionally implements only the
+// subset of NginxManager that runAutoRecovery uses (via the
+// autoRecoveryNginx interface).
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+
+	"nginx-proxy-guard/internal/model"
+)
+
+// fakeAutoRecoveryNginx satisfies the autoRecoveryNginx interface.
+// It simulates nginx -t failing for hosts whose ForwardHost contains the
+// marker "FAIL_MARKER" until those hosts' configs have been removed.
+type fakeAutoRecoveryNginx struct {
+	mu sync.Mutex
+
+	// writtenConfigs simulates the on-disk set of host IDs whose configs
+	// are currently "present" in nginx. The test seeds this before calling
+	// runAutoRecovery.
+	writtenConfigs map[string]bool
+
+	// wafRemoved tracks host IDs whose WAF config was removed.
+	wafRemoved map[string]bool
+
+	// failingHosts is the index of (domain → host) entries whose configs are
+	// toxic to nginx. As long as any entry in this map has a corresponding
+	// writtenConfigs entry, TestConfig will return an error referencing the
+	// FIRST toxic domain in failingOrder. Once a toxic host's config is
+	// removed, it is no longer reported.
+	failingHosts  map[string]string // domain → hostID
+	failingOrder  []string          // deterministic order of domains to report
+
+	testCallCount int
+}
+
+func newFakeAutoRecoveryNginx() *fakeAutoRecoveryNginx {
+	return &fakeAutoRecoveryNginx{
+		writtenConfigs: make(map[string]bool),
+		wafRemoved:     make(map[string]bool),
+		failingHosts:   make(map[string]string),
+	}
+}
+
+// TestConfig returns an error for the first toxic (failing + still-written)
+// host, or nil once none remain.
+func (f *fakeAutoRecoveryNginx) TestConfig(_ context.Context) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.testCallCount++
+	for _, domain := range f.failingOrder {
+		hostID, ok := f.failingHosts[domain]
+		if !ok {
+			continue
+		}
+		if f.writtenConfigs[hostID] {
+			// The error format must match parseNginxErrorForHost's regex:
+			// `proxy_host_<domain-with-underscores>\.conf`.
+			fileLabel := strings.ReplaceAll(domain, ".", "_")
+			return fmt.Errorf("nginx: [emerg] invalid host config in /etc/nginx/conf.d/proxy_host_%s.conf:42", fileLabel)
+		}
+	}
+	return nil
+}
+
+func (f *fakeAutoRecoveryNginx) RemoveConfig(_ context.Context, host *model.ProxyHost) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	delete(f.writtenConfigs, host.ID)
+	return nil
+}
+
+func (f *fakeAutoRecoveryNginx) RemoveHostWAFConfig(_ context.Context, hostID string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.wafRemoved[hostID] = true
+	return nil
+}
+
+// TestSyncAutoRecovery_Characterization exercises runAutoRecovery with:
+//   - 5 hosts total
+//   - 2 hosts whose ForwardHost contains "FAIL_MARKER" → their configs fail
+//     nginx test until removed.
+//
+// Characterization assertions:
+//   - After recovery, the 2 bad hosts' configs are no longer in writtenConfigs.
+//   - Their WAF configs were removed.
+//   - Their result entries are Success=false and Error is non-empty.
+//   - The 3 good hosts remain in writtenConfigs, Success=true, no WAF removal.
+//   - TestConfig was called at most 6 times (1 initial + up to 5 retries),
+//     matching the documented retry budget.
+//   - SuccessCount/FailedCount were adjusted correctly.
+func TestSyncAutoRecovery_Characterization(t *testing.T) {
+	ctx := context.Background()
+
+	hosts := []model.ProxyHost{
+		{ID: "host-1", DomainNames: []string{"good-1.example.com"}, ForwardHost: "10.0.0.1", Enabled: true},
+		{ID: "host-bad-1", DomainNames: []string{"bad-1.example.com"}, ForwardHost: "FAIL_MARKER-1", Enabled: true},
+		{ID: "host-2", DomainNames: []string{"good-2.example.com"}, ForwardHost: "10.0.0.2", Enabled: true},
+		{ID: "host-bad-2", DomainNames: []string{"bad-2.example.com"}, ForwardHost: "FAIL_MARKER-2", Enabled: true},
+		{ID: "host-3", DomainNames: []string{"good-3.example.com"}, ForwardHost: "10.0.0.3", Enabled: true},
+	}
+
+	fake := newFakeAutoRecoveryNginx()
+	// Seed: every host starts with a config "written".
+	for i := range hosts {
+		fake.writtenConfigs[hosts[i].ID] = true
+	}
+	// Mark bad hosts as toxic.
+	fake.failingHosts["bad-1.example.com"] = "host-bad-1"
+	fake.failingHosts["bad-2.example.com"] = "host-bad-2"
+	fake.failingOrder = []string{"bad-1.example.com", "bad-2.example.com"}
+
+	// Build the SyncAllResult as SyncAllConfigsWithDetails would, after the
+	// per-host generation loop has succeeded for every host.
+	result := &SyncAllResult{
+		TotalHosts:   len(hosts),
+		SuccessCount: len(hosts),
+		FailedCount:  0,
+	}
+	for i := range hosts {
+		result.Hosts = append(result.Hosts, SyncHostResult{
+			HostID:      hosts[i].ID,
+			DomainNames: hosts[i].DomainNames,
+			Success:     true,
+		})
+	}
+
+	// Simulate the caller's initial TestConfig call.
+	initialErr := fake.TestConfig(ctx)
+	if initialErr == nil {
+		t.Fatalf("expected initial TestConfig to fail (bad hosts present), got nil")
+	}
+
+	recovered, finalErr := runAutoRecovery(ctx, fake, hosts, result, initialErr)
+	if !recovered {
+		t.Fatalf("expected recovery to succeed, got recovered=false, err=%v", finalErr)
+	}
+
+	// Bad hosts should no longer have configs written.
+	if fake.writtenConfigs["host-bad-1"] {
+		t.Errorf("bad host-bad-1 config should have been removed, still present")
+	}
+	if fake.writtenConfigs["host-bad-2"] {
+		t.Errorf("bad host-bad-2 config should have been removed, still present")
+	}
+
+	// WAF removal was invoked for each bad host.
+	if !fake.wafRemoved["host-bad-1"] {
+		t.Errorf("WAF config for host-bad-1 should have been removed")
+	}
+	if !fake.wafRemoved["host-bad-2"] {
+		t.Errorf("WAF config for host-bad-2 should have been removed")
+	}
+
+	// Good hosts untouched.
+	for _, id := range []string{"host-1", "host-2", "host-3"} {
+		if !fake.writtenConfigs[id] {
+			t.Errorf("good host %s config should remain written", id)
+		}
+		if fake.wafRemoved[id] {
+			t.Errorf("good host %s WAF config should NOT have been removed", id)
+		}
+	}
+
+	// Result counts: 3 Success, 2 Failed.
+	if result.SuccessCount != 3 {
+		t.Errorf("expected SuccessCount=3 after recovery, got %d", result.SuccessCount)
+	}
+	if result.FailedCount != 2 {
+		t.Errorf("expected FailedCount=2 after recovery, got %d", result.FailedCount)
+	}
+
+	// Each bad host's result entry is failed and has the nginx error.
+	for _, id := range []string{"host-bad-1", "host-bad-2"} {
+		var hr *SyncHostResult
+		for i := range result.Hosts {
+			if result.Hosts[i].HostID == id {
+				hr = &result.Hosts[i]
+				break
+			}
+		}
+		if hr == nil {
+			t.Errorf("bad host %s missing from result.Hosts", id)
+			continue
+		}
+		if hr.Success {
+			t.Errorf("bad host %s should have Success=false", id)
+		}
+		if hr.Error == "" {
+			t.Errorf("bad host %s should have non-empty Error", id)
+		}
+	}
+
+	// Good hosts still Success=true.
+	for _, id := range []string{"host-1", "host-2", "host-3"} {
+		var hr *SyncHostResult
+		for i := range result.Hosts {
+			if result.Hosts[i].HostID == id {
+				hr = &result.Hosts[i]
+				break
+			}
+		}
+		if hr == nil || !hr.Success {
+			t.Errorf("good host %s should remain Success=true", id)
+		}
+	}
+
+	// Retry budget: initial + up to 5 retries = 6 TestConfig calls.
+	if fake.testCallCount > 6 {
+		t.Errorf("TestConfig called %d times, expected <= 6 (retry budget 5)", fake.testCallCount)
+	}
+	// Sanity: we should have at least 3 calls to recover two hosts
+	// (1 initial + 2 retries after removals).
+	if fake.testCallCount < 3 {
+		t.Errorf("TestConfig called only %d times, expected >= 3", fake.testCallCount)
+	}
+}
+
+// TestSyncAutoRecovery_UnparsableError pins the behavior when nginx returns an
+// error whose text does NOT match parseNginxErrorForHost's regex: the loop
+// exits early and reports recovered=false with the original error.
+func TestSyncAutoRecovery_UnparsableError(t *testing.T) {
+	ctx := context.Background()
+	hosts := []model.ProxyHost{
+		{ID: "host-1", DomainNames: []string{"example.com"}, ForwardHost: "10.0.0.1", Enabled: true},
+	}
+	fake := newFakeAutoRecoveryNginx()
+	fake.writtenConfigs["host-1"] = true
+
+	result := &SyncAllResult{
+		TotalHosts:   1,
+		SuccessCount: 1,
+		Hosts: []SyncHostResult{
+			{HostID: "host-1", DomainNames: []string{"example.com"}, Success: true},
+		},
+	}
+
+	initialErr := errors.New("some random nginx error without a filename pattern")
+	recovered, finalErr := runAutoRecovery(ctx, fake, hosts, result, initialErr)
+	if recovered {
+		t.Fatalf("expected recovered=false when error is unparsable")
+	}
+	if finalErr == nil || !strings.Contains(finalErr.Error(), "some random nginx error") {
+		t.Errorf("expected final error to match initial, got %v", finalErr)
+	}
+	// Nothing removed.
+	if !fake.writtenConfigs["host-1"] {
+		t.Errorf("no config should have been removed for unparsable error")
+	}
+}
+
+// TestSyncAutoRecovery_RetryBudgetExhausted pins the behavior when more
+// than 5 hosts are toxic: after 5 attempts the loop gives up and returns
+// recovered=false. This characterizes the fixed retry budget.
+func TestSyncAutoRecovery_RetryBudgetExhausted(t *testing.T) {
+	ctx := context.Background()
+
+	// 6 bad hosts — one more than the 5-attempt budget.
+	var hosts []model.ProxyHost
+	result := &SyncAllResult{}
+	fake := newFakeAutoRecoveryNginx()
+	for i := 0; i < 6; i++ {
+		id := fmt.Sprintf("host-bad-%d", i)
+		domain := fmt.Sprintf("bad-%d.example.com", i)
+		hosts = append(hosts, model.ProxyHost{ID: id, DomainNames: []string{domain}, Enabled: true})
+		result.Hosts = append(result.Hosts, SyncHostResult{HostID: id, DomainNames: []string{domain}, Success: true})
+		fake.writtenConfigs[id] = true
+		fake.failingHosts[domain] = id
+		fake.failingOrder = append(fake.failingOrder, domain)
+	}
+	result.TotalHosts = 6
+	result.SuccessCount = 6
+
+	initialErr := fake.TestConfig(ctx)
+	if initialErr == nil {
+		t.Fatalf("seed error: TestConfig should fail")
+	}
+
+	recovered, finalErr := runAutoRecovery(ctx, fake, hosts, result, initialErr)
+	if recovered {
+		t.Fatalf("expected recovered=false when >5 hosts are toxic, got recovered=true")
+	}
+	if finalErr == nil {
+		t.Errorf("expected non-nil final error after budget exhaustion")
+	}
+
+	// The first 5 bad hosts should have had their configs removed within
+	// the budget. The 6th should remain written.
+	removed := 0
+	for i := 0; i < 6; i++ {
+		id := fmt.Sprintf("host-bad-%d", i)
+		if !fake.writtenConfigs[id] {
+			removed++
+		}
+	}
+	if removed != 5 {
+		t.Errorf("expected exactly 5 configs removed within budget, got %d", removed)
+	}
+}

--- a/api/internal/service/waf_merge.go
+++ b/api/internal/service/waf_merge.go
@@ -1,0 +1,47 @@
+package service
+
+import "nginx-proxy-guard/internal/model"
+
+// mergeWAFExclusions merges host-specific WAF rule exclusions with global
+// exclusions. Host-specific exclusions take precedence — any global exclusion
+// whose RuleID already appears in host exclusions is dropped.
+//
+// Output shape per entry:
+//   - host-specific entries: copied verbatim
+//   - global-only entries:  rewritten as WAFRuleExclusion with
+//     ProxyHostID="global" and Reason suffixed with " (global)".
+//
+// Ordering: host exclusions first (in their incoming order), then the
+// non-duplicate global exclusions (in their incoming order). The resulting
+// slice is a newly allocated slice; callers may mutate it without aliasing
+// the input slices.
+//
+// This is the pure-function extraction of ProxyHostService.getMergedWAFExclusions;
+// it exists to be unit-testable without a database. The service method calls
+// this function after loading both slices from the repository.
+func mergeWAFExclusions(hostExclusions []model.WAFRuleExclusion, globalExclusions []model.GlobalWAFRuleExclusion) []model.WAFRuleExclusion {
+	hostExclusionMap := make(map[int]bool, len(hostExclusions))
+	for _, ex := range hostExclusions {
+		hostExclusionMap[ex.RuleID] = true
+	}
+
+	merged := make([]model.WAFRuleExclusion, len(hostExclusions))
+	copy(merged, hostExclusions)
+
+	for _, gex := range globalExclusions {
+		if !hostExclusionMap[gex.RuleID] {
+			merged = append(merged, model.WAFRuleExclusion{
+				ID:              gex.ID,
+				ProxyHostID:     "global",
+				RuleID:          gex.RuleID,
+				RuleCategory:    gex.RuleCategory,
+				RuleDescription: gex.RuleDescription,
+				Reason:          gex.Reason + " (global)",
+				DisabledBy:      gex.DisabledBy,
+				CreatedAt:       gex.CreatedAt,
+			})
+		}
+	}
+
+	return merged
+}

--- a/api/internal/service/waf_merge_characterization_test.go
+++ b/api/internal/service/waf_merge_characterization_test.go
@@ -1,0 +1,168 @@
+package service
+
+// Characterization tests for the WAF-exclusion merge logic.
+//
+// These tests freeze the CURRENT behavior of mergeWAFExclusions (which was
+// extracted out of ProxyHostService.getMergedWAFExclusions to enable unit
+// testing). See waf_merge.go for the extraction note.
+//
+// Observations worth noting for the refactor phases:
+//   - The current rule is "host wins on duplicate RuleID": when both lists
+//     contain the same rule_id, the host entry is kept verbatim and the
+//     global entry is dropped. This is what the production code has always
+//     done. The test `merged_with_duplicate` pins exactly that.
+//   - Global-only entries are rewritten into WAFRuleExclusion with
+//     ProxyHostID="global" and " (global)" appended to the Reason field.
+
+import (
+	"sort"
+	"testing"
+	"time"
+
+	"nginx-proxy-guard/internal/model"
+)
+
+func TestMergeWAFExclusions_Characterization(t *testing.T) {
+	now := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	cases := []struct {
+		name     string
+		host     []model.WAFRuleExclusion
+		global   []model.GlobalWAFRuleExclusion
+		wantIDs  []int // expected rule IDs, order-independent
+		checkFor func(t *testing.T, got []model.WAFRuleExclusion)
+	}{
+		{
+			name: "global_only",
+			host: nil,
+			global: []model.GlobalWAFRuleExclusion{
+				{ID: "g1", RuleID: 942100, RuleCategory: "sql_injection", Reason: "legacy admin", DisabledBy: "admin", CreatedAt: now},
+				{ID: "g2", RuleID: 941100, RuleCategory: "xss", Reason: "false positive", DisabledBy: "admin", CreatedAt: now},
+			},
+			wantIDs: []int{942100, 941100},
+			checkFor: func(t *testing.T, got []model.WAFRuleExclusion) {
+				for _, ex := range got {
+					if ex.ProxyHostID != "global" {
+						t.Errorf("expected global-only entry to have ProxyHostID=\"global\", got %q (rule %d)", ex.ProxyHostID, ex.RuleID)
+					}
+					// Reason is suffixed with " (global)".
+					if len(ex.Reason) < len(" (global)") || ex.Reason[len(ex.Reason)-len(" (global)"):] != " (global)" {
+						t.Errorf("expected Reason suffix \" (global)\" for rule %d, got %q", ex.RuleID, ex.Reason)
+					}
+				}
+			},
+		},
+		{
+			name: "host_only",
+			host: []model.WAFRuleExclusion{
+				{ID: "h1", ProxyHostID: "host-1", RuleID: 932100, RuleCategory: "rce", Reason: "known false positive", DisabledBy: "user", CreatedAt: now},
+			},
+			global:  nil,
+			wantIDs: []int{932100},
+			checkFor: func(t *testing.T, got []model.WAFRuleExclusion) {
+				if len(got) != 1 {
+					t.Fatalf("expected 1 result, got %d", len(got))
+				}
+				if got[0].ProxyHostID != "host-1" {
+					t.Errorf("host entry should preserve ProxyHostID; got %q", got[0].ProxyHostID)
+				}
+				if got[0].Reason != "known false positive" {
+					t.Errorf("host entry Reason should NOT be suffixed; got %q", got[0].Reason)
+				}
+			},
+		},
+		{
+			name: "merged_with_duplicate",
+			host: []model.WAFRuleExclusion{
+				{ID: "h-dup", ProxyHostID: "host-1", RuleID: 942100, RuleCategory: "sql_injection", Reason: "host-specific reason", DisabledBy: "user", CreatedAt: now},
+				{ID: "h2", ProxyHostID: "host-1", RuleID: 920100, RuleCategory: "protocol", Reason: "host-only", DisabledBy: "user", CreatedAt: now},
+			},
+			global: []model.GlobalWAFRuleExclusion{
+				{ID: "g-dup", RuleID: 942100, RuleCategory: "sql_injection", Reason: "global-conflict", DisabledBy: "admin", CreatedAt: now},
+				{ID: "g3", RuleID: 941100, RuleCategory: "xss", Reason: "global-only", DisabledBy: "admin", CreatedAt: now},
+			},
+			// Duplicate 942100 → host wins and appears once; 920100 from host;
+			// 941100 from global-only.
+			wantIDs: []int{942100, 920100, 941100},
+			checkFor: func(t *testing.T, got []model.WAFRuleExclusion) {
+				// Find entry for the duplicate rule_id and assert the host
+				// version won (ProxyHostID is the host's, not "global";
+				// Reason is the host one, not the global one).
+				var dup *model.WAFRuleExclusion
+				for i := range got {
+					if got[i].RuleID == 942100 {
+						dup = &got[i]
+						break
+					}
+				}
+				if dup == nil {
+					t.Fatalf("expected merged result to contain rule_id 942100")
+				}
+				if dup.ProxyHostID != "host-1" {
+					t.Errorf("duplicate rule: expected host to win (ProxyHostID=host-1), got %q", dup.ProxyHostID)
+				}
+				if dup.Reason != "host-specific reason" {
+					t.Errorf("duplicate rule: expected host Reason, got %q", dup.Reason)
+				}
+				// Count occurrences of the duplicate rule ID - must be exactly one.
+				count := 0
+				for _, ex := range got {
+					if ex.RuleID == 942100 {
+						count++
+					}
+				}
+				if count != 1 {
+					t.Errorf("duplicate rule_id must appear exactly once in output, got %d", count)
+				}
+			},
+		},
+		{
+			name:    "both_empty",
+			host:    nil,
+			global:  nil,
+			wantIDs: nil,
+			checkFor: func(t *testing.T, got []model.WAFRuleExclusion) {
+				if len(got) != 0 {
+					t.Errorf("expected empty result, got %d entries", len(got))
+				}
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			got := mergeWAFExclusions(tc.host, tc.global)
+
+			// Order-independent rule-id set comparison.
+			gotIDs := make([]int, 0, len(got))
+			for _, ex := range got {
+				gotIDs = append(gotIDs, ex.RuleID)
+			}
+			sort.Ints(gotIDs)
+			wantIDs := make([]int, len(tc.wantIDs))
+			copy(wantIDs, tc.wantIDs)
+			sort.Ints(wantIDs)
+
+			if !intSliceEqual(gotIDs, wantIDs) {
+				t.Errorf("rule IDs mismatch\n got:  %v\n want: %v", gotIDs, wantIDs)
+			}
+
+			if tc.checkFor != nil {
+				tc.checkFor(t, got)
+			}
+		})
+	}
+}
+
+func intSliceEqual(a, b []int) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
## Scope
Phase 2 of codebase-cleanup — characterization tests covering the nginx config generation pipeline. These tests freeze current behavior and protect Phase 3-6 refactors from regression.

## Changes
- `api/internal/nginx/proxy_host_template_characterization_test.go` — 6 cases with golden-file fixtures (http_only, https_force, waf_blocking, cache_enabled, advanced_config_conflict, upstream_load_balance)
- `api/internal/nginx/testdata/golden/proxy_host_*.conf` — 6 golden fixtures
- `api/internal/nginx/advanced_config_characterization_test.go` — 20 cases for the directive parser, covering edge cases like semicolon-separated directives on a single line (only first captured), uppercase input (not matched), commented-out directives, nested blocks
- `api/internal/service/waf_merge_characterization_test.go` — 4 cases (global_only, host_only, merged_with_duplicate, both_empty); asserts that on rule_id conflict, host entry wins (characterization observation)
- `api/internal/service/sync_auto_recovery_characterization_test.go` — 3 cases (happy-path recovery with 5 hosts / 2 bad, unparsable-error early exit, retry-budget exhaustion at >5 toxic hosts)

## Production-code changes (allowed surgical extractions for testability)
- `api/internal/service/waf_merge.go` — pure \`mergeWAFExclusions\` extracted from \`ProxyHostService.getMergedWAFExclusions\` so merge logic is testable without a DB. Original method now calls the extracted function.
- `api/internal/service/sync_auto_recovery.go` — pure \`runAutoRecovery\` extracted from \`ProxyHostService.SyncAllConfigsWithDetails\` so the auto-recovery loop is testable with a fake \`autoRecoveryNginx\` interface (subset of NginxManager). Original method now calls the extracted function.

No other production code was changed.

## Verification
- [x] \`go test ./internal/nginx/... ./internal/service/... -v -count=1\` green (all characterization tests pass)
- [x] \`go test ./internal/... ./cmd/... ./pkg/...\` green (all unit tests pass)
- [x] \`docker compose -f docker-compose.dev.yml build api\` succeeds
- Integration tests in \`tests/integration/\` require a live DB/API and fail on main too — not in scope

## Characterization notes preserved in comments
- Directive parser is line-oriented, not semicolon-aware (only first of N same-line directives is captured)
- Directive parser regex is \`[a-z_]+\` — uppercase input matches nothing
- WAF merge: host wins on \`rule_id\` conflict; global-only entries are rewritten with \`ProxyHostID="global"\` and \`" (global)"\` suffix on Reason
- Auto-recovery: 5-attempt retry budget; early-exit on unparsable nginx error text

## Out of scope
Beyond the two surgical pure-function extractions listed above, no production code changed.