### PR TITLE
refactor(ui/proxy-host): decompose useProxyHostForm into 5 focused hooks

### DIFF
--- a/ui/src/components/proxy-host/hooks/proxyHostValidation.ts
+++ b/ui/src/components/proxy-host/hooks/proxyHostValidation.ts
@@ -1,0 +1,68 @@
+import type { CreateProxyHostRequest } from '../../../types/proxy-host'
+import type { FormErrors } from '../types'
+
+/**
+ * Arguments required to validate a proxy host form.
+ */
+export interface ProxyHostValidationInput {
+  formData: CreateProxyHostRequest
+  portInput: string
+  certMode: 'select' | 'create'
+  /**
+   * i18n translator scoped to the `proxyHost` namespace.
+   * Accepting a callable keeps this module free of any React dependency.
+   */
+  t: (key: string) => string
+}
+
+/**
+ * Validate the core proxy host form fields (domains, forward host/port,
+ * certificate selection when SSL is on). Returns a FormErrors map — empty
+ * object means the form is valid.
+ *
+ * Pure function — no React state, no hooks.
+ */
+export function validateProxyHostForm({
+  formData,
+  portInput,
+  certMode,
+  t,
+}: ProxyHostValidationInput): FormErrors {
+  const newErrors: FormErrors = {}
+
+  const domains = formData.domain_names.map((d) => d.trim()).filter((d) => d)
+  if (domains.length === 0) {
+    newErrors.domain_names = t('validation.domainAtLeastOne')
+  }
+
+  if (!formData.forward_host.trim()) {
+    newErrors.forward_host = t('validation.hostRequired')
+  }
+
+  const port = parseInt(portInput)
+  if (!portInput || isNaN(port) || port < 1 || port > 65535) {
+    newErrors.forward_port = t('validation.portRange')
+  }
+
+  if (formData.ssl_enabled && certMode === 'select' && !formData.certificate_id) {
+    newErrors.certificate_id = t('validation.certSelectionRequired')
+  }
+
+  return newErrors
+}
+
+/**
+ * Convenience helper: returns `true` when the provided errors object is empty.
+ */
+export function isFormValid(errors: FormErrors): boolean {
+  return Object.keys(errors).length === 0
+}
+
+/**
+ * Normalize domain_names: trim whitespace and drop empty entries.
+ * Used in both validation and submit flows — extracted to keep behavior
+ * consistent across callers.
+ */
+export function normalizeDomains(domainNames: string[]): string[] {
+  return domainNames.map((d) => d.trim()).filter((d) => d)
+}

--- a/ui/src/components/proxy-host/hooks/useProxyHostCertificate.ts
+++ b/ui/src/components/proxy-host/hooks/useProxyHostCertificate.ts
@@ -1,0 +1,191 @@
+import { useState } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
+import { createCertificate, getCertificate } from '../../../api/certificates'
+import type { CreateCertificateRequest } from '../../../types/certificate'
+import type { CertificateState } from '../types'
+
+/**
+ * Default max wait time for certificate polling (2 minutes).
+ * Matches the original hook's `waitForCertificate(_, 120000)`.
+ */
+const DEFAULT_POLL_TIMEOUT_MS = 120_000
+
+/** Interval between certificate status polls (2 seconds). */
+const POLL_INTERVAL_MS = 2_000
+
+/**
+ * Return from {@link useProxyHostCertificate.ensureCertificate}.
+ *
+ * `ok === false` means the caller should NOT proceed to save the
+ * proxy host (either creation failed or polling timed out / errored).
+ * The cert log modal is left open so the user can see the error.
+ */
+export interface EnsureCertificateResult {
+  ok: boolean
+  certificateId?: string
+}
+
+/**
+ * Hook for managing the certificate selection/creation UI and the
+ * "create a new certificate before saving" sub-flow used by the submit
+ * orchestrator.
+ *
+ * Responsibilities:
+ *  - Own UI state for cert creation (progress, error, success, elapsed
+ *    time, pending cert id for the log modal).
+ *  - Expose {@link ensureCertificate} which creates a cert, polls it
+ *    to `issued`, and returns the resulting id.
+ */
+export function useProxyHostCertificate() {
+  const queryClient = useQueryClient()
+
+  const [certCreating, setCertCreating] = useState(false)
+  const [certError, setCertError] = useState<string | null>(null)
+  const [certSuccess, setCertSuccess] = useState<string | null>(null)
+  const [certProgress, setCertProgress] = useState<string | null>(null)
+  const [certElapsedTime, setCertElapsedTime] = useState(0)
+  /** Id of the pending cert — drives the log modal visibility. */
+  const [pendingCertId, setPendingCertId] = useState<string | null>(null)
+
+  /**
+   * Poll the certificate's status until it's `issued`, `error`, or the
+   * timeout is reached. Updates progress/error state in place so the UI
+   * can reflect the current status.
+   *
+   * @returns true if the certificate reached `issued`, false otherwise.
+   */
+  async function waitForCertificate(
+    certId: string,
+    maxWaitTime = DEFAULT_POLL_TIMEOUT_MS,
+  ): Promise<boolean> {
+    const startTime = Date.now()
+
+    while (Date.now() - startTime < maxWaitTime) {
+      const elapsed = Math.floor((Date.now() - startTime) / 1000)
+      setCertElapsedTime(elapsed)
+
+      try {
+        const cert = await getCertificate(certId)
+
+        // Null check for certificate response
+        if (!cert) {
+          console.error('Certificate not found:', certId)
+          setCertProgress(`Issuing certificate... (${elapsed}s)`)
+          await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS))
+          continue
+        }
+
+        if (cert.status === 'issued') {
+          setCertProgress('Certificate issued successfully!')
+          return true
+        } else if (cert.status === 'error') {
+          setCertError(cert.error_message || 'Certificate issuance failed')
+          return false
+        } else {
+          setCertProgress(`Issuing certificate... (${elapsed}s)`)
+        }
+      } catch (err) {
+        console.error('Error polling certificate status:', err)
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS))
+    }
+
+    setCertError('Certificate issuance timed out. Please check the certificate status manually.')
+    return false
+  }
+
+  /**
+   * Create a certificate for the given domains and wait for it to be
+   * issued (if it didn't complete synchronously). Keeps the cert log
+   * modal open on failure so the user can see what happened.
+   */
+  async function ensureCertificate(
+    domains: string[],
+    newCertData: CreateCertificateRequest,
+  ): Promise<EnsureCertificateResult> {
+    setCertCreating(true)
+    setCertError(null)
+    setCertSuccess(null)
+    setCertProgress('Creating certificate request...')
+    setCertElapsedTime(0)
+
+    try {
+      const certData: CreateCertificateRequest = {
+        ...newCertData,
+        domain_names: domains,
+      }
+      const cert = await createCertificate(certData)
+      setPendingCertId(cert.id) // Open log modal
+      queryClient.invalidateQueries({ queryKey: ['certificates'] })
+
+      if (cert.status === 'issued') {
+        setCertSuccess('Certificate created!')
+        setPendingCertId(null) // Close log modal on success
+      } else {
+        setCertProgress('Waiting for certificate issuance...')
+        const success = await waitForCertificate(cert.id)
+
+        if (!success) {
+          setCertCreating(false)
+          // DON'T close the modal here - let user see the error.
+          // Modal will be closed when user clicks close button.
+          return { ok: false }
+        }
+
+        setCertSuccess('Certificate issued successfully!')
+        setPendingCertId(null) // Close log modal on success
+      }
+
+      setCertProgress(null)
+      queryClient.invalidateQueries({ queryKey: ['certificates'] })
+      return { ok: true, certificateId: cert.id }
+    } catch (err) {
+      setCertError(err instanceof Error ? err.message : 'Failed to create certificate')
+      setCertCreating(false)
+      // DON'T close the modal here - let user see the error.
+      return { ok: false }
+    }
+  }
+
+  /** Close the certificate log modal. */
+  function closeCertLogModal() {
+    setPendingCertId(null)
+  }
+
+  /** Build the aggregated CertificateState object expected by SSLTabContent. */
+  function buildCertState(
+    mode: 'select' | 'create',
+    newCertData: CreateCertificateRequest,
+  ): CertificateState {
+    return {
+      mode,
+      data: newCertData,
+      creating: certCreating,
+      error: certError,
+      success: certSuccess,
+      progress: certProgress,
+      elapsedTime: certElapsedTime,
+    }
+  }
+
+  return {
+    // Raw state (useful for submit orchestrator)
+    certCreating,
+    setCertCreating,
+    certError,
+    certSuccess,
+    certProgress,
+    certElapsedTime,
+    pendingCertId,
+
+    // Derived + handlers
+    buildCertState,
+    ensureCertificate,
+    waitForCertificate,
+    closeCertLogModal,
+  }
+}
+
+/** Public return type, inferred. */
+export type ProxyHostCertificate = ReturnType<typeof useProxyHostCertificate>

