### PR TITLE
feat(nginx): verify health after reload with auto-revert

### DIFF
--- a/api/internal/bootstrap/container.go
+++ b/api/internal/bootstrap/container.go
@@ -2,6 +2,7 @@ package bootstrap
 
 import (
 	"context"
+	"os"
 
 	"nginx-proxy-guard/internal/config"
 	"nginx-proxy-guard/internal/database"
@@ -37,6 +38,14 @@ func NewContainer(cfg *config.Config) (*Container, error) {
 	redisCache := InitCache(cfg)
 
 	nginxManager := nginx.NewManager(cfg.NginxConfigPath, cfg.NginxCertsPath)
+
+	// Post-reload health probe (opt-out via NPG_HEALTH_PROBE=false)
+	probeDisabled := os.Getenv("NPG_HEALTH_PROBE") == "false"
+	nginxContainer := os.Getenv("NGINX_CONTAINER")
+	if nginxContainer == "" {
+		nginxContainer = "npg-proxy"
+	}
+	nginxManager.SetHealthProber(nginx.NewHealthProber(nginxContainer, probeDisabled))
 
 	repos := InitRepositories(db, redisCache)
 	svcs := InitServices(cfg, db, redisCache, nginxManager, repos)

--- a/api/internal/config/constants.go
+++ b/api/internal/config/constants.go
@@ -106,6 +106,13 @@ const (
 	ReloadRetryBaseDelay = 500 * time.Millisecond // 500ms, 1s, 2s doubling
 )
 
+// Post-reload health verification — runs after a successful nginx reload.
+// Failure triggers the Phase 1 rollback mechanism.
+const (
+	WorkerReadyTimeout = 2 * time.Second
+	HealthProbeTimeout = 500 * time.Millisecond
+)
+
 // GeoIP constants
 const (
 	MinGeoIPDatabaseSize = 1000000 // 1MB minimum for valid GeoIP database

--- a/api/internal/nginx/health_probe.go
+++ b/api/internal/nginx/health_probe.go
@@ -1,0 +1,109 @@
+// api/internal/nginx/health_probe.go
+package nginx
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+
+	"nginx-proxy-guard/internal/config"
+)
+
+// healthExecutor wraps the docker exec call so tests can substitute a fake
+// without spawning real docker processes.
+type healthExecutor interface {
+	Exec(ctx context.Context, args ...string) (string, error)
+}
+
+type dockerHealthExecutor struct {
+	containerName string
+}
+
+func (e *dockerHealthExecutor) Exec(ctx context.Context, args ...string) (string, error) {
+	full := append([]string{"exec", e.containerName}, args...)
+	cmd := exec.CommandContext(ctx, "docker", full...)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+// HealthProber verifies nginx is serving traffic after a reload by checking
+// (1) worker processes exist and (2) the /health endpoint responds 200.
+type HealthProber struct {
+	exec     healthExecutor
+	disabled bool
+}
+
+// NewHealthProber returns a prober targeting containerName. If disabled is true,
+// Verify always returns nil (opt-out via env var handled by caller).
+func NewHealthProber(containerName string, disabled bool) *HealthProber {
+	return &HealthProber{
+		exec:     &dockerHealthExecutor{containerName: containerName},
+		disabled: disabled,
+	}
+}
+
+// Verify runs the two-stage probe. Returns nil on success; any failure message
+// is suitable to include in user-facing error reporting.
+func (p *HealthProber) Verify(ctx context.Context) error {
+	if p.disabled {
+		return nil
+	}
+	if err := p.waitForWorkersReady(ctx, config.WorkerReadyTimeout); err != nil {
+		return fmt.Errorf("worker readiness: %w", err)
+	}
+	if err := p.probeHTTP(ctx, config.HealthProbeTimeout); err != nil {
+		return fmt.Errorf("http probe: %w", err)
+	}
+	return nil
+}
+
+// waitForWorkersReady polls `ps` inside the container until at least one
+// `nginx: worker` process is visible, or the timeout elapses.
+func (p *HealthProber) waitForWorkersReady(ctx context.Context, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		workers, err := p.countWorkers(ctx)
+		if err == nil && workers > 0 {
+			return nil
+		}
+		select {
+		case <-time.After(100 * time.Millisecond):
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	return fmt.Errorf("no nginx worker process visible within %v", timeout)
+}
+
+// countWorkers returns the number of lines in `ps ax` containing "nginx: worker".
+func (p *HealthProber) countWorkers(ctx context.Context) (int, error) {
+	out, err := p.exec.Exec(ctx, "sh", "-c", "ps ax | grep -c 'nginx: worker' || true")
+	if err != nil {
+		return 0, err
+	}
+	trimmed := strings.TrimSpace(out)
+	// `grep -c` counts grep-itself; subtract 1. Fallback: treat missing as 0.
+	n, err := strconv.Atoi(trimmed)
+	if err != nil {
+		return 0, fmt.Errorf("parse worker count %q: %w", trimmed, err)
+	}
+	if n > 0 {
+		n-- // subtract the grep process match
+	}
+	return n, nil
+}
+
+// probeHTTP runs `curl -sf --max-time X http://127.0.0.1:<httpPort>/health` inside the container.
+// Returns nil on 2xx; any non-2xx or network issue is an error.
+func (p *HealthProber) probeHTTP(ctx context.Context, timeout time.Duration) error {
+	seconds := timeout.Seconds()
+	cmd := fmt.Sprintf("curl -sf --max-time %.2f http://127.0.0.1:80/health", seconds)
+	_, err := p.exec.Exec(ctx, "sh", "-c", cmd)
+	if err != nil {
+		return fmt.Errorf("/health did not return 2xx: %w", err)
+	}
+	return nil
+}

--- a/api/internal/nginx/health_probe_test.go
+++ b/api/internal/nginx/health_probe_test.go
@@ -1,0 +1,86 @@
+// api/internal/nginx/health_probe_test.go
+package nginx
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+type fakeHealthExec struct {
+	outputs []string // per-call stdout
+	errs    []error  // per-call error
+	calls   int
+}
+
+func (f *fakeHealthExec) Exec(ctx context.Context, args ...string) (string, error) {
+	i := f.calls
+	f.calls++
+	var out string
+	var err error
+	if i < len(f.outputs) {
+		out = f.outputs[i]
+	}
+	if i < len(f.errs) {
+		err = f.errs[i]
+	}
+	return out, err
+}
+
+func newTestProber(f *fakeHealthExec) *HealthProber {
+	return &HealthProber{exec: f}
+}
+
+func TestHealthProber_Disabled_AlwaysSucceeds(t *testing.T) {
+	p := &HealthProber{exec: &fakeHealthExec{}, disabled: true}
+	if err := p.Verify(context.Background()); err != nil {
+		t.Fatalf("expected nil when disabled, got %v", err)
+	}
+}
+
+func TestHealthProber_WorkersReady_ThenHTTPOK(t *testing.T) {
+	// First exec (countWorkers): returns "4" (grep -c reports 3 workers + grep itself)
+	// Second exec (probeHTTP): returns "" with no error (curl -sf success)
+	f := &fakeHealthExec{outputs: []string{"4\n", ""}}
+	p := newTestProber(f)
+	if err := p.Verify(context.Background()); err != nil {
+		t.Fatalf("expected success, got %v", err)
+	}
+	if f.calls != 2 {
+		t.Errorf("exec calls = %d, want 2", f.calls)
+	}
+}
+
+func TestHealthProber_WorkersTimeout(t *testing.T) {
+	// countWorkers returns "1" (which becomes 0 after subtracting grep itself)
+	// repeatedly — should time out.
+	f := &fakeHealthExec{}
+	// Preload many "1" responses so polling returns 0 workers every time.
+	for i := 0; i < 50; i++ {
+		f.outputs = append(f.outputs, "1\n")
+	}
+	p := &HealthProber{exec: f}
+
+	// Use a very short timeout to keep the test fast.
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+
+	err := p.waitForWorkersReady(ctx, 250*time.Millisecond)
+	if err == nil {
+		t.Fatal("expected timeout error, got nil")
+	}
+}
+
+func TestHealthProber_HTTPProbeFails(t *testing.T) {
+	// workers OK, curl returns non-zero.
+	f := &fakeHealthExec{
+		outputs: []string{"4\n", "curl: (22) The requested URL returned error: 500\n"},
+		errs:    []error{nil, errors.New("exit status 22")},
+	}
+	p := newTestProber(f)
+	err := p.Verify(context.Background())
+	if err == nil {
+		t.Fatal("expected http probe error, got nil")
+	}
+}

--- a/api/internal/nginx/manager.go
+++ b/api/internal/nginx/manager.go
@@ -33,6 +33,8 @@ type Manager struct {
 	enableIPv6     bool   // Enable IPv6 listen directives (default: true)
 
 	cli nginxCLI // extracted for testability (Phase 0)
+
+	healthProber *HealthProber
 }
 
 func NewManager(configPath, certsPath string) *Manager {
@@ -106,6 +108,12 @@ func (m *Manager) GetEnableIPv6() bool {
 // SetEnableIPv6 sets whether IPv6 listen directives should be included in configs
 func (m *Manager) SetEnableIPv6(enabled bool) {
 	m.enableIPv6 = enabled
+}
+
+// SetHealthProber wires the post-reload health verifier. May be called once
+// after NewManager. Pass nil or a disabled prober to opt out.
+func (m *Manager) SetHealthProber(p *HealthProber) {
+	m.healthProber = p
 }
 
 // writeFileAtomic writes data to a file atomically using temp file + fsync + rename

--- a/api/internal/nginx/reload_characterization_test.go
+++ b/api/internal/nginx/reload_characterization_test.go
@@ -124,6 +124,25 @@ func TestTestAndReloadNginxWithRetry_NonTransientImmediate(t *testing.T) {
 	}
 }
 
+// TestTestAndReloadNginxWithRetry_HealthProbeFail — reload succeeds, health probe
+// rejects: caller must see an error so it can roll back.
+func TestTestAndReloadNginxWithRetry_HealthProbeFail(t *testing.T) {
+	cli := &fakeNginxCLI{} // test + reload both succeed
+	badExec := &fakeHealthExec{ // health exec returns workers-ready but http fails
+		outputs: []string{"4\n", ""},
+		errs:    []error{nil, errors.New("exit status 22")},
+	}
+	m := &Manager{cli: cli, healthProber: &HealthProber{exec: badExec}}
+
+	err := m.testAndReloadNginxWithRetry(context.Background())
+	if err == nil {
+		t.Fatal("expected error from failing health probe")
+	}
+	if cli.reloadCalls != 1 {
+		t.Errorf("reload calls = %d, want 1 (no retry on health fail)", cli.reloadCalls)
+	}
+}
+
 // TestIsTransientReloadError — verify classification of common errors.
 func TestIsTransientReloadError(t *testing.T) {
 	cases := []struct {

--- a/api/internal/nginx/reload_retry.go
+++ b/api/internal/nginx/reload_retry.go
@@ -50,14 +50,26 @@ func (m *Manager) testAndReloadNginxWithRetry(ctx context.Context) error {
 		}
 
 		err := m.testAndReloadNginx(ctx)
-		if err == nil {
-			return nil
+		if err != nil {
+			lastErr = err
+			if !isTransientReloadError(err) {
+				return err
+			}
+			continue
 		}
-		lastErr = err
 
-		if !isTransientReloadError(err) {
-			return err // non-transient: caller rolls back immediately
+		// Reload reported success. Verify workers + HTTP probe before
+		// considering the attempt complete.
+		if m.healthProber != nil {
+			if verifyErr := m.healthProber.Verify(ctx); verifyErr != nil {
+				log.Printf("[NginxReload] Post-reload health probe failed: %v", verifyErr)
+				lastErr = fmt.Errorf("post-reload health probe failed: %w", verifyErr)
+				// Health failures are effectively non-transient — config must be rolled back.
+				// Return immediately so the caller restores the previous-good config.
+				return lastErr
+			}
 		}
+		return nil
 	}
 
 	return fmt.Errorf("nginx reload failed after %d attempts: %w",


### PR DESCRIPTION
## Scope
Phase 2 of proxy-stability — after a successful `nginx -s reload`, verify that workers are ready and `/health` returns 200. Any failure triggers the Phase 1 rollback mechanism so nginx ends up on the last known-good config.
Spec: docs/superpowers/specs/2026-04-17-proxy-stability-design.md §5

## Changes
- New `HealthProber` with 2-stage verification (workers ready + HTTP 200 on /health)
- `Manager.healthProber` field + `SetHealthProber` setter, wired from bootstrap
- `testAndReloadNginxWithRetry` calls `Verify` after a successful reload
- Opt-out via `NPG_HEALTH_PROBE=false`
- 4 new HealthProber unit tests + 1 new reload characterization test

## Verification
- [x] `go test ./internal/nginx/...` green
- [x] `docker compose build api` succeeds
- [x] E2E `specs/proxy-host/` and `specs/security/waf.spec.ts` green

## Out of scope
- Metrics (Phase 3)