### PR TITLE
fix(migration): v2.13.3 hotfix — auto-disable survives upgradeSQL transaction aborts

### DIFF
--- a/api/internal/config/constants.go
+++ b/api/internal/config/constants.go
@@ -3,7 +3,7 @@ package config
 import "time"
 
 // Application version
-const AppVersion = "2.13.2"
+const AppVersion = "2.13.3"
 
 // Health status constants
 const (

--- a/api/internal/database/migration.go
+++ b/api/internal/database/migration.go
@@ -149,46 +149,15 @@ func (db *DB) RunMigrations() error {
 		('8ec83a35-dea8-4f51-9185-37035f0a4501', 'http_method', 'Dangerous Methods', '^(TRACE|TRACK|DEBUG|CONNECT)$', 'request_method', 'Blocks dangerous HTTP methods', 'warning', true, true, 50, NULL)
 		ON CONFLICT (id) DO NOTHING;
 
-		-- One-shot auto-disable for overly-broad system rules (Issue #123, v2.13.2+).
-		-- Fires only when auto_disabled_at IS NULL AND enabled = true — so users who have
-		-- already re-enabled (or who upgraded from a post-fix version) are not touched.
-		-- is_system = true guards against matching a coincidentally same-UUID user rule.
-		DO $$
-		DECLARE
-			affected_count int := 0;
-		BEGIN
-			UPDATE public.exploit_block_rules
-			SET enabled = false,
-				auto_disabled_at = now()
-			WHERE id IN (
-				'a5cb921c-2c10-475b-8753-a56e2af1e5ba',
-				'41d1f7bf-9179-44cb-b41a-1685ce88d965',
-				'aa90285b-2986-46f9-80e6-99946327cd24'
-			)
-			AND is_system = true
-			AND enabled = true
-			AND auto_disabled_at IS NULL;
-
-			GET DIAGNOSTICS affected_count = ROW_COUNT;
-			IF affected_count > 0 THEN
-				INSERT INTO public.system_logs (source, level, message, details, component)
-				VALUES (
-					'internal',
-					'info',
-					format('Auto-disabled %s overly-broad exploit rule(s) to prevent false positives on search/CMS endpoints. Review and optionally re-enable at /waf/exploit-rules.', affected_count),
-					jsonb_build_object(
-						'rule_ids', ARRAY[
-							'a5cb921c-2c10-475b-8753-a56e2af1e5ba',
-							'41d1f7bf-9179-44cb-b41a-1685ce88d965',
-							'aa90285b-2986-46f9-80e6-99946327cd24'
-						],
-						'reason', 'github issue #123: simple keyword matching produces false positives on legitimate search queries',
-						'rollback_hint', 'set enabled=true in the UI; the migration will not touch these rows again once auto_disabled_at is set'
-					),
-					'exploit_rules_migration'
-				);
-			END IF;
-		END $$;
+		-- NOTE: the v2.13.2 one-shot auto-disable for overly-broad system rules
+		-- (Issue #123) intentionally lives OUTSIDE this upgradeSQL block — see the
+		-- ApplyExploitRulesAutoDisable(db) call below. Placing it here was a bug in
+		-- v2.13.2: if any earlier statement in upgradeSQL fails (e.g. a stale
+		-- TimescaleDB chunk causes a pq chunk-not-found error), PostgreSQL aborts the
+		-- implicit transaction and every subsequent statement — including the DO $$
+		-- block — silently skips, leaving the three overly-broad rules enabled on
+		-- exactly the installations that needed the fix. v2.13.3 moves the helper
+		-- to its own db.Exec so it runs regardless of upgradeSQL outcome.
 
 		-- Performance indexes for logs_partitioned (v2.4.0+)
 		CREATE INDEX IF NOT EXISTS idx_logs_part_block_reason_ts ON logs_partitioned (block_reason, timestamp DESC) WHERE block_reason != 'none';
@@ -442,6 +411,18 @@ func (db *DB) RunMigrations() error {
 		if _, err := db.Exec(a.sql); err != nil {
 			log.Printf("Warning: independent upgrade %s failed: %v", a.desc, err)
 		}
+	}
+
+	// v2.13.3: one-shot auto-disable for overly-broad system rules (Issue #123).
+	// Runs as an INDEPENDENT db.Exec so a prior failure in upgradeSQL (e.g. a
+	// stale TimescaleDB chunk error that aborts the implicit transaction) cannot
+	// silently skip the fix. v2.13.2 placed this DO block inside upgradeSQL and
+	// the implicit-transaction abort left the three rules enabled on affected
+	// installations. The helper is idempotent — it only updates rows where
+	// auto_disabled_at IS NULL AND enabled = true, so admins who have already
+	// re-enabled are not touched and repeat boots are no-ops.
+	if err := ApplyExploitRulesAutoDisable(db.DB); err != nil {
+		log.Printf("Warning: exploit rules auto-disable migration failed: %v", err)
 	}
 
 	// Run 006_fix_numeric_overflow migration for existing installations (Issue #29 fix)

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nginx-proxy-guard-ui",
   "private": true,
-  "version": "2.13.2",
+  "version": "2.13.3",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary

v2.13.2's Issue #123 auto-disable migration placed its `DO $$` block inside the multi-statement `upgradeSQL` Exec. If any earlier statement fails (e.g. `pq: chunk not found` from a stale TimescaleDB chunk — a common real-world occurrence), PostgreSQL aborts the implicit transaction and **silently skips every subsequent statement**, including the DO block. Users who upgrade to v2.13.2 with TimescaleDB chunk noise end up with the three overly-broad seed rules still `enabled=true` — exactly the bug #123 was supposed to fix.

Same class of bug as Issue #105 (`ui_error_page_language`). The `migration.go` comment above `independentAlters` explicitly warns about this. v2.13.2 failed to heed that warning.

## Fix

Move the one-shot auto-disable out of `upgradeSQL` and invoke `ApplyExploitRulesAutoDisable(db.DB)` as its own `db.Exec` after the `independentAlters` loop. The helper was already extracted for the integration test, so this is a plumbing fix.

- Idempotent: guards are `auto_disabled_at IS NULL AND enabled = true AND is_system = true` — v2.13.2 installs that already ran won't be double-processed; admin-re-enabled rules stay untouched.
- Independent Exec: a failure here cannot cascade, and failures are logged individually (`Warning: exploit rules auto-disable migration failed: %v`).

## Test plan

- [x] **Code path verification** — DO block removed from upgradeSQL; `ApplyExploitRulesAutoDisable` called after independentAlters loop.
- [x] **Go integration test** — `TestExploitRulesAutoDisableOnUpgrade` PASS.
- [x] **Fresh install** — 3 rules ship disabled with `auto_disabled_at` set (seed data).
- [x] **Simulated upgrade from pre-fix state** — UPDATE rules to `enabled=true, auto_disabled_at=NULL`, restart API → migration fires, 3 rules auto-disabled, system_logs entry present.
- [x] **Idempotency** — admin re-enable (`enabled=true, auto_disabled_at` preserved) survives subsequent boots.
- [x] **Phase 1 + Phase 2 E2E specs** — 10/10 PASS after fresh install.
- [x] **Live production proof** — applied the equivalent UPDATE manually on the affected v2.13.2 prod DB (wiki.jjagu.com); `?search=update`/`insert`/`delete` now 200, UNION SELECT + `<script>` still 403.

## Impact on existing users

- **Fresh v2.13.3 installs**: unaffected (seed data already correct).
- **Upgrades from v2.13.1 or earlier**: fix now runs unconditionally regardless of upgradeSQL outcome.
- **Upgrades from v2.13.2 without TimescaleDB chunk issues**: already received the auto-disable; this hotfix is a no-op for them (idempotency guard).
- **Upgrades from v2.13.2 WITH chunk issues** (the buggy path): auto-disable now fires, fixing Issue #123 on their install.

release: v2.13.3