--- a/ui/src/components/proxy-host/hooks/useProxyHostExtras.ts
+++ b/ui/src/components/proxy-host/hooks/useProxyHostExtras.ts
@@ -1,0 +1,189 @@
+import { useQueryClient } from '@tanstack/react-query'
+import { deleteGeoRestriction, getGeoRestriction, setGeoRestriction } from '../../../api/access'
+import { updateBotFilter } from '../../../api/security'
+import { api } from '../../../api/client'
+import type { BotFilterState, GeoDataState } from '../types'
+
+/** Arguments required by {@link ProxyHostExtras.saveExtrasForCreate}. */
+interface SaveExtrasCreateArgs {
+  hostId: string
+  botFilterData: BotFilterState
+  geoData: GeoDataState
+  blockedCloudProviders: string[]
+  cloudProviderChallengeMode: boolean
+  cloudProviderAllowSearchBots: boolean
+}
+
+/** Arguments required by {@link ProxyHostExtras.saveExtrasForUpdate}. */
+interface SaveExtrasUpdateArgs extends SaveExtrasCreateArgs {
+  /**
+   * The pre-existing geo restriction for this host. We use this to
+   * decide whether to DELETE the restriction when the user has cleared
+   * all geo settings (vs. a host that never had one).
+   */
+  existingGeoRestriction: Awaited<ReturnType<typeof getGeoRestriction>> | null | undefined
+}
+
+/**
+ * Hook that exposes two methods for saving the "extras" (bot filter,
+ * geo restriction, cloud provider blocking). Each extra is saved with
+ * `skip_reload=true` so the caller can issue a single nginx config
+ * regenerate after all extras are applied.
+ *
+ * Behavior differs between create (only save what's enabled) and update
+ * (always save all three, including delete-on-unset for geo).
+ */
+export function useProxyHostExtras() {
+  const queryClient = useQueryClient()
+
+  /**
+   * For the CREATE flow: a freshly-created host has no prior settings,
+   * so we only need to issue API calls for the extras that are actually
+   * set. Errors are logged but do NOT abort the flow — the primary host
+   * is already created, losing a bot filter write is recoverable.
+   *
+   * Runs all applicable calls in parallel.
+   *
+   * @returns true when at least one extra was saved (so the caller
+   *          knows it needs to regenerate the nginx config afterwards).
+   */
+  async function saveExtrasForCreate({
+    hostId,
+    botFilterData,
+    geoData,
+    blockedCloudProviders,
+    cloudProviderChallengeMode,
+    cloudProviderAllowSearchBots,
+  }: SaveExtrasCreateArgs): Promise<boolean> {
+    const promises: Promise<unknown>[] = []
+
+    if (
+      botFilterData.enabled ||
+      botFilterData.custom_blocked_agents ||
+      botFilterData.custom_allowed_agents
+    ) {
+      promises.push(
+        updateBotFilter(hostId, botFilterData, true).catch((err) =>
+          console.error('Failed to save bot filter:', err),
+        ),
+      )
+    }
+
+    if (
+      (geoData.enabled && geoData.countries.length > 0) ||
+      (geoData.allowed_ips?.length ?? 0) > 0
+    ) {
+      promises.push(
+        setGeoRestriction(
+          hostId,
+          {
+            mode: geoData.mode,
+            countries: geoData.countries,
+            allowed_ips: geoData.allowed_ips,
+            allow_private_ips: geoData.allow_private_ips,
+            allow_search_bots: geoData.allow_search_bots,
+            enabled: geoData.enabled && geoData.countries.length > 0,
+            challenge_mode: geoData.challenge_mode,
+          },
+          true,
+        ).catch((err) => console.error('Failed to save geo restriction:', err)),
+      )
+    }
+
+    if (
+      blockedCloudProviders.length > 0 ||
+      cloudProviderChallengeMode ||
+      cloudProviderAllowSearchBots
+    ) {
+      promises.push(
+        api
+          .put(`/api/v1/proxy-hosts/${hostId}/blocked-cloud-providers?skip_reload=true`, {
+            blocked_providers: blockedCloudProviders,
+            challenge_mode: cloudProviderChallengeMode,
+            allow_search_bots: cloudProviderAllowSearchBots,
+          })
+          .catch((err) => console.error('Failed to save blocked cloud providers:', err)),
+      )
+    }
+
+    if (promises.length === 0) return false
+    await Promise.all(promises)
+    return true
+  }
+
+  /**
+   * For the UPDATE flow: always save all three extras in parallel. Geo
+   * restriction DELETEs when the user has cleared both country blocking
+   * and priority-allow IPs (but only if a record previously existed).
+   *
+   * Errors per-extra are logged, not thrown — mirrors the original hook
+   * which rejected only on nginx regenerate failure (handled by caller).
+   */
+  async function saveExtrasForUpdate({
+    hostId,
+    botFilterData,
+    geoData,
+    blockedCloudProviders,
+    cloudProviderChallengeMode,
+    cloudProviderAllowSearchBots,
+    existingGeoRestriction,
+  }: SaveExtrasUpdateArgs): Promise<void> {
+    const promises = [
+      // Bot filter (skip reload)
+      updateBotFilter(hostId, botFilterData, true)
+        .then(() => queryClient.invalidateQueries({ queryKey: ['botFilter', hostId] }))
+        .catch((err) => console.error('Failed to save bot filter:', err)),
+
+      // Geo restriction (skip reload)
+      (async () => {
+        try {
+          const hasGeoBlocking = geoData.enabled && geoData.countries.length > 0
+          const hasPriorityAllowIPs = (geoData.allowed_ips?.length ?? 0) > 0
+
+          if (hasGeoBlocking || hasPriorityAllowIPs) {
+            await setGeoRestriction(
+              hostId,
+              {
+                mode: geoData.mode,
+                countries: geoData.countries,
+                allowed_ips: geoData.allowed_ips,
+                allow_private_ips: geoData.allow_private_ips,
+                allow_search_bots: geoData.allow_search_bots,
+                enabled: hasGeoBlocking,
+                challenge_mode: geoData.challenge_mode,
+              },
+              true,
+            )
+          } else if (existingGeoRestriction) {
+            await deleteGeoRestriction(hostId, true)
+          }
+          queryClient.invalidateQueries({ queryKey: ['geoRestriction', hostId] })
+        } catch (err) {
+          console.error('Failed to save geo restriction:', err)
+        }
+      })(),
+
+      // Blocked cloud providers (skip reload)
+      api
+        .put(`/api/v1/proxy-hosts/${hostId}/blocked-cloud-providers?skip_reload=true`, {
+          blocked_providers: blockedCloudProviders,
+          challenge_mode: cloudProviderChallengeMode,
+          allow_search_bots: cloudProviderAllowSearchBots,
+        })
+        .then(() =>
+          queryClient.invalidateQueries({ queryKey: ['blockedCloudProviders', hostId] }),
+        )
+        .catch((err) => console.error('Failed to save blocked cloud providers:', err)),
+    ]
+
+    await Promise.all(promises)
+  }
+
+  return {
+    saveExtrasForCreate,
+    saveExtrasForUpdate,
+  }
+}
+
+/** Public return type, inferred. */
+export type ProxyHostExtras = ReturnType<typeof useProxyHostExtras>

