### PR TITLE
test(nginx): add reload failure scenario tests

### DIFF
--- a/api/internal/nginx/manager.go
+++ b/api/internal/nginx/manager.go
@@ -6,14 +6,12 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
 	"sync"
 	"text/template"
 
-	"nginx-proxy-guard/internal/config"
 	"nginx-proxy-guard/internal/model"
 )
 
@@ -33,6 +31,8 @@ type Manager struct {
 	apiURL         string // API URL for nginx to reach API (default: http://127.0.0.1:9080)
 	dnsResolver    string // DNS resolver for nginx (default: 127.0.0.53 8.8.8.8)
 	enableIPv6     bool   // Enable IPv6 listen directives (default: true)
+
+	cli nginxCLI // extracted for testability (Phase 0)
 }
 
 func NewManager(configPath, certsPath string) *Manager {
@@ -72,7 +72,7 @@ func NewManager(configPath, certsPath string) *Manager {
 		dnsResolver = "127.0.0.53 8.8.8.8"
 	}
 
-	return &Manager{
+	m := &Manager{
 		configPath:     configPath,
 		certsPath:      certsPath,
 		modsecPath:     modsecPath,
@@ -84,6 +84,8 @@ func NewManager(configPath, certsPath string) *Manager {
 		dnsResolver:    dnsResolver,
 		enableIPv6:     true,
 	}
+	m.cli = newDockerNginxCLI(nginxContainer)
+	return m
 }
 
 // GetHTTPPort returns the HTTP listen port
@@ -362,23 +364,7 @@ func (m *Manager) testConfigInternal(ctx context.Context) error {
 	if m.skipTest {
 		return nil
 	}
-
-	testCtx, cancel := context.WithTimeout(ctx, config.NginxTestTimeout)
-	defer cancel()
-
-	cmd := exec.CommandContext(testCtx, "docker", "exec", m.nginxContainer, "nginx", "-t")
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		if testCtx.Err() == context.DeadlineExceeded {
-			return fmt.Errorf("nginx config test timed out after %s", config.NginxTestTimeout)
-		}
-		outputStr := strings.TrimSpace(string(output))
-		if outputStr != "" {
-			return fmt.Errorf("nginx config test failed: %s", outputStr)
-		}
-		return fmt.Errorf("nginx config test failed: %v", err)
-	}
-	return nil
+	return m.cli.Test(ctx)
 }
 
 // reloadNginxInternal is the internal reload function without locking
@@ -386,19 +372,7 @@ func (m *Manager) reloadNginxInternal(ctx context.Context) error {
 	if m.skipTest {
 		return nil
 	}
-
-	reloadCtx, cancel := context.WithTimeout(ctx, config.NginxReloadTimeout)
-	defer cancel()
-
-	cmd := exec.CommandContext(reloadCtx, "docker", "exec", m.nginxContainer, "nginx", "-s", "reload")
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		if reloadCtx.Err() == context.DeadlineExceeded {
-			return fmt.Errorf("nginx reload timed out after %s", config.NginxReloadTimeout)
-		}
-		return fmt.Errorf("nginx reload failed: %s", string(output))
-	}
-	return nil
+	return m.cli.Reload(ctx)
 }
 
 func (m *Manager) GenerateConfig(ctx context.Context, host *model.ProxyHost) error {

--- a/api/internal/nginx/nginx_cli.go
+++ b/api/internal/nginx/nginx_cli.go
@@ -1,0 +1,46 @@
+package nginx
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// nginxCLI abstracts the two docker exec calls the manager needs so
+// tests can substitute a fake implementation without touching docker.
+type nginxCLI interface {
+	Test(ctx context.Context) error
+	Reload(ctx context.Context) error
+}
+
+// dockerNginxCLI runs nginx commands via docker exec against the configured container.
+type dockerNginxCLI struct {
+	containerName string
+}
+
+func newDockerNginxCLI(containerName string) *dockerNginxCLI {
+	return &dockerNginxCLI{containerName: containerName}
+}
+
+// Test runs `nginx -t` inside the container. Returns a non-nil error when the
+// configuration is invalid or the exec itself fails.
+func (d *dockerNginxCLI) Test(ctx context.Context) error {
+	cmd := exec.CommandContext(ctx, "docker", "exec", d.containerName, "nginx", "-t")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("nginx -t failed: %w: %s", err, strings.TrimSpace(string(output)))
+	}
+	return nil
+}
+
+// Reload runs `nginx -s reload` inside the container. A nil error means the
+// reload signal was delivered (post-signal worker health is verified separately).
+func (d *dockerNginxCLI) Reload(ctx context.Context) error {
+	cmd := exec.CommandContext(ctx, "docker", "exec", d.containerName, "nginx", "-s", "reload")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("nginx -s reload failed: %w: %s", err, strings.TrimSpace(string(output)))
+	}
+	return nil
+}

--- a/api/internal/nginx/nginx_cli.go
+++ b/api/internal/nginx/nginx_cli.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"os/exec"
 	"strings"
+
+	"nginx-proxy-guard/internal/config"
 )
 
 // nginxCLI abstracts the two docker exec calls the manager needs so
@@ -15,6 +17,9 @@ type nginxCLI interface {
 }
 
 // dockerNginxCLI runs nginx commands via docker exec against the configured container.
+// Each method applies its own timeout (NginxTestTimeout / NginxReloadTimeout) so a
+// hung docker exec cannot block callers beyond the configured budget even when
+// the caller-supplied context has no deadline.
 type dockerNginxCLI struct {
 	containerName string
 }
