### PR TITLE
harden(exploit-rules): v2.13.5 — uri_pattern control-char guard + test coverage

### DIFF
--- a/api/internal/config/constants.go
+++ b/api/internal/config/constants.go
@@ -3,7 +3,7 @@ package config
 import "time"
 
 // Application version
-const AppVersion = "2.13.4"
+const AppVersion = "2.13.5"
 
 // Health status constants
 const (

--- a/api/internal/database/migration.go
+++ b/api/internal/database/migration.go
@@ -206,6 +206,16 @@ func (db *DB) RunMigrations() error {
 		// v2.13.2: drop legacy single-column unique constraints in favor of the
 		// composite (rule_id, COALESCE(uri_pattern,'')) unique indexes below.
 		// -----------------------------------------------------------------------
+		// ---------------------------------------------------------------------
+		// v2.13.2: replace single-column UNIQUE constraints with composite
+		// expression indexes to allow multiple URI-scoped exclusions per rule.
+		//
+		// Order matters: DROP CONSTRAINT runs before CREATE UNIQUE INDEX within
+		// the same upgrades loop but across separate db.Exec calls. On a running
+		// server there's a brief window with no uniqueness between the two — OK
+		// here because migrations run at boot before e.Start() accepts traffic.
+		// DO NOT reorder.
+		// ---------------------------------------------------------------------
 		{
 			desc: "v2.13.2: drop global_exploit_rule_exclusions_rule_id_key",
 			sql: `ALTER TABLE public.global_exploit_rule_exclusions

--- a/api/internal/handler/exploit_block_rule.go
+++ b/api/internal/handler/exploit_block_rule.go
@@ -52,8 +52,11 @@ func parseExploitRuleHostPath(path string) (hostID, ruleID string) {
 
 // validateURIPattern checks a user-provided URI regex for:
 //   - nil/empty/whitespace → returns (nil, nil) meaning "full exclusion, no URI scope"
+//   - length cap (512 chars) to guard against multi-MB regex compilation DoS
+//   - absence of characters that would break nginx config rendering:
+//     '$' (nginx variable interpolation), '"' (string-literal terminator),
+//     and control chars (\n, \r, \t, \0) that could smuggle new directives
 //   - compilability as Go regex
-//   - absence of '$' which would break nginx variable interpolation
 // Returns a *string pointing to the trimmed pattern when valid, or an error describing
 // the first problem found.
 func validateURIPattern(raw *string) (*string, error) {
@@ -64,13 +67,15 @@ func validateURIPattern(raw *string) (*string, error) {
 	if trimmed == "" {
 		return nil, nil
 	}
-	// Reject '$' because nginx interpolates it as a variable reference inside the
-	// double-quoted string that contains the rendered pattern. Other regex
-	// metachars like '\', '.', '*', etc. are fine — Go's regexp.Compile below
-	// rejects any malformed escape sequence, and escapeNginxPattern handles quote
-	// escaping at render time.
-	if strings.Contains(trimmed, "$") {
-		return nil, fmt.Errorf("uri_pattern must not contain '$'")
+	if len(trimmed) > 512 {
+		return nil, fmt.Errorf("uri_pattern exceeds 512 character limit")
+	}
+	// Reject characters that would break nginx config rendering.
+	// - '$' is interpolated by nginx as variable reference inside double-quoted strings.
+	// - '"' would terminate the string literal in `if ($request_uri ~* "...")`.
+	// - newlines/tabs/null bytes can smuggle new directives past the template.
+	if strings.ContainsAny(trimmed, "$\"\n\r\t\x00") {
+		return nil, fmt.Errorf("uri_pattern must not contain '$', '\"', or control characters")
 	}
 	if _, err := regexp.Compile(trimmed); err != nil {
 		return nil, fmt.Errorf("uri_pattern is not a valid regex: %v", err)

--- a/api/tests/integration/exploit_rules_migration_test.go
+++ b/api/tests/integration/exploit_rules_migration_test.go
@@ -146,3 +146,140 @@ func indexOfSubstring(haystack, needle string) int {
 	}
 	return -1
 }
+
+// TestExploitRulesAutoDisable_DeletedRulesHandled verifies the helper does not
+// error out when one of its target rule IDs is missing from the DB (e.g. admin
+// deleted it via direct SQL). Locks in the "UPDATE ... WHERE id = ..." semantic
+// which silently no-ops on missing rows.
+func TestExploitRulesAutoDisable_DeletedRulesHandled(t *testing.T) {
+	db, err := sql.Open("postgres", dbURL)
+	if err != nil {
+		t.Fatalf("db connect: %v", err)
+	}
+	defer db.Close()
+
+	if err := db.Ping(); err != nil {
+		t.Skipf("test DB unreachable (%v) — skipping migration test", err)
+	}
+
+	// Simulate an unusual DB state where a target rule was deleted (e.g., manual admin action via direct SQL).
+	// Save current rules first so we can restore.
+	type ruleBackup struct {
+		id             string
+		category       string
+		name           string
+		pattern        string
+		patternType    string
+		description    sql.NullString
+		severity       sql.NullString
+		enabled        bool
+		isSystem       bool
+		sortOrder      int
+		autoDisabledAt sql.NullTime
+	}
+	var saved []ruleBackup
+	for _, id := range falsePositiveRuleIDs {
+		var r ruleBackup
+		err := db.QueryRow(`SELECT id, category, name, pattern, pattern_type, description, severity, enabled, is_system, sort_order, auto_disabled_at FROM exploit_block_rules WHERE id = $1`, id).Scan(
+			&r.id, &r.category, &r.name, &r.pattern, &r.patternType, &r.description, &r.severity, &r.enabled, &r.isSystem, &r.sortOrder, &r.autoDisabledAt,
+		)
+		if err != nil {
+			t.Fatalf("backup rule %s: %v", id, err)
+		}
+		saved = append(saved, r)
+	}
+	defer func() {
+		// Restore
+		for _, r := range saved {
+			_, _ = db.Exec(`INSERT INTO exploit_block_rules (id, category, name, pattern, pattern_type, description, severity, enabled, is_system, sort_order, auto_disabled_at)
+				VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+				ON CONFLICT (id) DO UPDATE SET enabled = EXCLUDED.enabled, auto_disabled_at = EXCLUDED.auto_disabled_at`,
+				r.id, r.category, r.name, r.pattern, r.patternType, r.description, r.severity, r.enabled, r.isSystem, r.sortOrder, r.autoDisabledAt)
+		}
+	}()
+
+	// Delete one target rule
+	deleteID := falsePositiveRuleIDs[0]
+	_, err = db.Exec(`DELETE FROM exploit_block_rules WHERE id = $1`, deleteID)
+	if err != nil {
+		t.Fatalf("delete rule: %v", err)
+	}
+
+	// Run the helper — should not error even with a missing rule
+	if err := database.ApplyExploitRulesAutoDisable(db); err != nil {
+		t.Fatalf("helper errored on deleted rule: %v", err)
+	}
+}
+
+// TestExploitRulesAutoDisable_MixedPriorState verifies the helper only touches
+// rules where auto_disabled_at IS NULL. If the admin has already pre-flagged
+// a rule (timestamp set, enabled=true), the helper must leave it alone while
+// still disabling the other unflagged rules.
+func TestExploitRulesAutoDisable_MixedPriorState(t *testing.T) {
+	db, err := sql.Open("postgres", dbURL)
+	if err != nil {
+		t.Fatalf("db connect: %v", err)
+	}
+	defer db.Close()
+
+	if err := db.Ping(); err != nil {
+		t.Skipf("test DB unreachable (%v) — skipping migration test", err)
+	}
+
+	// Set up: rule[0] already flagged (admin pre-handled), rules[1] and rules[2] NULL + enabled=true
+	preFlaggedTime := time.Now().Add(-24 * time.Hour)
+	_, err = db.Exec(`UPDATE exploit_block_rules SET enabled = true, auto_disabled_at = $2 WHERE id = $1`,
+		falsePositiveRuleIDs[0], preFlaggedTime)
+	if err != nil {
+		t.Fatalf("setup rule 0: %v", err)
+	}
+	_, err = db.Exec(`UPDATE exploit_block_rules SET enabled = true, auto_disabled_at = NULL WHERE id = $1 OR id = $2`,
+		falsePositiveRuleIDs[1], falsePositiveRuleIDs[2])
+	if err != nil {
+		t.Fatalf("setup rules 1,2: %v", err)
+	}
+
+	// Restore after
+	defer func() {
+		for _, id := range falsePositiveRuleIDs {
+			_, _ = db.Exec(`UPDATE exploit_block_rules SET enabled = false, auto_disabled_at = NULL WHERE id = $1`, id)
+		}
+		// Run helper to restore normal flagged+disabled state
+		_ = database.ApplyExploitRulesAutoDisable(db)
+	}()
+
+	// Run helper
+	if err := database.ApplyExploitRulesAutoDisable(db); err != nil {
+		t.Fatalf("helper: %v", err)
+	}
+
+	// Assert: rule[0] untouched (enabled should still be true, timestamp should still be preFlaggedTime)
+	var enabled0 bool
+	var ts0 time.Time
+	err = db.QueryRow(`SELECT enabled, auto_disabled_at FROM exploit_block_rules WHERE id = $1`, falsePositiveRuleIDs[0]).Scan(&enabled0, &ts0)
+	if err != nil {
+		t.Fatalf("query rule 0: %v", err)
+	}
+	if !enabled0 {
+		t.Errorf("rule 0 (pre-flagged) should NOT have been re-disabled, but enabled=false")
+	}
+	if !ts0.Equal(preFlaggedTime) && ts0.Unix() != preFlaggedTime.Unix() {
+		t.Errorf("rule 0 auto_disabled_at was modified: expected %v, got %v", preFlaggedTime, ts0)
+	}
+
+	// Assert: rule[1] and rule[2] got auto-disabled
+	for _, id := range falsePositiveRuleIDs[1:] {
+		var enabled bool
+		var ts sql.NullTime
+		err := db.QueryRow(`SELECT enabled, auto_disabled_at FROM exploit_block_rules WHERE id = $1`, id).Scan(&enabled, &ts)
+		if err != nil {
+			t.Fatalf("query rule %s: %v", id, err)
+		}
+		if enabled {
+			t.Errorf("rule %s (was unflagged) should have been auto-disabled", id)
+		}
+		if !ts.Valid {
+			t.Errorf("rule %s should have auto_disabled_at set", id)
+		}
+	}
+}

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nginx-proxy-guard-ui",
   "private": true,
-  "version": "2.13.4",
+  "version": "2.13.5",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary

Post-release code review of the v2.13.2→v2.13.4 chain flagged three Important hardening items. Addresses all three.

## Changes

### 1. `validateURIPattern` rejects more injection vectors (`handler/exploit_block_rule.go`)

Previously rejected only `\$` and uncompilable regex. A malicious admin could smuggle nginx directives by including a newline or double-quote in the pattern, which would flow through `escapeNginxPattern` (only escapes `"`) into the generated `if (\$request_uri ~\* "...")` string literal.

Now also rejects: `"`, `\\n`, `\\r`, `\\t`, null byte. Also adds a 512-char length cap to block multi-megabyte regex DoS at every request.

### 2. Migration ordering doc comment (`database/migration.go`)

The v2.13.2 DROP CONSTRAINT → CREATE UNIQUE INDEX pair has a brief window with no uniqueness enforcement between the two `db.Exec` calls. Harmless today (migrations run pre-traffic) but a reorder would break this. Added explicit comment flagging the invariant.

### 3. Integration test coverage (`tests/integration/exploit_rules_migration_test.go`)

Two new test functions lock in auto-disable semantics under edge states:
- **`TestExploitRulesAutoDisable_DeletedRulesHandled`** — helper must not error if a target rule was manually deleted from DB.
- **`TestExploitRulesAutoDisable_MixedPriorState`** — confirms 'only touch unflagged' invariant: a rule with prior auto_disabled_at timestamp and enabled=true (admin-re-enabled) stays untouched while sibling rules with NULL marker get auto-disabled.

## Test plan

- [x] Go integration: 3/3 tests pass (`TestExploitRulesAutoDisableOnUpgrade`, `_DeletedRulesHandled`, `_MixedPriorState`)
- [x] Handler validation:
  - `uri_pattern: "^/search\\nBAD"` → HTTP 400 (newline rejected)
  - `uri_pattern: "^/search\""` → HTTP 400 (double-quote rejected)
  - `uri_pattern: "aaa...600 chars"` → HTTP 400 (length cap)
  - `uri_pattern: "^/search/legitimate"` → HTTP 201 (still works)

## Impact

- **Breaking**: None. Previously-valid patterns still validate. New rejections cover patterns that a reasonable user would never write deliberately.
- **Migration**: No new schema/data changes — purely code.

release: v2.13.5