--- a/ui/src/components/proxy-host/hooks/useProxyHostForm.ts
+++ b/ui/src/components/proxy-host/hooks/useProxyHostForm.ts
@@ -1,675 +1,104 @@
-import { useState, useEffect } from 'react'
-import { useTranslation } from 'react-i18next'
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { createProxyHost, updateProxyHost, regenerateHostConfig } from '../../../api/proxy-hosts'
-import { listCertificates, createCertificate, getCertificate } from '../../../api/certificates'
-import { listDNSProviders } from '../../../api/dns-providers'
-import { getAccessLists, getGeoRestriction, setGeoRestriction, deleteGeoRestriction, getCountryCodes } from '../../../api/access'
-import { getBotFilter, updateBotFilter } from '../../../api/security'
-import { getGeoIPStatus } from '../../../api/settings'
-import { api, ApiError } from '../../../api/client'
-import type { ProxyHost, CreateProxyHostRequest } from '../../../types/proxy-host'
-import type { CreateCertificateRequest } from '../../../types/certificate'
-import type { BotFilterState, GeoDataState, FormErrors, CertificateState } from '../types'
+import type { ProxyHost } from '../../../types/proxy-host'
+import { useProxyHostFormState } from './useProxyHostFormState'
+import { useProxyHostCertificate } from './useProxyHostCertificate'
+import { useProxyHostExtras } from './useProxyHostExtras'
+import { useProxyHostSubmit } from './useProxyHostSubmit'
 