@@ -26,6 +31,8 @@ func newDockerNginxCLI(containerName string) *dockerNginxCLI {
 // Test runs `nginx -t` inside the container. Returns a non-nil error when the
 // configuration is invalid or the exec itself fails.
 func (d *dockerNginxCLI) Test(ctx context.Context) error {
+	ctx, cancel := context.WithTimeout(ctx, config.NginxTestTimeout)
+	defer cancel()
 	cmd := exec.CommandContext(ctx, "docker", "exec", d.containerName, "nginx", "-t")
 	output, err := cmd.CombinedOutput()
 	if err != nil {
@@ -37,6 +44,8 @@ func (d *dockerNginxCLI) Test(ctx context.Context) error {
 // Reload runs `nginx -s reload` inside the container. A nil error means the
 // reload signal was delivered (post-signal worker health is verified separately).
 func (d *dockerNginxCLI) Reload(ctx context.Context) error {
+	ctx, cancel := context.WithTimeout(ctx, config.NginxReloadTimeout)
+	defer cancel()
 	cmd := exec.CommandContext(ctx, "docker", "exec", d.containerName, "nginx", "-s", "reload")
 	output, err := cmd.CombinedOutput()
 	if err != nil {

--- a/api/internal/nginx/reload_characterization_test.go
+++ b/api/internal/nginx/reload_characterization_test.go
@@ -1,0 +1,95 @@
+package nginx
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// fakeNginxCLI records calls and returns scripted errors per call.
+type fakeNginxCLI struct {
+	testErrs   []error
+	reloadErrs []error
+	testCalls   int
+	reloadCalls int
+}
+
+func (f *fakeNginxCLI) Test(ctx context.Context) error {
+	idx := f.testCalls
+	f.testCalls++
+	if idx < len(f.testErrs) {
+		return f.testErrs[idx]
+	}
+	return nil
+}
+
+func (f *fakeNginxCLI) Reload(ctx context.Context) error {
+	idx := f.reloadCalls
+	f.reloadCalls++
+	if idx < len(f.reloadErrs) {
+		return f.reloadErrs[idx]
+	}
+	return nil
+}
+
+func newFakeManager(cli nginxCLI) *Manager {
+	return &Manager{cli: cli}
+}
+
+func TestTestAndReloadNginx_Success(t *testing.T) {
+	cli := &fakeNginxCLI{}
+	m := newFakeManager(cli)
+	if err := m.testAndReloadNginx(context.Background()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cli.testCalls != 1 {
+		t.Errorf("test calls = %d, want 1", cli.testCalls)
+	}
+	if cli.reloadCalls != 1 {
+		t.Errorf("reload calls = %d, want 1", cli.reloadCalls)
+	}
+}
+
+func TestTestAndReloadNginx_TestFails_SyntaxError(t *testing.T) {
+	syntaxErr := errors.New("nginx: [emerg] invalid number of arguments in \"server_name\" directive")
+	cli := &fakeNginxCLI{testErrs: []error{syntaxErr}}
+	m := newFakeManager(cli)
+	err := m.testAndReloadNginx(context.Background())
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if cli.reloadCalls != 0 {
+		t.Errorf("reload should not be called on test failure, got %d calls", cli.reloadCalls)
+	}
+}
+
+func TestTestAndReloadNginx_ReloadFails(t *testing.T) {
+	reloadErr := errors.New("reload failed: permission denied")
+	cli := &fakeNginxCLI{reloadErrs: []error{reloadErr}}
+	m := newFakeManager(cli)
+	err := m.testAndReloadNginx(context.Background())
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if cli.testCalls != 1 {
+		t.Errorf("test calls = %d, want 1", cli.testCalls)
+	}
+	if cli.reloadCalls != 1 {
+		t.Errorf("reload calls = %d, want 1", cli.reloadCalls)
+	}
+}
+
+func TestTestAndReloadNginx_TransientDockerError_CurrentBehavior(t *testing.T) {
+	// Pre-retry behavior: transient docker errors are NOT retried and propagate as-is.
+	// Phase 1 will change this test (rename + retry expectation).
+	transient := errors.New("docker: connection refused")
+	cli := &fakeNginxCLI{testErrs: []error{transient}}
+	m := newFakeManager(cli)
+	err := m.testAndReloadNginx(context.Background())
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if cli.testCalls != 1 {
+		t.Errorf("test calls = %d, want 1 (no retry in v2.10)", cli.testCalls)
+	}
+}


### PR DESCRIPTION
## Scope
Phase 0 of proxy-stability — extract docker exec behind a narrow `nginxCLI` interface and add 4 characterization tests covering the current single-host reload path.
Spec: docs/superpowers/specs/2026-04-17-proxy-stability-design.md §3

## Changes
- New `nginx_cli.go` with `nginxCLI` interface + `dockerNginxCLI` implementation
- `Manager` gains a `cli nginxCLI` field, used by `testConfigInternal` / `reloadNginxInternal`
- New `reload_characterization_test.go` with 4 cases: success, syntax-failure short-circuits reload, reload-failure, transient-docker-error-no-retry (current behavior baseline)

## Verification
- [x] `go test ./internal/nginx/... ./internal/service/...` green
- [x] Existing 33 characterization cases unchanged
- [x] `docker compose build api` succeeds

## Out of scope
- Retry logic (Phase 1)
- Post-reload health probe (Phase 2)
- Metrics (Phase 3)