+/**
+ * Thin container hook that composes the proxy-host form from four
+ * focused sub-hooks:
+ *
+ *  - {@link useProxyHostFormState}  – field values, setters, queries
+ *  - {@link useProxyHostCertificate} – cert create + 2s polling
+ *  - {@link useProxyHostExtras}     – bot/geo/cloud saves (skip_reload)
+ *  - {@link useProxyHostSubmit}     – 6-step orchestrator
+ *
+ * The public API matches the original monolithic hook so
+ * `ProxyHostForm.tsx` does not need to change.
+ */
 export function useProxyHostForm(host: ProxyHost | null | undefined, onClose: () => void) {
-  const queryClient = useQueryClient()
-  const { t } = useTranslation('proxyHost')
-  const isEditing = !!host
-
-  // Form data state
-  const [formData, setFormData] = useState<CreateProxyHostRequest>({
-    domain_names: [''],
-    forward_scheme: 'http',
-    forward_host: '',
-    forward_port: 80,
-    ssl_enabled: false,
-    ssl_force_https: false,
-    ssl_http2: true,
-    ssl_http3: false,
-    certificate_id: undefined,
-    access_list_id: undefined,
-    allow_websocket_upgrade: true,
-    cache_enabled: false,
-    cache_static_only: true,
-    cache_ttl: '7d',
-    block_exploits: true,
-    // Host-level proxy settings (empty = use global)
-    client_max_body_size: '',
-    proxy_max_temp_file_size: '',
-    proxy_buffering: '',
-    proxy_request_buffering: '',
-    waf_enabled: false,
-    waf_mode: 'blocking',
-    waf_paranoia_level: 1,
-    waf_anomaly_threshold: 5,
-    advanced_config: '',
-    enabled: true,
-  })
-
-  // Port input state - initialize from host if editing
-  const [portInput, setPortInput] = useState(() =>
-    host?.forward_port?.toString() || '80'
-  )
-
-  // Errors state
-  const [errors, setErrors] = useState<FormErrors>({})
-
-  // Save progress state
-  const [saveProgress, setSaveProgress] = useState({
-    isOpen: false,
-    currentStep: 0,
-    error: null as string | null,
-    errorDetails: null as string | null,
-  })
-
-  // Certificate state
-  const [certMode, setCertMode] = useState<'select' | 'create'>('select')
-  const [newCertData, setNewCertData] = useState<CreateCertificateRequest>({
-    domain_names: [],
-    provider: 'letsencrypt',
-    auto_renew: true,
-  })
-  const [certCreating, setCertCreating] = useState(false)
-  const [certError, setCertError] = useState<string | null>(null)
-  const [certSuccess, setCertSuccess] = useState<string | null>(null)
-  const [certProgress, setCertProgress] = useState<string | null>(null)
-  const [certElapsedTime, setCertElapsedTime] = useState(0)
-  const [pendingCertId, setPendingCertId] = useState<string | null>(null) // For log modal
-
-  // Bot filter state
-  const [botFilterData, setBotFilterData] = useState<BotFilterState>({
-    enabled: false,
-    block_bad_bots: true,
-    block_ai_bots: false,
-    allow_search_engines: true,
-    block_suspicious_clients: false,
-    custom_blocked_agents: '',
-    custom_allowed_agents: '',
-    challenge_suspicious: false,
-  })
-
-  // GeoIP state
-  const [geoData, setGeoData] = useState<GeoDataState>({
-    enabled: false,
-    mode: 'blacklist',
-    countries: [],
-    allowed_ips: [],
-    allow_private_ips: true,
-    allow_search_bots: false,
-    challenge_mode: false,
-  })
-  const [geoSearchTerm, setGeoSearchTerm] = useState('')
-  const [allowedIPsInput, setAllowedIPsInput] = useState('')
-
-  // Cloud provider blocking state
-  const [blockedCloudProviders, setBlockedCloudProviders] = useState<string[]>([])
-  const [cloudProviderChallengeMode, setCloudProviderChallengeMode] = useState(false)
-  const [cloudProviderAllowSearchBots, setCloudProviderAllowSearchBots] = useState(false)
-
-  // Queries
-  const { data: certificatesData } = useQuery({
-    queryKey: ['certificates'],
-    queryFn: () => listCertificates(),
-  })
-
-  const { data: accessListsData } = useQuery({
-    queryKey: ['accessLists'],
-    queryFn: () => getAccessLists(1, 100),
-  })
-
-  const { data: dnsProvidersData } = useQuery({
-    queryKey: ['dnsProviders'],
-    queryFn: () => listDNSProviders(1, 100),
-  })
-
-  const { data: existingBotFilter } = useQuery({
-    queryKey: ['botFilter', host?.id],
-    queryFn: () => getBotFilter(host!.id),
-    enabled: !!host?.id,
-  })
-
-  const { data: geoipStatus } = useQuery({
-    queryKey: ['geoipStatus'],
-    queryFn: getGeoIPStatus,
-  })
-
-  const isGeoIPAvailable = geoipStatus?.status === 'active' || (geoipStatus?.enabled && geoipStatus?.country_db)
-
-  const { data: countryCodes } = useQuery({
-    queryKey: ['countryCodes'],
-    queryFn: getCountryCodes,
-    enabled: !!isGeoIPAvailable,
-  })
-
-  const { data: existingGeoRestriction } = useQuery({
-    queryKey: ['geoRestriction', host?.id],
-    queryFn: () => getGeoRestriction(host!.id).catch(() => null),
-    enabled: !!host?.id && !!isGeoIPAvailable,
-  })
-
-  const { data: existingCloudProviderSettings } = useQuery({
-    queryKey: ['blockedCloudProviders', host?.id],
-    queryFn: async () => {
-      const response = await api.get<{ blocked_providers: string[]; challenge_mode: boolean; allow_search_bots: boolean }>(`/api/v1/proxy-hosts/${host!.id}/blocked-cloud-providers`)
-      return {
-        blocked_providers: response.blocked_providers || [],
-        challenge_mode: response.challenge_mode || false,
-        allow_search_bots: response.allow_search_bots || false,
-      }
-    },
-    enabled: !!host?.id,
-  })
-
-  // Derived data
-  const availableCerts = certificatesData?.data?.filter((c) => c.status === 'issued') || []
-  const pendingCerts = certificatesData?.data?.filter((c) => c.status === 'pending') || []
-  const availableAccessLists = accessListsData?.data || []
-  const dnsProviders = dnsProvidersData?.data || []
-
-  // Effects
-  useEffect(() => {
-    if (existingBotFilter) {
-      setBotFilterData({
-        enabled: existingBotFilter.enabled,
-        block_bad_bots: existingBotFilter.block_bad_bots,
-        block_ai_bots: existingBotFilter.block_ai_bots,
-        allow_search_engines: existingBotFilter.allow_search_engines,
-        block_suspicious_clients: existingBotFilter.block_suspicious_clients,
-        custom_blocked_agents: existingBotFilter.custom_blocked_agents || '',
-        custom_allowed_agents: existingBotFilter.custom_allowed_agents || '',
-        challenge_suspicious: existingBotFilter.challenge_suspicious,
-      })
-    }
-  }, [existingBotFilter])
-
-  useEffect(() => {
-    if (existingGeoRestriction) {
-      setGeoData({
-        enabled: existingGeoRestriction.enabled && existingGeoRestriction.countries?.length > 0,
-        mode: existingGeoRestriction.mode,
-        countries: existingGeoRestriction.countries || [],
-        allowed_ips: existingGeoRestriction.allowed_ips || [],
-        allow_private_ips: existingGeoRestriction.allow_private_ips ?? true,
-        allow_search_bots: existingGeoRestriction.allow_search_bots ?? false,
-        challenge_mode: existingGeoRestriction.challenge_mode || false,
-      })
-      setAllowedIPsInput((existingGeoRestriction.allowed_ips || []).join('\n'))
-    }
-  }, [existingGeoRestriction])
-
-  useEffect(() => {
-    if (existingCloudProviderSettings) {
-      setBlockedCloudProviders(existingCloudProviderSettings.blocked_providers)
-      setCloudProviderChallengeMode(existingCloudProviderSettings.challenge_mode)
-      setCloudProviderAllowSearchBots(existingCloudProviderSettings.allow_search_bots || false)
-    }
-  }, [existingCloudProviderSettings])
-
-  useEffect(() => {
-    const domains = formData.domain_names.filter(d => d.trim())
-    if (domains.length > 0 && certMode === 'create') {
-      setNewCertData(prev => ({ ...prev, domain_names: domains }))
-    }
-  }, [formData.domain_names, certMode])
-
-  useEffect(() => {
-    if (host) {
-      setFormData({
-        domain_names: host.domain_names,
-        forward_scheme: host.forward_scheme,
-        forward_host: host.forward_host,
-        forward_port: host.forward_port,
-        ssl_enabled: host.ssl_enabled,
-        ssl_force_https: host.ssl_force_https,
-        ssl_http2: host.ssl_http2,
-        ssl_http3: host.ssl_http3,
-        certificate_id: host.certificate_id,
-        access_list_id: host.access_list_id,
-        allow_websocket_upgrade: host.allow_websocket_upgrade,
-        cache_enabled: host.cache_enabled,
-        cache_static_only: host.cache_static_only ?? true,
-        cache_ttl: host.cache_ttl || '7d',
-        block_exploits: host.block_exploits,
-        // Host-level proxy settings
-        client_max_body_size: host.client_max_body_size || '',
-        proxy_max_temp_file_size: host.proxy_max_temp_file_size || '',
-        proxy_buffering: host.proxy_buffering || '',
-        proxy_request_buffering: host.proxy_request_buffering || '',
-        waf_enabled: host.waf_enabled,
-        waf_mode: (host.waf_mode as 'blocking' | 'detection') || 'blocking',
-        waf_paranoia_level: host.waf_paranoia_level || 1,
-        waf_anomaly_threshold: host.waf_anomaly_threshold || 5,
-        advanced_config: host.advanced_config || '',
-        enabled: host.enabled,
-      })
-      setPortInput(host.forward_port.toString())
-    }
-  }, [host])
-
-  // Helper to close progress modal after delay
-  const closeProgressWithDelay = (delay = 800) => {
-    setTimeout(() => {
-      setSaveProgress({ isOpen: false, currentStep: 0, error: null, errorDetails: null })
-      onClose()
-    }, delay)
-  }
-
-  // Mutations
-  const createMutation = useMutation({
-    mutationFn: createProxyHost,
-    onMutate: () => {
-      // Step 0: Server processing (DB + config + test + reload)
-      setSaveProgress(prev => ({ ...prev, currentStep: 0 }))
-    },
-    onSuccess: async (newHost) => {
-      // Step 1: Additional settings
-      setSaveProgress(prev => ({ ...prev, currentStep: 1 }))
-
-      // Save additional settings in PARALLEL for speed (skip nginx reload since main API already did it)
-      const additionalSettingsPromises: Promise<unknown>[] = []
-
-      if (botFilterData.enabled || botFilterData.custom_blocked_agents || botFilterData.custom_allowed_agents) {
-        additionalSettingsPromises.push(
-          updateBotFilter(newHost.id, botFilterData, true)
-            .catch(err => console.error('Failed to save bot filter:', err))
-        )
-      }
-
-      // Save geo restriction if geo blocking enabled OR if priority allow IPs exist
-      if ((geoData.enabled && geoData.countries.length > 0) || (geoData.allowed_ips?.length ?? 0) > 0) {
-        additionalSettingsPromises.push(
-          setGeoRestriction(newHost.id, {
-            mode: geoData.mode,
-            countries: geoData.countries,
-            allowed_ips: geoData.allowed_ips,
-            allow_private_ips: geoData.allow_private_ips,
-            allow_search_bots: geoData.allow_search_bots,
-            enabled: geoData.enabled && geoData.countries.length > 0,
-            challenge_mode: geoData.challenge_mode,
-          }, true).catch(err => console.error('Failed to save geo restriction:', err))
-        )
-      }
-
-      if (blockedCloudProviders.length > 0 || cloudProviderChallengeMode || cloudProviderAllowSearchBots) {
-        additionalSettingsPromises.push(
-          api.put(`/api/v1/proxy-hosts/${newHost.id}/blocked-cloud-providers?skip_reload=true`, {
-            blocked_providers: blockedCloudProviders,
-            challenge_mode: cloudProviderChallengeMode,
-            allow_search_bots: cloudProviderAllowSearchBots,
-          }).catch(err => console.error('Failed to save blocked cloud providers:', err))
-        )
-      }
-
-      if (additionalSettingsPromises.length > 0) {
-        await Promise.all(additionalSettingsPromises)
-        // Regenerate config for this specific host to apply additional settings
-        try {
-          await regenerateHostConfig(newHost.id)
-        } catch (err) {
-          const isApiError = err instanceof ApiError
-          setSaveProgress(prev => ({
-            ...prev,
-            error: err instanceof Error ? err.message : 'Failed to apply nginx config',
-            errorDetails: isApiError ? (err as ApiError).details || null : null,
-          }))
-          return
-        }
-      }
-
-      // Step 2: Complete
-      setSaveProgress(prev => ({ ...prev, currentStep: 2 }))
-      queryClient.invalidateQueries({ queryKey: ['proxy-hosts'] })
-      closeProgressWithDelay()
-    },
-    onError: (error) => {
-      const isApiError = error instanceof ApiError
-      setSaveProgress(prev => ({
-        ...prev,
-        error: error instanceof Error ? error.message : 'Failed to create proxy host',
-        errorDetails: isApiError ? error.details || null : null,
-      }))
-    },
-  })
-
-  const updateMutation = useMutation({
-    mutationFn: ({ id, data }: { id: string; data: CreateProxyHostRequest }) =>
-      updateProxyHost(id, data, true),
-    onMutate: () => {
-      // Step 0: Server processing (DB save, nginx deferred to regenerate)
-      setSaveProgress(prev => ({ ...prev, currentStep: 0 }))
-    },
-    onSuccess: async (_, variables) => {
-      // Step 1: Additional settings
-      setSaveProgress(prev => ({ ...prev, currentStep: 1 }))
-
-      // Save additional settings in PARALLEL (all skip nginx reload)
-      const additionalSettingsPromises = [
-        // Bot filter (skip reload)
-        updateBotFilter(variables.id, botFilterData, true)
-          .then(() => queryClient.invalidateQueries({ queryKey: ['botFilter', variables.id] }))
-          .catch(err => console.error('Failed to save bot filter:', err)),
-
-        // Geo restriction (skip reload)
-        (async () => {
-          try {
-            const hasGeoBlocking = geoData.enabled && geoData.countries.length > 0
-            const hasPriorityAllowIPs = (geoData.allowed_ips?.length ?? 0) > 0
-
-            if (hasGeoBlocking || hasPriorityAllowIPs) {
-              await setGeoRestriction(variables.id, {
-                mode: geoData.mode,
-                countries: geoData.countries,
-                allowed_ips: geoData.allowed_ips,
-                allow_private_ips: geoData.allow_private_ips,
-                allow_search_bots: geoData.allow_search_bots,
-                enabled: hasGeoBlocking,
-                challenge_mode: geoData.challenge_mode,
-              }, true)
-            } else if (existingGeoRestriction) {
-              await deleteGeoRestriction(variables.id, true)
-            }
-            queryClient.invalidateQueries({ queryKey: ['geoRestriction', variables.id] })
-          } catch (err) {
-            console.error('Failed to save geo restriction:', err)
-          }
-        })(),
-
-        // Blocked cloud providers (skip reload)
-        api.put(`/api/v1/proxy-hosts/${variables.id}/blocked-cloud-providers?skip_reload=true`, {
-          blocked_providers: blockedCloudProviders,
-          challenge_mode: cloudProviderChallengeMode,
-          allow_search_bots: cloudProviderAllowSearchBots,
-        })
-          .then(() => queryClient.invalidateQueries({ queryKey: ['blockedCloudProviders', variables.id] }))
-          .catch(err => console.error('Failed to save blocked cloud providers:', err)),
-      ]
-
-      await Promise.all(additionalSettingsPromises)
-
-      // Single nginx config generation + test + reload (all settings applied at once)
-      try {
-        await regenerateHostConfig(variables.id)
-      } catch (err) {
-        const isApiError = err instanceof ApiError
-        setSaveProgress(prev => ({
-          ...prev,
-          error: err instanceof Error ? err.message : 'Failed to apply nginx config',
-          errorDetails: isApiError ? (err as ApiError).details || null : null,
-        }))
-        return
-      }
-
-      // Step 2: Complete
-      setSaveProgress(prev => ({ ...prev, currentStep: 2 }))
-      queryClient.invalidateQueries({ queryKey: ['proxy-hosts'] })
-      closeProgressWithDelay()
-    },
-    onError: (error) => {
-      const isApiError = error instanceof ApiError
-      setSaveProgress(prev => ({
-        ...prev,
-        error: error instanceof Error ? error.message : 'Failed to update proxy host',
-        errorDetails: isApiError ? error.details || null : null,
-      }))
-    },
-  })
-
-  const mutation = isEditing ? updateMutation : createMutation
-
-  // Validation
-  const validate = (): boolean => {
-    const newErrors: FormErrors = {}
-
-    const domains = formData.domain_names.map((d) => d.trim()).filter((d) => d)
-    if (domains.length === 0) {
-      newErrors.domain_names = t('validation.domainAtLeastOne')
-    }
-
-    if (!formData.forward_host.trim()) {
-      newErrors.forward_host = t('validation.hostRequired')
-    }
-
-    const port = parseInt(portInput)
-    if (!portInput || isNaN(port) || port < 1 || port > 65535) {
-      newErrors.forward_port = t('validation.portRange')
-    }
-
-    if (formData.ssl_enabled && certMode === 'select' && !formData.certificate_id) {
-      newErrors.certificate_id = t('validation.certSelectionRequired')
-    }
-
-    setErrors(newErrors)
-    return Object.keys(newErrors).length === 0
-  }
-
-  // Certificate helper
-  const waitForCertificate = async (certId: string, maxWaitTime = 120000): Promise<boolean> => {
-    const startTime = Date.now()
-    const pollInterval = 2000
-
-    while (Date.now() - startTime < maxWaitTime) {
-      const elapsed = Math.floor((Date.now() - startTime) / 1000)
-      setCertElapsedTime(elapsed)
-
-      try {
-        const cert = await getCertificate(certId)
-
-        // Null check for certificate response
-        if (!cert) {
-          console.error('Certificate not found:', certId)
-          setCertProgress(`Issuing certificate... (${elapsed}s)`)
-          await new Promise(resolve => setTimeout(resolve, pollInterval))
-          continue
-        }
-
-        if (cert.status === 'issued') {
-          setCertProgress('Certificate issued successfully!')
-          return true
-        } else if (cert.status === 'error') {
-          setCertError(cert.error_message || 'Certificate issuance failed')
-          return false
-        } else {
-          setCertProgress(`Issuing certificate... (${elapsed}s)`)
-        }
-      } catch (err) {
-        console.error('Error polling certificate status:', err)
-      }
-
-      await new Promise(resolve => setTimeout(resolve, pollInterval))
-    }
-
-    setCertError('Certificate issuance timed out. Please check the certificate status manually.')
-    return false
-  }
-
-  // Submit handler
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault()
-
-    // Step 0: Validation
-    setSaveProgress({ isOpen: true, currentStep: 0, error: null, errorDetails: null })
-
-    if (!validate()) {
-      setSaveProgress({ isOpen: false, currentStep: 0, error: null, errorDetails: null })
-      return
-    }
-
-    const domains = formData.domain_names.map((d) => d.trim()).filter((d) => d)
-    let certificateId = formData.certificate_id
-
-    if (formData.ssl_enabled && certMode === 'create') {
-      if (domains.length === 0) {
-        setErrors({ domain_names: t('validation.addDomainsBeforeCert') })
-        setSaveProgress({ isOpen: false, currentStep: 0, error: null, errorDetails: null })
-        return
-      }
-
-      setCertCreating(true)
-      setCertError(null)
-      setCertSuccess(null)
-      setCertProgress('Creating certificate request...')
-      setCertElapsedTime(0)
-      // Close save progress modal while cert is being created
-      setSaveProgress({ isOpen: false, currentStep: 0, error: null, errorDetails: null })
-
-      try {
-        const certData: CreateCertificateRequest = {
-          ...newCertData,
-          domain_names: domains,
-        }
-        const cert = await createCertificate(certData)
-        setPendingCertId(cert.id) // Open log modal
-        queryClient.invalidateQueries({ queryKey: ['certificates'] })
-
-        if (cert.status === 'issued') {
-          certificateId = cert.id
-          setCertSuccess('Certificate created!')
-          setPendingCertId(null) // Close log modal on success
-        } else {
-          setCertProgress('Waiting for certificate issuance...')
-          const success = await waitForCertificate(cert.id)
-
-          if (!success) {
-            setCertCreating(false)
-            // DON'T close the modal here - let user see the error
-            // Modal will be closed when user clicks close button
-            return
-          }
-
-          certificateId = cert.id
-          setCertSuccess('Certificate issued successfully!')
-          setPendingCertId(null) // Close log modal on success
-        }
-      } catch (err) {
-        setCertError(err instanceof Error ? err.message : 'Failed to create certificate')
-        setCertCreating(false)
-        // DON'T close the modal here - let user see the error
-        return
-      }
-
-      setCertProgress(null)
-      queryClient.invalidateQueries({ queryKey: ['certificates'] })
-      // Re-open save progress modal after cert is created
-      setSaveProgress({ isOpen: true, currentStep: 0, error: null, errorDetails: null })
-    }
-
-    const data = {
-      ...formData,
-      domain_names: domains,
-      forward_port: parseInt(portInput) || 80,
-      certificate_id: certificateId,
-    }
-
-    if (isEditing && host) {
-      updateMutation.mutate({ id: host.id, data })
-    } else {
-      createMutation.mutate(data)
-    }
-
-    setCertCreating(false)
-  }
-
-  // Close progress modal on error
-  const closeSaveProgress = () => {
-    setSaveProgress({ isOpen: false, currentStep: 0, error: null, errorDetails: null })
-  }
-
-  // Close certificate log modal
-  const closeCertLogModal = () => {
-    setPendingCertId(null)
-  }
-
-  // Domain helpers
+  const state = useProxyHostFormState(host)
+  const cert = useProxyHostCertificate()
+  const extras = useProxyHostExtras()
+  const submit = useProxyHostSubmit({ host, state, cert, extras, onClose })
+
+  // Domain list helpers — small inline operations on formData.domain_names
   const addDomain = () => {
-    setFormData((prev) => ({
+    state.setFormData((prev) => ({
       ...prev,
       domain_names: [...prev.domain_names, ''],
     }))
   }
 
   const removeDomain = (index: number) => {
-    setFormData((prev) => ({
+    state.setFormData((prev) => ({
       ...prev,
       domain_names: prev.domain_names.filter((_, i) => i !== index),
     }))
   }
 
   const updateDomain = (index: number, value: string) => {
-    setFormData((prev) => ({
+    state.setFormData((prev) => ({
       ...prev,
       domain_names: prev.domain_names.map((d, i) => (i === index ? value : d)),
     }))
   }
 
-  // Certificate state object
-  const certState: CertificateState = {
-    mode: certMode,
-    data: newCertData,
-    creating: certCreating,
-    error: certError,
-    success: certSuccess,
-    progress: certProgress,
-    elapsedTime: certElapsedTime,
-  }
+  const certState = cert.buildCertState(state.certMode, state.newCertData)
 
   return {
-    // State
-    formData,
-    setFormData,
-    portInput,
-    setPortInput,
-    errors,
-    setErrors,
-    isEditing,
+    // Form data + errors
+    formData: state.formData,
+    setFormData: state.setFormData,
+    portInput: state.portInput,
+    setPortInput: state.setPortInput,
+    errors: state.errors,
+    setErrors: state.setErrors,
+    isEditing: state.isEditing,
 
-    // Certificate
+    // Certificate form + creation
     certState,
-    setCertMode,
-    setNewCertData,
+    setCertMode: state.setCertMode,
+    setNewCertData: state.setNewCertData,
+    certCreating: cert.certCreating,
+    pendingCertId: cert.pendingCertId,
+    closeCertLogModal: cert.closeCertLogModal,
 
     // Bot filter
-    botFilterData,
-    setBotFilterData,
+    botFilterData: state.botFilterData,
+    setBotFilterData: state.setBotFilterData,
 
     // GeoIP
-    geoData,
-    setGeoData,
-    geoSearchTerm,
-    setGeoSearchTerm,
-    allowedIPsInput,
-    setAllowedIPsInput,
+    geoData: state.geoData,
+    setGeoData: state.setGeoData,
+    geoSearchTerm: state.geoSearchTerm,
+    setGeoSearchTerm: state.setGeoSearchTerm,
+    allowedIPsInput: state.allowedIPsInput,
+    setAllowedIPsInput: state.setAllowedIPsInput,
 
     // Cloud provider blocking
-    blockedCloudProviders,
-    setBlockedCloudProviders,
-    cloudProviderChallengeMode,
-    setCloudProviderChallengeMode,
-    cloudProviderAllowSearchBots,
-    setCloudProviderAllowSearchBots,
+    blockedCloudProviders: state.blockedCloudProviders,
+    setBlockedCloudProviders: state.setBlockedCloudProviders,
+    cloudProviderChallengeMode: state.cloudProviderChallengeMode,
+    setCloudProviderChallengeMode: state.setCloudProviderChallengeMode,
+    cloudProviderAllowSearchBots: state.cloudProviderAllowSearchBots,
+    setCloudProviderAllowSearchBots: state.setCloudProviderAllowSearchBots,
 
-    // Data from queries
-    availableCerts,
-    pendingCerts,
-    availableAccessLists,
-    dnsProviders,
-    geoipStatus,
-    countryCodes,
+    // External data
+    availableCerts: state.availableCerts,
+    pendingCerts: state.pendingCerts,
+    availableAccessLists: state.availableAccessLists,
+    dnsProviders: state.dnsProviders,
+    geoipStatus: state.geoipStatus,
+    countryCodes: state.countryCodes,
 
-    // Mutations
-    mutation,
-    certCreating,
+    // Submit + progress
+    mutation: submit.mutation,
+    saveProgress: submit.saveProgress,
+    closeSaveProgress: submit.closeSaveProgress,
+    handleSubmit: submit.handleSubmit,
 
-    // Save progress
-    saveProgress,
-    closeSaveProgress,
-
-    // Certificate log modal
-    pendingCertId,
-    closeCertLogModal,
-
-    // Handlers
-    handleSubmit,
+    // Domain helpers
     addDomain,
     removeDomain,
     updateDomain,

--- a/ui/src/components/proxy-host/hooks/useProxyHostFormState.ts
+++ b/ui/src/components/proxy-host/hooks/useProxyHostFormState.ts
@@ -1,0 +1,294 @@
+import { useEffect, useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { listCertificates } from '../../../api/certificates'
+import { listDNSProviders } from '../../../api/dns-providers'
+import { getAccessLists, getCountryCodes, getGeoRestriction } from '../../../api/access'
+import { getBotFilter } from '../../../api/security'
+import { getGeoIPStatus } from '../../../api/settings'
+import { api } from '../../../api/client'
+import type { ProxyHost, CreateProxyHostRequest } from '../../../types/proxy-host'
+import type { CreateCertificateRequest } from '../../../types/certificate'
+import type { BotFilterState, FormErrors, GeoDataState } from '../types'
+
+/** Public return type is inferred from {@link useProxyHostFormState}. */
+export type ProxyHostFormStateResult = ReturnType<typeof useProxyHostFormState>
+
+/**
+ * Owns all form-field state and the external data the form reads from the
+ * API. Split out from useProxyHostForm so the composition hook stays thin.
+ *
+ * NOTE: The submit orchestrator lives in a separate hook and receives this
+ * whole object so it can call the same setters.
+ */
+export function useProxyHostFormState(host: ProxyHost | null | undefined) {
+  const isEditing = !!host
+
+  // Form data state
+  const [formData, setFormData] = useState<CreateProxyHostRequest>({
+    domain_names: [''],
+    forward_scheme: 'http',
+    forward_host: '',
+    forward_port: 80,
+    ssl_enabled: false,
+    ssl_force_https: false,
+    ssl_http2: true,
+    ssl_http3: false,
+    certificate_id: undefined,
+    access_list_id: undefined,
+    allow_websocket_upgrade: true,
+    cache_enabled: false,
+    cache_static_only: true,
+    cache_ttl: '7d',
+    block_exploits: true,
+    // Host-level proxy settings (empty = use global)
+    client_max_body_size: '',
+    proxy_max_temp_file_size: '',
+    proxy_buffering: '',
+    proxy_request_buffering: '',
+    waf_enabled: false,
+    waf_mode: 'blocking',
+    waf_paranoia_level: 1,
+    waf_anomaly_threshold: 5,
+    advanced_config: '',
+    enabled: true,
+  })
+
+  // Port input state - initialize from host if editing
+  const [portInput, setPortInput] = useState(() =>
+    host?.forward_port?.toString() || '80',
+  )
+
+  // Errors state
+  const [errors, setErrors] = useState<FormErrors>({})
+
+  // Certificate state
+  const [certMode, setCertMode] = useState<'select' | 'create'>('select')
+  const [newCertData, setNewCertData] = useState<CreateCertificateRequest>({
+    domain_names: [],
+    provider: 'letsencrypt',
+    auto_renew: true,
+  })
+
+  // Bot filter state
+  const [botFilterData, setBotFilterData] = useState<BotFilterState>({
+    enabled: false,
+    block_bad_bots: true,
+    block_ai_bots: false,
+    allow_search_engines: true,
+    block_suspicious_clients: false,
+    custom_blocked_agents: '',
+    custom_allowed_agents: '',
+    challenge_suspicious: false,
+  })
+
+  // GeoIP state
+  const [geoData, setGeoData] = useState<GeoDataState>({
+    enabled: false,
+    mode: 'blacklist',
+    countries: [],
+    allowed_ips: [],
+    allow_private_ips: true,
+    allow_search_bots: false,
+    challenge_mode: false,
+  })
+  const [geoSearchTerm, setGeoSearchTerm] = useState('')
+  const [allowedIPsInput, setAllowedIPsInput] = useState('')
+
+  // Cloud provider blocking state
+  const [blockedCloudProviders, setBlockedCloudProviders] = useState<string[]>([])
+  const [cloudProviderChallengeMode, setCloudProviderChallengeMode] = useState(false)
+  const [cloudProviderAllowSearchBots, setCloudProviderAllowSearchBots] = useState(false)
+
+  // ───── Queries ────────────────────────────────────────────────────────
+  const { data: certificatesData } = useQuery({
+    queryKey: ['certificates'],
+    queryFn: () => listCertificates(),
+  })
+
+  const { data: accessListsData } = useQuery({
+    queryKey: ['accessLists'],
+    queryFn: () => getAccessLists(1, 100),
+  })
+
+  const { data: dnsProvidersData } = useQuery({
+    queryKey: ['dnsProviders'],
+    queryFn: () => listDNSProviders(1, 100),
+  })
+
+  const { data: existingBotFilter } = useQuery({
+    queryKey: ['botFilter', host?.id],
+    queryFn: () => getBotFilter(host!.id),
+    enabled: !!host?.id,
+  })
+
+  const { data: geoipStatus } = useQuery({
+    queryKey: ['geoipStatus'],
+    queryFn: getGeoIPStatus,
+  })
+
+  const isGeoIPAvailable =
+    geoipStatus?.status === 'active' || (geoipStatus?.enabled && geoipStatus?.country_db)
+
+  const { data: countryCodes } = useQuery({
+    queryKey: ['countryCodes'],
+    queryFn: getCountryCodes,
+    enabled: !!isGeoIPAvailable,
+  })
+
+  const { data: existingGeoRestriction } = useQuery({
+    queryKey: ['geoRestriction', host?.id],
+    queryFn: () => getGeoRestriction(host!.id).catch(() => null),
+    enabled: !!host?.id && !!isGeoIPAvailable,
+  })
+
+  const { data: existingCloudProviderSettings } = useQuery({
+    queryKey: ['blockedCloudProviders', host?.id],
+    queryFn: async () => {
+      const response = await api.get<{
+        blocked_providers: string[]
+        challenge_mode: boolean
+        allow_search_bots: boolean
+      }>(`/api/v1/proxy-hosts/${host!.id}/blocked-cloud-providers`)
+      return {
+        blocked_providers: response.blocked_providers || [],
+        challenge_mode: response.challenge_mode || false,
+        allow_search_bots: response.allow_search_bots || false,
+      }
+    },
+    enabled: !!host?.id,
+  })
+
+  // ───── Derived data ──────────────────────────────────────────────────
+  const availableCerts = certificatesData?.data?.filter((c) => c.status === 'issued') || []
+  const pendingCerts = certificatesData?.data?.filter((c) => c.status === 'pending') || []
+  const availableAccessLists = accessListsData?.data || []
+  const dnsProviders = dnsProvidersData?.data || []
+
+  // ───── Effects: hydrate form state from server data ──────────────────
+  useEffect(() => {
+    if (existingBotFilter) {
+      setBotFilterData({
+        enabled: existingBotFilter.enabled,
+        block_bad_bots: existingBotFilter.block_bad_bots,
+        block_ai_bots: existingBotFilter.block_ai_bots,
+        allow_search_engines: existingBotFilter.allow_search_engines,
+        block_suspicious_clients: existingBotFilter.block_suspicious_clients,
+        custom_blocked_agents: existingBotFilter.custom_blocked_agents || '',
+        custom_allowed_agents: existingBotFilter.custom_allowed_agents || '',
+        challenge_suspicious: existingBotFilter.challenge_suspicious,
+      })
+    }
+  }, [existingBotFilter])
+
+  useEffect(() => {
+    if (existingGeoRestriction) {
+      setGeoData({
+        enabled: existingGeoRestriction.enabled && existingGeoRestriction.countries?.length > 0,
+        mode: existingGeoRestriction.mode,
+        countries: existingGeoRestriction.countries || [],
+        allowed_ips: existingGeoRestriction.allowed_ips || [],
+        allow_private_ips: existingGeoRestriction.allow_private_ips ?? true,
+        allow_search_bots: existingGeoRestriction.allow_search_bots ?? false,
+        challenge_mode: existingGeoRestriction.challenge_mode || false,
+      })
+      setAllowedIPsInput((existingGeoRestriction.allowed_ips || []).join('\n'))
+    }
+  }, [existingGeoRestriction])
+
+  useEffect(() => {
+    if (existingCloudProviderSettings) {
+      setBlockedCloudProviders(existingCloudProviderSettings.blocked_providers)
+      setCloudProviderChallengeMode(existingCloudProviderSettings.challenge_mode)
+      setCloudProviderAllowSearchBots(existingCloudProviderSettings.allow_search_bots || false)
+    }
+  }, [existingCloudProviderSettings])
+
+  useEffect(() => {
+    const domains = formData.domain_names.filter((d) => d.trim())
+    if (domains.length > 0 && certMode === 'create') {
+      setNewCertData((prev) => ({ ...prev, domain_names: domains }))
+    }
+  }, [formData.domain_names, certMode])
+
+  useEffect(() => {
+    if (host) {
+      setFormData({
+        domain_names: host.domain_names,
+        forward_scheme: host.forward_scheme,
+        forward_host: host.forward_host,
+        forward_port: host.forward_port,
+        ssl_enabled: host.ssl_enabled,
+        ssl_force_https: host.ssl_force_https,
+        ssl_http2: host.ssl_http2,
+        ssl_http3: host.ssl_http3,
+        certificate_id: host.certificate_id,
+        access_list_id: host.access_list_id,
+        allow_websocket_upgrade: host.allow_websocket_upgrade,
+        cache_enabled: host.cache_enabled,
+        cache_static_only: host.cache_static_only ?? true,
+        cache_ttl: host.cache_ttl || '7d',
+        block_exploits: host.block_exploits,
+        // Host-level proxy settings
+        client_max_body_size: host.client_max_body_size || '',
+        proxy_max_temp_file_size: host.proxy_max_temp_file_size || '',
+        proxy_buffering: host.proxy_buffering || '',
+        proxy_request_buffering: host.proxy_request_buffering || '',
+        waf_enabled: host.waf_enabled,
+        waf_mode: (host.waf_mode as 'blocking' | 'detection') || 'blocking',
+        waf_paranoia_level: host.waf_paranoia_level || 1,
+        waf_anomaly_threshold: host.waf_anomaly_threshold || 5,
+        advanced_config: host.advanced_config || '',
+        enabled: host.enabled,
+      })
+      setPortInput(host.forward_port.toString())
+    }
+  }, [host])
+
+  return {
+    // Form data
+    formData,
+    setFormData,
+    portInput,
+    setPortInput,
+    errors,
+    setErrors,
+
+    // Certificate form
+    certMode,
+    setCertMode,
+    newCertData,
+    setNewCertData,
+
+    // Bot filter
+    botFilterData,
+    setBotFilterData,
+
+    // GeoIP
+    geoData,
+    setGeoData,
+    geoSearchTerm,
+    setGeoSearchTerm,
+    allowedIPsInput,
+    setAllowedIPsInput,
+
+    // Cloud provider blocking
+    blockedCloudProviders,
+    setBlockedCloudProviders,
+    cloudProviderChallengeMode,
+    setCloudProviderChallengeMode,
+    cloudProviderAllowSearchBots,
+    setCloudProviderAllowSearchBots,
+
+    // External data
+    availableCerts,
+    pendingCerts,
+    availableAccessLists,
+    dnsProviders,
+    geoipStatus,
+    countryCodes,
+    existingGeoRestriction,
+
+    // Flags
+    isEditing,
+  }
+}

--- a/ui/src/components/proxy-host/hooks/useProxyHostSubmit.ts
+++ b/ui/src/components/proxy-host/hooks/useProxyHostSubmit.ts
@@ -1,0 +1,253 @@
+import { useState } from 'react'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { useTranslation } from 'react-i18next'
+import {
+  createProxyHost,
+  regenerateHostConfig,
+  updateProxyHost,
+} from '../../../api/proxy-hosts'
+import { ApiError } from '../../../api/client'
+import type { CreateProxyHostRequest, ProxyHost } from '../../../types/proxy-host'
+import { isFormValid, normalizeDomains, validateProxyHostForm } from './proxyHostValidation'
+import type { ProxyHostCertificate } from './useProxyHostCertificate'
+import type { ProxyHostExtras } from './useProxyHostExtras'
+import type { ProxyHostFormStateResult } from './useProxyHostFormState'
+
+/** Save progress modal state. */
+export interface SaveProgressState {
+  isOpen: boolean
+  currentStep: number
+  error: string | null
+  errorDetails: string | null
+}
+
+interface UseProxyHostSubmitArgs {
+  host: ProxyHost | null | undefined
+  state: ProxyHostFormStateResult
+  cert: ProxyHostCertificate
+  extras: ProxyHostExtras
+  onClose: () => void
+}
+
+/** Fresh save-progress state — closed modal, no error. */
+const INITIAL_PROGRESS: SaveProgressState = {
+  isOpen: false,
+  currentStep: 0,
+  error: null,
+  errorDetails: null,
+}
+
+/**
+ * Orchestrates the submit flow for the proxy host form. Responsible
+ * for the multi-step pipeline:
+ *
+ *  1. Validation (fail → early return)
+ *  2. Cert create + poll (when SSL on and certMode === 'create')
+ *  3. POST / PUT the proxy host itself
+ *  4. Fan-out additional settings saves (bot/geo/cloud w/ skip_reload=true)
+ *  5. Single nginx config regenerate
+ *  6. Close modal + invalidate queries
+ */
+export function useProxyHostSubmit({
+  host,
+  state,
+  cert,
+  extras,
+  onClose,
+}: UseProxyHostSubmitArgs) {
+  const queryClient = useQueryClient()
+  const { t } = useTranslation('proxyHost')
+  const isEditing = !!host
+
+  const [saveProgress, setSaveProgress] = useState<SaveProgressState>(INITIAL_PROGRESS)
+
+  /** Helper to close the progress modal after a short delay. */
+  function closeProgressWithDelay(delay = 800) {
+    setTimeout(() => {
+      setSaveProgress(INITIAL_PROGRESS)
+      onClose()
+    }, delay)
+  }
+
+  /**
+   * Translate a thrown error into the `error` + `errorDetails` shape
+   * used by the SaveProgressModal.
+   */
+  function errorToProgress(err: unknown, fallback: string) {
+    const isApiError = err instanceof ApiError
+    return {
+      error: err instanceof Error ? err.message : fallback,
+      errorDetails: isApiError ? err.details || null : null,
+    }
+  }
+
+  // ───── Create mutation ──────────────────────────────────────────────
+  const createMutation = useMutation({
+    mutationFn: createProxyHost,
+    onMutate: () => {
+      // Step 0: Server processing (DB + config + test + reload)
+      setSaveProgress((prev) => ({ ...prev, currentStep: 0 }))
+    },
+    onSuccess: async (newHost) => {
+      // Step 1: Additional settings
+      setSaveProgress((prev) => ({ ...prev, currentStep: 1 }))
+
+      const savedAny = await extras.saveExtrasForCreate({
+        hostId: newHost.id,
+        botFilterData: state.botFilterData,
+        geoData: state.geoData,
+        blockedCloudProviders: state.blockedCloudProviders,
+        cloudProviderChallengeMode: state.cloudProviderChallengeMode,
+        cloudProviderAllowSearchBots: state.cloudProviderAllowSearchBots,
+      })
+
+      if (savedAny) {
+        // Regenerate config for this specific host to apply additional settings
+        try {
+          await regenerateHostConfig(newHost.id)
+        } catch (err) {
+          setSaveProgress((prev) => ({
+            ...prev,
+            ...errorToProgress(err, 'Failed to apply nginx config'),
+          }))
+          return
+        }
+      }
+
+      // Step 2: Complete
+      setSaveProgress((prev) => ({ ...prev, currentStep: 2 }))
+      queryClient.invalidateQueries({ queryKey: ['proxy-hosts'] })
+      closeProgressWithDelay()
+    },
+    onError: (error) => {
+      setSaveProgress((prev) => ({
+        ...prev,
+        ...errorToProgress(error, 'Failed to create proxy host'),
+      }))
+    },
+  })
+
+  // ───── Update mutation ──────────────────────────────────────────────
+  const updateMutation = useMutation({
+    mutationFn: ({ id, data }: { id: string; data: CreateProxyHostRequest }) =>
+      updateProxyHost(id, data, true),
+    onMutate: () => {
+      // Step 0: Server processing (DB save, nginx deferred to regenerate)
+      setSaveProgress((prev) => ({ ...prev, currentStep: 0 }))
+    },
+    onSuccess: async (_, variables) => {
+      // Step 1: Additional settings
+      setSaveProgress((prev) => ({ ...prev, currentStep: 1 }))
+
+      await extras.saveExtrasForUpdate({
+        hostId: variables.id,
+        botFilterData: state.botFilterData,
+        geoData: state.geoData,
+        blockedCloudProviders: state.blockedCloudProviders,
+        cloudProviderChallengeMode: state.cloudProviderChallengeMode,
+        cloudProviderAllowSearchBots: state.cloudProviderAllowSearchBots,
+        existingGeoRestriction: state.existingGeoRestriction,
+      })
+
+      // Single nginx config generation + test + reload (all settings applied at once)
+      try {
+        await regenerateHostConfig(variables.id)
+      } catch (err) {
+        setSaveProgress((prev) => ({
+          ...prev,
+          ...errorToProgress(err, 'Failed to apply nginx config'),
+        }))
+        return
+      }
+
+      // Step 2: Complete
+      setSaveProgress((prev) => ({ ...prev, currentStep: 2 }))
+      queryClient.invalidateQueries({ queryKey: ['proxy-hosts'] })
+      closeProgressWithDelay()
+    },
+    onError: (error) => {
+      setSaveProgress((prev) => ({
+        ...prev,
+        ...errorToProgress(error, 'Failed to update proxy host'),
+      }))
+    },
+  })
+
+  const mutation = isEditing ? updateMutation : createMutation
+
+  // ───── Submit handler ──────────────────────────────────────────────
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+
+    // Step 0: Validation — open modal first, close on early return
+    setSaveProgress({ isOpen: true, currentStep: 0, error: null, errorDetails: null })
+
+    const newErrors = validateProxyHostForm({
+      formData: state.formData,
+      portInput: state.portInput,
+      certMode: state.certMode,
+      t,
+    })
+    state.setErrors(newErrors)
+    if (!isFormValid(newErrors)) {
+      setSaveProgress(INITIAL_PROGRESS)
+      return
+    }
+
+    const domains = normalizeDomains(state.formData.domain_names)
+    let certificateId = state.formData.certificate_id
+
+    // Step 1: Create certificate if SSL + create mode
+    if (state.formData.ssl_enabled && state.certMode === 'create') {
+      if (domains.length === 0) {
+        state.setErrors({ domain_names: t('validation.addDomainsBeforeCert') })
+        setSaveProgress(INITIAL_PROGRESS)
+        return
+      }
+
+      // Close save progress modal while cert is being created (cert has its own UI).
+      setSaveProgress(INITIAL_PROGRESS)
+
+      const result = await cert.ensureCertificate(domains, state.newCertData)
+      if (!result.ok) {
+        // ensureCertificate already handled UI state; don't reset cert modal here.
+        return
+      }
+      certificateId = result.certificateId
+
+      // Re-open save progress modal after cert is created
+      setSaveProgress({ isOpen: true, currentStep: 0, error: null, errorDetails: null })
+    }
+
+    // Step 2+: Fire the host mutation
+    const data = {
+      ...state.formData,
+      domain_names: domains,
+      forward_port: parseInt(state.portInput) || 80,
+      certificate_id: certificateId,
+    }
+
+    if (isEditing && host) {
+      updateMutation.mutate({ id: host.id, data })
+    } else {
+      createMutation.mutate(data)
+    }
+
+    cert.setCertCreating(false)
+  }
+
+  /** Close the save-progress modal (e.g. when the user dismisses an error). */
+  function closeSaveProgress() {
+    setSaveProgress(INITIAL_PROGRESS)
+  }
+
+  return {
+    saveProgress,
+    closeSaveProgress,
+    handleSubmit,
+    mutation,
+  }
+}
+
+/** Public return type, inferred. */
+export type ProxyHostSubmit = ReturnType<typeof useProxyHostSubmit>


### PR DESCRIPTION
## Scope
Phase 6 (FINAL) of codebase-cleanup — split 677-line useProxyHostForm hook into 5 focused modules.
Spec: docs/superpowers/specs/2026-04-17-codebase-cleanup-design.md §9

## Changes
- \`proxyHostValidation.ts\` — pure validation (no React hook) — 68 lines
- \`useProxyHostFormState.ts\` — field + tab state + queries + hydration effects — 294 lines
- \`useProxyHostCertificate.ts\` — cert select/create + 2s polling (120s timeout) — 191 lines
- \`useProxyHostExtras.ts\` — bot/geo/cloud saves with skip_reload=true — 189 lines
- \`useProxyHostSubmit.ts\` — 6-step submit orchestrator — 253 lines
- \`useProxyHostForm.ts\` — thin container (106 lines, down from 677)
- External API unchanged — \`ProxyHostForm.tsx\` consumer untouched

## Verification
- [x] \`npm run build\` / docker UI build succeeds (typecheck clean)
- [x] Backend Phase 2 characterization tests still green (nginx + service packages \`ok\`)
- [x] E2E proxy-host specs: 50/50 passed
- [x] E2E security specs: 182/182 passed
- [x] E2E certificates specs: 41/41 passed

## Out of scope
- No backend changes
- No UI/tab/i18n/route changes beyond hook internals