### PR TITLE
feat(db): run on MariaDB and MySQL as well as PostgreSQL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,7 @@ temp/
 # Database
 *.sql
 !api/internal/database/migrations/*.sql
+!api/internal/database/migrations/mariadb/*.sql
 
 # Backups
 backups/
@@ -81,3 +82,6 @@ docs/superpowers/
 PLAN_DB_PERFORMANCE.md
 ARCHITECTURE.md
 MIGRATION-v2.md
+
+# Python bytecode from scripts/
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Built-in DDNS keeps your domains pointed at your home server as your public IP c
 | Technology | Purpose |
 |------------|---------|
 | **Nginx 1.30.2** | High-performance HTTP and stream reverse proxy core with HTTP/3 & QUIC support |
-| **TimescaleDB (PostgreSQL 17)** | Time-series-optimized database with automatic log compression |
+| **TimescaleDB (PostgreSQL 17)**, **MariaDB 11** _or_ **MySQL 8** | Time-series-optimized database with automatic log compression; MariaDB and MySQL are supported alternatives (see [Database engine](#-database-engine)) |
 | **Valkey 9** | Redis-compatible high-speed caching and session management (optional) |
 | **Go 1.26 (Echo v4)** | Backend API with efficient resource management and concurrency |
 | **React 19 & TypeScript 6** | Type-safe, component-based modern UI (Vite 8 + Tailwind 4) |
@@ -265,12 +265,87 @@ https://localhost:81/api/v1/swagger
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `DB_PASSWORD` | PostgreSQL password | (required) |
+| `DB_PASSWORD` | Database password | (required) |
 | `JWT_SECRET` | Secret for JWT tokens | (required) |
 | `TZ` | Timezone | `UTC` |
-| `DB_USER` | PostgreSQL user | `postgres` |
+| `DB_USER` | Database user | `postgres` |
 | `DB_NAME` | Database name | `nginx_proxy_guard` |
+| `DATABASE_URL` | Full connection URL; its scheme picks the engine | built from the variables above |
 | `DOCKER_API_VERSION` | Docker API version (for Synology) | auto-detect |
+
+---
+
+## 🗄 Database Engine
+
+Nginx Proxy Guard runs on **TimescaleDB/PostgreSQL** (the default), **MariaDB
+11**, or **MySQL 8**. The engine is chosen by the `DATABASE_URL` scheme —
+nothing else in the configuration differs.
+
+**PostgreSQL** is the default and needs no configuration.
+
+**MariaDB or MySQL** need the compose overlay that swaps the `db` service:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.mariadb.yml up -d
+# or
+docker compose -f docker-compose.yml -f docker-compose.mysql.yml up -d
+```
+
+and in `.env`:
+
+```ini
+DB_USER=npg
+DB_PASSWORD=change-me
+DB_ROOT_PASSWORD=change-me-too
+DATABASE_URL=mariadb://npg:change-me@db:3306/nginx_proxy_guard
+# so later `docker compose` commands pick the overlay up automatically
+COMPOSE_FILE=docker-compose.yml:docker-compose.mariadb.yml
+```
+
+The scheme only selects the driver. Which of MariaDB and MySQL is actually
+listening is settled by asking the server, so `mysql://` pointed at MariaDB
+(or the reverse) still behaves correctly.
+
+**Choose once, at install time.** There is no in-place migration between the
+two engines. Moving an existing install means starting from an empty database
+or restoring a Nginx Proxy Guard backup — backups are engine-independent
+because the API exports and imports them itself rather than shelling out to
+`pg_dump`.
+
+**What differs on MariaDB**
+
+| | PostgreSQL / TimescaleDB | MariaDB / MySQL |
+|---|---|---|
+| Log storage | Hypertables | Native monthly `RANGE` partitions |
+| Compression | TimescaleDB chunk compression | InnoDB page compression (~5x measured) |
+| Retention | Drops old chunks | Drops old partitions |
+| Log text search | Trigram (GIN) indexed | Scan within the selected time window |
+
+Everything else — proxy hosts, certificates, WAF, GeoIP, notifications, SSO,
+backups — behaves identically. `GET /health/detailed` reports which engine is
+in use under `database.engine`.
+
+**Log compression.** The high-volume tables (`logs_partitioned`, `logs`,
+`system_logs`, `audit_logs`) are created with InnoDB page compression — zlib
+level 1 on MariaDB, `COMPRESSION='zlib'` on MySQL. Measured on 200,000 realistic access-log rows, `logs_partitioned`
+occupies 60 MB on disk against 317 MB logical — a factor of 5.3. Level 1 is
+chosen over the default 6 because both produce the same size on log data while
+level 6 costs 2.7x the write time, and log ingestion is this application's
+write-heaviest path.
+
+Page compression needs a filesystem that can punch holes in sparse files —
+ext4, xfs and btrfs all can. Where it is unavailable InnoDB still compresses
+the page but writes it at full size, so the effect is a little wasted CPU
+rather than an error.
+
+**Log text search** is the one thing with no MariaDB or MySQL equivalent. PostgreSQL
+backs the log search box with `pg_trgm` GIN indexes, which make arbitrary
+`%substring%` matching indexed; neither MySQL-family engine has a trigram
+index, and their FULLTEXT index is word-based, so it cannot answer a
+partial-token query at all (searching `sourc` would not find `resource`).
+Rather than silently change what the search box matches, they scan — but only
+within the time range the query selects, which prunes to the relevant monthly
+partitions. Keeping a time filter on is what makes log search fast there.
 
 ---
 

--- a/README_KO.md
+++ b/README_KO.md
@@ -134,7 +134,7 @@ UDP를 통한 더 빠르고 안정적인 연결을 위한 최신 프로토콜 �
 | 기술 | 용도 |
 |------|------|
 | **Nginx 1.30.2** | HTTP/3 & QUIC을 지원하는 고성능 HTTP 및 stream 리버스 프록시 코어 |
-| **TimescaleDB (PostgreSQL 17)** | 로그 자동 압축을 위한 시계열 최적화 데이터베이스 |
+| **TimescaleDB (PostgreSQL 17)**, **MariaDB 11** _또는_ **MySQL 8** | 로그 자동 압축을 위한 시계열 최적화 데이터베이스. MariaDB와 MySQL도 대안으로 지원합니다 ([데이터베이스 엔진](#-데이터베이스-엔진) 참고) |
 | **Valkey 9** | Redis 호환 고속 캐싱 및 세션 관리 (선택) |
 | **Go 1.26 (Echo v4)** | 효율적인 리소스 관리와 동시성 처리 백엔드 API |
 | **React 19 & TypeScript 6** | 타입 안전성과 컴포넌트 기반의 모던 UI (Vite 8 + Tailwind 4) |
@@ -265,12 +265,84 @@ https://localhost:81/api/v1/swagger
 
 | 변수 | 설명 | 기본값 |
 |------|------|--------|
-| `DB_PASSWORD` | PostgreSQL 비밀번호 | (필수) |
+| `DB_PASSWORD` | 데이터베이스 비밀번호 | (필수) |
 | `JWT_SECRET` | JWT 토큰용 시크릿 | (필수) |
 | `TZ` | 시간대 | `UTC` |
-| `DB_USER` | PostgreSQL 사용자 | `postgres` |
+| `DB_USER` | 데이터베이스 사용자 | `postgres` |
 | `DB_NAME` | 데이터베이스 이름 | `nginx_proxy_guard` |
+| `DATABASE_URL` | 전체 접속 URL. 스킴으로 엔진이 결정됩니다 | 위 변수들로 자동 구성 |
 | `DOCKER_API_VERSION` | Docker API 버전 (시놀로지용) | 자동 감지 |
+
+---
+
+## 🗄 데이터베이스 엔진
+
+Nginx Proxy Guard는 **TimescaleDB/PostgreSQL**(기본), **MariaDB 11**, **MySQL 8**
+위에서 동작합니다. 엔진은 `DATABASE_URL`의 스킴으로 결정되며, 그 외 설정은
+동일합니다.
+
+**PostgreSQL**은 기본값이라 따로 설정할 것이 없습니다.
+
+**MariaDB나 MySQL**을 쓰려면 `db` 서비스를 교체하는 compose 오버레이를 함께
+지정합니다.
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.mariadb.yml up -d
+# 또는
+docker compose -f docker-compose.yml -f docker-compose.mysql.yml up -d
+```
+
+스킴은 드라이버만 고릅니다. MariaDB인지 MySQL인지는 접속 후 서버에 직접 물어서
+판별하므로, `mysql://`로 MariaDB를 가리켜도(혹은 그 반대여도) 정상 동작합니다.
+
+`.env`에는 다음을 넣습니다.
+
+```ini
+DB_USER=npg
+DB_PASSWORD=change-me
+DB_ROOT_PASSWORD=change-me-too
+DATABASE_URL=mariadb://npg:change-me@db:3306/nginx_proxy_guard
+# 이후 docker compose 명령이 오버레이를 자동으로 인식하도록
+COMPOSE_FILE=docker-compose.yml:docker-compose.mariadb.yml
+```
+
+**엔진은 설치 시점에 한 번만 고르세요.** 두 엔진 간 무중단 마이그레이션은
+없습니다. 기존 설치를 옮기려면 빈 데이터베이스에서 새로 시작하거나 Nginx Proxy
+Guard 백업을 복원해야 합니다. 백업은 `pg_dump`가 아니라 API가 직접 내보내고
+가져오므로 엔진과 무관하게 호환됩니다.
+
+**MariaDB에서 달라지는 점**
+
+| | PostgreSQL / TimescaleDB | MariaDB / MySQL |
+|---|---|---|
+| 로그 저장 | 하이퍼테이블 | 네이티브 월별 `RANGE` 파티션 |
+| 압축 | TimescaleDB 청크 압축 | InnoDB 페이지 압축 (실측 약 5배) |
+| 보존 정책 | 오래된 청크 삭제 | 오래된 파티션 삭제 |
+| 로그 텍스트 검색 | 트라이그램(GIN) 인덱스 | 선택한 기간 범위 내 스캔 |
+
+프록시 호스트, 인증서, WAF, GeoIP, 알림, SSO, 백업 등 나머지 기능은 완전히
+동일하게 동작합니다. 현재 어떤 엔진을 쓰는지는 `GET /health/detailed`의
+`database.engine`에서 확인할 수 있습니다.
+
+**로그 압축.** 대용량 테이블(`logs_partitioned`, `logs`, `system_logs`,
+`audit_logs`)은 InnoDB 페이지 압축으로 생성됩니다(MariaDB는 zlib 레벨 1,
+MySQL은 `COMPRESSION='zlib'`). 실제 형태의
+액세스 로그 20만 건으로 측정했을 때 `logs_partitioned`는 논리 317MB 대비
+디스크 60MB — 5.3배입니다. 기본값 6이 아니라 레벨 1을 쓰는 이유는, 로그
+데이터에서는 두 레벨의 결과 크기가 같은데 레벨 6은 쓰기에 2.7배가 걸리고,
+로그 수집이 이 애플리케이션에서 가장 쓰기가 많은 경로이기 때문입니다.
+
+페이지 압축은 sparse 파일에 hole punch가 가능한 파일시스템이 필요합니다
+(ext4, xfs, btrfs 모두 가능). 지원하지 않는 환경에서는 InnoDB가 페이지를
+압축하되 전체 크기로 기록하므로, 오류가 아니라 약간의 CPU 낭비로 끝납니다.
+
+**로그 텍스트 검색**은 MariaDB/MySQL에 대응물이 없는 유일한 항목입니다.
+PostgreSQL은 `pg_trgm` GIN 인덱스로 임의의 `%부분문자열%` 매칭을 인덱스로
+처리하지만, 두 엔진에는 트라이그램 인덱스가 없고 FULLTEXT는 단어 단위라 부분
+토큰 질의를 아예 처리하지 못합니다(`sourc`로 `resource`를 찾을 수 없음).
+검색창의 동작을 조용히 바꾸는 대신 스캔하되, 질의가 선택한 기간 범위로 월별
+파티션이 프루닝됩니다. 기간 필터를 켜두는 것이 검색을 빠르게 유지하는
+방법입니다.
 
 ---
 

--- a/api/go.mod
+++ b/api/go.mod
@@ -22,6 +22,7 @@ require (
 )
 
 require (
+	filippo.io/edwards25519 v1.2.0 // indirect
 	github.com/aws/aws-sdk-go-v2 v1.41.6 // indirect
 	github.com/aws/aws-sdk-go-v2/config v1.32.16 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.15 // indirect
@@ -42,6 +43,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/go-jose/go-jose/v4 v4.1.4 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
+	github.com/go-sql-driver/mysql v1.10.0 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/labstack/gommon v0.5.0 // indirect
 	github.com/lufia/plan9stats v0.0.0-20260330125221-c963978e514e // indirect

--- a/api/go.sum
+++ b/api/go.sum
@@ -1,3 +1,5 @@
+filippo.io/edwards25519 v1.2.0 h1:crnVqOiS4jqYleHd9vaKZ+HKtHfllngJIiOpNpoJsjo=
+filippo.io/edwards25519 v1.2.0/go.mod h1:xzAOLCNug/yB62zG1bQ8uziwrIqIuxhctzJT18Q77mc=
 github.com/aws/aws-sdk-go-v2 v1.41.6 h1:1AX0AthnBQzMx1vbmir3Y4WsnJgiydmnJjiLu+LvXOg=
 github.com/aws/aws-sdk-go-v2 v1.41.6/go.mod h1:dy0UzBIfwSeot4grGvY1AqFWN5zgziMmWGzysDnHFcQ=
 github.com/aws/aws-sdk-go-v2/config v1.32.16 h1:Q0iQ7quUgJP0F/SCRTieScnaMdXr9h/2+wze1u3cNeM=
@@ -48,6 +50,8 @@ github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz
 github.com/go-jose/go-jose/v4 v4.1.4/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
 github.com/go-ole/go-ole v1.2.6 h1:/Fpf6oFPoeFik9ty7siob0G6Ke8QvQEuVcuChpwXzpY=
 github.com/go-ole/go-ole v1.2.6/go.mod h1:pprOEPIfldk/42T2oK7lQ4v4JSDwmV0As9GaiUsvbm0=
+github.com/go-sql-driver/mysql v1.10.0 h1:Q+1LV8DkHJvSYAdR83XzuhDaTykuDx0l6fkXxoWCWfw=
+github.com/go-sql-driver/mysql v1.10.0/go.mod h1:M+cqaI7+xxXGG9swrdeUIoPG3Y3KCkF0pZej+SK+nWk=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=

--- a/api/internal/database/database.go
+++ b/api/internal/database/database.go
@@ -9,6 +9,8 @@ import (
 	"time"
 
 	_ "github.com/lib/pq"
+
+	"nginx-proxy-guard/internal/database/dialect"
 )
 
 // Initial-connect retry budget. TimescaleDB crash recovery (WAL replay after
@@ -22,6 +24,12 @@ const (
 
 type DB struct {
 	*sql.DB
+
+	// kind는 이 핸들이 어느 백엔드와 이야기하는지를 담는다. 질의 코드는 거의
+	// 전부 dialect에 무관하다. MySQL 계열 드라이버가 Postgres SQL을 실행 도중
+	// 재작성하기 때문이다. 다만 기계적 번역이 불가능한 소수의 구문(배열과 jsonb
+	// 연산자, COPY, 파티션 관리)은 이 값으로 분기한다.
+	kind dialect.Kind
 
 	// bgCtx is cancelled by Close() so any background migration goroutines
 	// spawned from RunMigrations honour graceful shutdown instead of
@@ -41,8 +49,24 @@ type DB struct {
 	migLastError    string
 }
 
+// New는 databaseURL이 가리키는 데이터베이스를 연다. 백엔드는 URL 스킴으로
+// 고른다. postgres://(알아보지 못한 값의 기본값) 또는 mysql:// / mariadb://.
 func New(databaseURL string) (*DB, error) {
-	db, err := sql.Open("postgres", databaseURL)
+	kind := dialect.Detect(databaseURL)
+
+	dsn := databaseURL
+	if kind.IsMySQLFamily() {
+		// go-sql-driver는 자체 DSN 형식을 쓰고, NginxProxyGuard는 그 위에 접속
+		// 파라미터 몇 가지를 강제한다(UTC 시각, 매칭 행 수, ANSI_QUOTES).
+		// dialect.MySQLDSN 참고.
+		var err error
+		dsn, err = dialect.MySQLDSN(databaseURL, false)
+		if err != nil {
+			return nil, fmt.Errorf("failed to build database DSN: %w", err)
+		}
+	}
+
+	db, err := sql.Open(dialect.DriverName(kind), dsn)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open database connection: %w", err)
 	}
@@ -69,9 +93,28 @@ func New(databaseURL string) (*DB, error) {
 		time.Sleep(connectRetryInterval)
 	}
 
+	// URL 스킴은 드라이버만 골랐을 뿐이다. MySQL 계열 두 엔진 중 실제로 어느
+	// 쪽인지는 서버에 직접 묻는다. RETURNING, DDL의 IF NOT EXISTS, 압축 표기가
+	// 서로 다르기 때문이다.
+	if kind.IsMySQLFamily() {
+		kind = dialect.DetectFlavor(func(q string) *sql.Row { return db.QueryRow(q) })
+	}
+
+	// 리포지토리가 만들어지기 전에 공표한다. 일부는 맨 *sql.DB를 받으므로
+	// dialect를 패키지에서 읽는다.
+	dialect.SetActive(kind)
+	log.Printf("[DB] Connected to %s (%s)", kind, dialect.Redact(databaseURL))
+
 	bgCtx, bgCancel := context.WithCancel(context.Background())
-	return &DB{DB: db, bgCtx: bgCtx, bgCancel: bgCancel}, nil
+	return &DB{DB: db, kind: kind, bgCtx: bgCtx, bgCancel: bgCancel}, nil
 }
+
+// Kind는 이 핸들이 어느 백엔드와 이야기하는지 돌려준다. 리포지토리는 MySQL 계열
+// 드라이버가 스스로 재작성할 수 없는 구문에만 이 값을 쓴다.
+func (db *DB) Kind() dialect.Kind { return db.kind }
+
+// IsMySQLFamily는 리포지토리가 가장 자주 쓰는 분기의 축약형이다.
+func (db *DB) IsMySQLFamily() bool { return db.kind.IsMySQLFamily() }
 
 // RecordMigrationFailure accumulates a failed upgrade-migration statement.
 // Called from RunMigrations' per-statement warn-and-continue loop; the

--- a/api/internal/database/dialect/coverage_test.go
+++ b/api/internal/database/dialect/coverage_test.go
@@ -1,0 +1,166 @@
+package dialect
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	gotoken "go/token"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// TestEveryQueryTranslates는 internal/ 아래의 SQL 리터럴을 훑으며 번역기가
+// 전부 받아들이는지 확인한다.
+//
+// MySQL 계열 지원이 썩지 않게 지켜 주는 장치다. 설계 전체가 "리포지토리는
+// PostgreSQL을 쓰고 드라이버가 재작성한다"에 기대고 있으므로, 번역 불가 구문을
+// 쓰는 새 질의는 어떤 PostgreSQL 테스트로도 잡히지 않는 장애가 된다. 그런 질의를
+// 추가하면 작성하는 그 순간 여기서 실패한다.
+//
+// 정말로 기계적 번역이 불가능한 질의는 dialect.ActiveIsMySQLFamily() 분기 뒤에
+// 대응 구현과 함께 두고, 그 파일을 아래 postgresOnlyBranches에 올린다.
+func TestEveryQueryTranslates(t *testing.T) {
+	root := repositoryRoot(t)
+
+	var failures []string
+	for _, path := range goFilesUnder(t, root) {
+		rel, _ := filepath.Rel(root, path)
+		if postgresOnlyBranches[filepath.ToSlash(rel)] || notSQL[filepath.ToSlash(rel)] {
+			continue
+		}
+		for _, lit := range sqlLiterals(t, path) {
+			if _, err := Translate(lit.text); err != nil {
+				failures = append(failures, fmt.Sprintf("%s:%d: %v\n    %s",
+					filepath.ToSlash(rel), lit.line, err, snippet(lit.text)))
+			}
+		}
+	}
+
+	sort.Strings(failures)
+	if len(failures) > 0 {
+		t.Fatalf("%d SQL literal(s) cannot be translated for MariaDB:\n\n%s",
+			len(failures), strings.Join(failures, "\n"))
+	}
+}
+
+// postgresOnlyBranches는 호출부가 먼저 dialect를 확인하고 다른 경로를 타기
+// 때문에 MySQL 계열에서는 도달하지 않는 SQL을 담은 파일들이다. 각 항목에 대응
+// 구현을 적어 두어 짝이 눈에 보이게 한다.
+var postgresOnlyBranches = map[string]bool{
+	// TimescaleDB 전환, 하이퍼테이블 복구, 레거시 로그 백필.
+	// MySQL 계열은 대신 migration_mysqlfamily.go를 실행한다.
+	"database/migration.go": true,
+
+	// PL/pgSQL 파티션 헬퍼와 pg_class 통계.
+	// MySQL 계열: scheduler/partition_mariadb.go.
+	"scheduler/partition.go": true,
+
+	// 시간별 국가 맵을 jsonb_each_text로 집계하는 부분.
+	// MySQL 계열: DashboardRepository.getTopCountriesMariaDB.
+	"repository/dashboard.go": true,
+
+	// UNNEST 기반 도메인 교집합.
+	// MySQL 계열: ProxyHostRepository.checkDomainExistsMariaDB.
+	"repository/proxy_host_queries.go": true,
+
+	// TimescaleDB 압축 지표.
+	// MySQL 계열: GetHypertableStats가 아무것도 돌려주지 않는다(하이퍼테이블이
+	// 없다).
+	"repository/health_detailed.go": true,
+
+	// PL/pgSQL 보존 헬퍼인 drop_old_partitions().
+	// MySQL 계열: 여기서는 행 단위 DELETE를 하고, 파티션 단위 보존은
+	// scheduler/partition_mariadb.go가 맡는다.
+	"repository/log_cleanup.go": true,
+}
+
+// notSQL은 아래 휴리스틱에만 SQL처럼 보이는 리터럴을 가진 파일들이다.
+// `::`와 "select"라는 단어가 들어 있는 nginx 설정 템플릿이다.
+var notSQL = map[string]bool{
+	"nginx/main_config.go":           true,
+	"nginx/default_server_config.go": true,
+}
+
+type sqlLiteral struct {
+	text string
+	line int
+}
+
+// looksLikeSQL은 일부러 느슨하다. 오탐은 허용 목록 한 줄이면 되지만, 미탐은
+// 운영 장애가 된다.
+var looksLikeSQL = regexp.MustCompile(`(?is)\b(SELECT|INSERT\s+INTO|UPDATE|DELETE\s+FROM|WITH)\b`)
+
+func sqlLiterals(t *testing.T, path string) []sqlLiteral {
+	t.Helper()
+	fset := gotoken.NewFileSet()
+	file, err := parser.ParseFile(fset, path, nil, 0)
+	if err != nil {
+		return nil
+	}
+
+	var out []sqlLiteral
+	ast.Inspect(file, func(n ast.Node) bool {
+		lit, ok := n.(*ast.BasicLit)
+		if !ok || lit.Kind != gotoken.STRING {
+			return true
+		}
+		text, err := strconv.Unquote(lit.Value)
+		if err != nil {
+			text = strings.Trim(lit.Value, "`")
+		}
+		if len(text) < 25 || !looksLikeSQL.MatchString(text) {
+			return true
+		}
+		out = append(out, sqlLiteral{text: text, line: fset.Position(lit.Pos()).Line})
+		return true
+	})
+	return out
+}
+
+func goFilesUnder(t *testing.T, root string) []string {
+	t.Helper()
+	var out []string
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() || !strings.HasSuffix(path, ".go") {
+			return err
+		}
+		// 테스트 파일에는 일부러 번역 불가한 예시가 들어 있고, 이 패키지의
+		// 오류 메시지 자체가 거부하는 문법을 인용한다.
+		if strings.HasSuffix(path, "_test.go") || strings.Contains(path, "/database/dialect/") {
+			return nil
+		}
+		out = append(out, path)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking %s: %v", root, err)
+	}
+	return out
+}
+
+// repositoryRoot는 이 패키지 위치를 기준으로 internal/을 찾는다.
+func repositoryRoot(t *testing.T) string {
+	t.Helper()
+	root, err := filepath.Abs(filepath.Join("..", "..", ".."))
+	if err != nil {
+		t.Fatal(err)
+	}
+	internal := filepath.Join(root, "internal")
+	if _, err := os.Stat(internal); err != nil {
+		t.Skipf("cannot locate internal/ from the test's working directory: %v", err)
+	}
+	return internal
+}
+
+func snippet(s string) string {
+	s = strings.Join(strings.Fields(s), " ")
+	if len(s) > 100 {
+		return s[:100] + "..."
+	}
+	return s
+}

--- a/api/internal/database/dialect/dialect.go
+++ b/api/internal/database/dialect/dialect.go
@@ -1,0 +1,361 @@
+// dialect 패키지는 NginxProxyGuard가 "지금 어느 SQL 백엔드와 이야기하는가"를
+// 신경 써야 하는 지점을 한곳에 모은다.
+//
+// 지원 백엔드는 셋이다. PostgreSQL/TimescaleDB, MariaDB, MySQL.
+//
+// 이 프로젝트는 PostgreSQL을 전제로 작성됐고, 2만 줄이 넘는 리포지토리 코드가
+// Postgres를 모국어로 쓴다. $N 플레이스홀더, ON CONFLICT, RETURNING, text[]
+// 컬럼, jsonb, COUNT(*) FILTER (WHERE ...) 같은 것들이다. 리포지토리 63개
+// 파일을 갈라내는 대신, 나머지 두 엔진은 한 층 아래에서 지원한다. 각 문장을
+// 서버로 보내는 길에 재작성하는 database/sql 드라이버다(translate.go와
+// driver.go 참고). 리포지토리는 계속 Postgres SQL을 쓰고 dialect를 모른 채로
+// 남는다. 기계적 대응물이 없는 소수의 구문(배열 연산자, jsonb 함수, COPY)만
+// Kind로 분기한다.
+//
+// MariaDB와 MySQL은 생성된 스키마 한 벌을 포함해 거의 모든 것을 공유한다.
+// 갈라지는 지점 — MySQL은 RETURNING 절이 없고, 대부분의 DDL에서 IF NOT EXISTS를
+// 거부하며, 페이지 압축 표기가 다르다 — 은 번역기가 처리한다. 그리고 반대편에
+// 어떤 서버가 있는지는 접속 URL의 스킴을 믿는 대신 서버에 직접 물어서 정한다.
+package dialect
+
+import (
+	"database/sql"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync/atomic"
+)
+
+// Kind는 지원하는 데이터베이스 백엔드를 식별한다.
+type Kind string
+
+const (
+	Postgres Kind = "postgres"
+	MariaDB  Kind = "mariadb"
+	MySQL    Kind = "mysql"
+)
+
+func (k Kind) String() string { return string(k) }
+
+// IsMySQLFamily는 이 백엔드가 MySQL 프로토콜과 방언을 쓰는지 — 즉 MariaDB이거나
+// MySQL인지 — 판별한다.
+//
+// 리포지토리가 분기할 때 쓰는 기준이다. 둘은 충분히 가까워서 배열과 JSON 처리,
+// information_schema 조회, ILIKE 흉내내기를 한 번만 작성해도 양쪽에서 동작한다.
+// 진짜로 다른 부분 — RETURNING 지원 여부, DDL의 IF NOT EXISTS, 압축 문법 — 은
+// 호출부가 아니라 번역기가 구분한다(translate.go 참고).
+func (k Kind) IsMySQLFamily() bool { return k == MariaDB || k == MySQL }
+
+// Detect는 DATABASE_URL이 가리키는 백엔드를 판별한다.
+//
+// 알아보지 못한 값은 전부 Postgres로 본다. 이 프로젝트는 지금까지 줄곧
+// Postgres 전용이었으므로, 파싱되지 않거나 낯선 URL은 MySQL 계열 지원이 생기기
+// 전과 정확히 같게 동작해야 한다.
+func Detect(databaseURL string) Kind {
+	scheme, _, hasScheme := strings.Cut(databaseURL, "://")
+	if !hasScheme {
+		// go-sql-driver의 순수 DSN에는 스킴이 아예 없다
+		// ("user:pass@tcp(host:3306)/db"). 운영자가 네이티브 DSN을 그대로
+		// DATABASE_URL에 붙여넣을 수 있도록 네트워크 접두사를 인식한다.
+		if strings.Contains(databaseURL, "@tcp(") || strings.Contains(databaseURL, "@unix(") {
+			return MariaDB
+		}
+		return Postgres
+	}
+	switch strings.ToLower(scheme) {
+	case "mysql", "mariadb":
+		// 두 스킴 모두 같은 드라이버와 같은 DSN으로 이어진다. 실제로 어느
+		// 서버가 떠 있는지는 접속 후 DetectFlavor가 정한다. 접속 URL의 스킴은
+		// 선언이 아니라 습관이고, 잘못 적었다고 동작이 달라져서는 안 된다.
+		return MariaDB
+	default:
+		return Postgres
+	}
+}
+
+// DetectFlavor는 서버에 MySQL 계열 두 엔진 중 어느 쪽인지 직접 묻는다.
+//
+// MariaDB는 버전 문자열에 이름을 넣는다("11.4.12-MariaDB-ubu2404"). MySQL은
+// 넣지 않는다("8.4.11"). 이를 구분해야 하는 이유는 MySQL이 RETURNING 절을
+// 지원하지 않고, 대부분의 DDL에서 IF NOT EXISTS를 거부하며, 페이지 압축 표기가
+// 다르기 때문이다.
+//
+// 버전을 읽지 못하면 둘 중 더 관대한 쪽인 MariaDB로 본다. MariaDB만 허용하는
+// 구문은 어차피 전부 흉내내기가 준비돼 있으므로 이쪽으로 잘못 짚으면 효율만
+// 조금 손해지만, 반대로 짚으면 아무 이유 없이 MySQL 모양의 SQL을 MariaDB
+// 서버로 보내게 된다.
+func DetectFlavor(queryRow func(string) *sql.Row) Kind {
+	var version string
+	if err := queryRow("SELECT VERSION()").Scan(&version); err != nil {
+		return MariaDB
+	}
+	if strings.Contains(strings.ToLower(version), "mariadb") {
+		return MariaDB
+	}
+	return MySQL
+}
+
+// DriverName은 이 백엔드에 대해 열어야 할 database/sql 드라이버 이름을 돌려준다.
+// MySQL 계열의 이름은 driver.go에 등록된 번역 래퍼이며, 맨 "mysql" 드라이버가
+// 아니다. 그쪽을 직접 열면 날것의 Postgres SQL이 서버로 나간다.
+func DriverName(k Kind) string {
+	if k.IsMySQLFamily() {
+		return TranslatingDriverName
+	}
+	return "postgres"
+}
+
+// forcedMySQLParams는 선호가 아니라 필수인 DSN 파라미터들이다. 각각이
+// Postgres와의 동작 차이를 메우므로, 운영자가 DATABASE_URL에 적어 넣은 값보다
+// 우선한다. 여기서 "친절하게" 값을 존중해 주면 조용한 데이터 손상이나, 일부
+// 행에서만 실패하는 질의로 나타난다.
+var forcedMySQLParams = map[string]string{
+	// DATETIME 컬럼을 time.Time으로 스캔한다. 리포지토리들은 time.Time 필드로
+	// 곧바로 스캔하므로, 이게 없으면 []byte를 받아 실패한다.
+	"parseTime": "true",
+
+	// 모든 DATETIME을 UTC로 읽고 쓴다. Postgres 컬럼은
+	// `timestamp with time zone`이고 앱은 UTC로 정규화한다. MySQL 계열의
+	// DATETIME에는 시간대가 없으므로 드라이버가 대신 정해 줘야 한다. 아래의
+	// 세션 time_zone과 합쳐지면, 컨테이너 TZ가 UTC가 아니어도 NOW()와 Go 쪽
+	// 타임스탬프가 어긋나지 않는다.
+	"loc": "UTC",
+
+	// UPDATE가 (실제로 바뀐 행이 아니라) 매칭된 행 수를 보고하게 한다.
+	// Postgres는 WHERE에 걸린 모든 행을 세지만, MySQL은 기본적으로 값이 실제로
+	// 바뀐 행만 센다. 리포지토리들은 RowsAffected()==0을 "없음"으로 취급하므로,
+	// 이게 없으면 같은 값을 다시 쓰는 멱등 업데이트가 404로 잘못 보고된다.
+	"clientFoundRows": "true",
+
+	// 전체 utf8mb4, 바이너리 콜레이션. Postgres의 텍스트 비교는 대소문자를
+	// 구분하지만 MySQL 계열의 기본 *_general_ci 콜레이션은 구분하지 않는다.
+	// 그대로 두면 users.username이나 proxy_hosts 도메인 등의 유니크 인덱스에서
+	// "Admin"과 "admin"이 조용히 같은 값이 된다. 대소문자 무시 매칭은 Postgres가
+	// 원래 요구한 자리에서만, ILIKE를 명시적 콜레이션이 붙은 LIKE로 번역하는
+	// 방식으로 되살린다(translate.go 참고).
+	"collation": "utf8mb4_bin",
+}
+
+// sessionSQLMode는 모든 커넥션에 적용된다.
+//
+//   - ANSI_QUOTES는 "따옴표"로 감싼 구간을 문자열 리터럴이 아니라 식별자로
+//     만든다. 덕분에 예약어인 컬럼명을 인용한 Postgres SQL — 가장 눈에 띄는
+//     것은 로그 테이블의 "timestamp" 컬럼 — 이 그대로 파싱된다.
+//   - PIPES_AS_CONCAT은 ||를 논리 OR가 아니라 문자열 연결로 되돌린다. 없으면
+//     ||로 문자열을 만드는 질의가 0/1을 돌려준다.
+//   - STRICT_TRANS_TABLES는 조용한 잘림과 범위 초과 변환을 오류로 만든다.
+//     쓰기 시 값을 훼손하지 않는 Postgres의 태도와 맞춘다.
+//   - NO_ENGINE_SUBSTITUTION은 스키마가 지정한 스토리지 엔진을 몰래 바꾸는 대신
+//     소리 내어 실패하게 한다.
+//
+// ONLY_FULL_GROUP_BY는 의도적으로 뺐다. 대시보드 집계 몇 개가 Postgres의 더
+// 느슨한 함수 종속성 분석에 기대고 있어 거부당한다.
+const sessionSQLMode = "ANSI_QUOTES,PIPES_AS_CONCAT,STRICT_TRANS_TABLES,NO_ENGINE_SUBSTITUTION"
+
+// MySQLDSN은 DATABASE_URL을 go-sql-driver가 기대하는 DSN 형식으로 바꾸고 위에
+// 나열한 파라미터를 강제한다.
+//
+// 이미 네이티브 DSN인 값(스킴 없음)도 같은 파라미터 강제를 거쳐 통과하므로 두
+// 표기가 동일하게 동작한다.
+func MySQLDSN(databaseURL string, multiStatements bool) (string, error) {
+	base, params, err := splitMySQLDSN(databaseURL)
+	if err != nil {
+		return "", err
+	}
+
+	translatePostgresParams(params)
+
+	for k, v := range forcedMySQLParams {
+		params.Set(k, v)
+	}
+	// 따옴표를 씌우는 이유: 드라이버는 알아보지 못한 파라미터를 핸드셰이크 중
+	// `SET <name>=<value>` 형태로 그대로 재생하는데, 쉼표로 나열한 맨 목록은
+	// 거기서 올바른 값이 아니다.
+	params.Set("sql_mode", "'"+sessionSQLMode+"'")
+	params.Set("time_zone", "'+00:00'")
+
+	// 다중 문장 권한은 마이그레이션 커넥션에만 준다. 초기 스키마와 몇몇
+	// 업그레이드 단계가 문장 덩어리로 들어오기 때문이다. 서비스용 풀은 단일
+	// 문장으로 유지해서, 만에 하나 질의에 인젝션이 생겨도 두 번째 문장을 이어
+	// 붙일 수 없게 한다.
+	if multiStatements {
+		params.Set("multiStatements", "true")
+	} else {
+		params.Del("multiStatements")
+	}
+
+	if enc := params.Encode(); enc != "" {
+		return base + "?" + enc, nil
+	}
+	return base, nil
+}
+
+// sslmodeToTLS는 libpq의 sslmode를 go-sql-driver의 tls 파라미터로 대응시킨다.
+//
+// "prefer"와 "allow"에는 정확한 대응물이 없다. MySQL 드라이버는 TLS를 요구하거나
+// 쓰지 않거나 둘 중 하나다. 그래서 인증서 검증 없이 기회주의적으로 암호화하는
+// 쪽으로 보낸다. 둘 중에는 이쪽이 더 가깝다.
+var sslmodeToTLS = map[string]string{
+	"disable":     "false",
+	"allow":       "skip-verify",
+	"prefer":      "skip-verify",
+	"require":     "skip-verify",
+	"verify-ca":   "true",
+	"verify-full": "true",
+}
+
+// postgresOnlyParams는 MySQL 계열에서 아무 의미가 없는 libpq 접속
+// 파라미터들이다.
+//
+// 무시가 아니라 제거해야 한다. go-sql-driver는 알아보지 못한 파라미터를
+// 핸드셰이크 중 `SET <name>=<value>`로 재생하므로, 하나라도 남아 있으면
+// "Unknown system variable"로 접속 자체가 실패한다. 잘 돌아가던 PostgreSQL URL을
+// 복사해 스킴만 바꾸는 것이 MySQL 계열을 시험해 보는 가장 자연스러운 방법인데,
+// 그대로 두면 진짜 원인을 전혀 알려주지 않는 오류로 실패한다.
+var postgresOnlyParams = []string{
+	"search_path", "application_name", "fallback_application_name",
+	"target_session_attrs", "options", "connect_timeout", "client_encoding",
+	"sslcert", "sslkey", "sslrootcert", "sslcrl", "sslpassword", "channel_binding",
+	"gssencmode", "krbsrvname", "service", "passfile", "requiressl",
+}
+
+// translatePostgresParams는 옮겨갈 수 있는 것은 바꿔 적고 나머지는 버린다.
+func translatePostgresParams(params url.Values) {
+	if mode := params.Get("sslmode"); mode != "" {
+		params.Del("sslmode")
+		// 운영자가 명시한 tls=가 우선한다. sslmode는 보조 수단일 뿐이다.
+		if params.Get("tls") == "" {
+			if tls, ok := sslmodeToTLS[strings.ToLower(mode)]; ok {
+				params.Set("tls", tls)
+			}
+		}
+	}
+
+	// libpq는 접속 타임아웃을 초 단위로 적지만, go-sql-driver는 다른 이름으로
+	// Go duration을 원한다.
+	if timeout := params.Get("connect_timeout"); timeout != "" && params.Get("timeout") == "" {
+		if _, err := strconv.Atoi(timeout); err == nil {
+			params.Set("timeout", timeout+"s")
+		}
+	}
+
+	for _, name := range postgresOnlyParams {
+		params.Del(name)
+	}
+}
+
+// splitMySQLDSN은 두 표기 중 어느 쪽이든 go-sql-driver의
+// "user:pass@proto(addr)/dbname" 접두사와 질의 값들로 정규화한다.
+func splitMySQLDSN(databaseURL string) (string, url.Values, error) {
+	if !strings.Contains(databaseURL, "://") {
+		base, rawQuery, _ := strings.Cut(databaseURL, "?")
+		params, err := url.ParseQuery(rawQuery)
+		if err != nil {
+			return "", nil, fmt.Errorf("invalid DSN parameters: %w", err)
+		}
+		if base == "" {
+			return "", nil, fmt.Errorf("empty database DSN")
+		}
+		return base, params, nil
+	}
+
+	u, err := url.Parse(databaseURL)
+	if err != nil {
+		return "", nil, fmt.Errorf("invalid DATABASE_URL: %w", err)
+	}
+
+	var creds string
+	if u.User != nil {
+		user := u.User.Username()
+		if pass, ok := u.User.Password(); ok {
+			creds = user + ":" + pass + "@"
+		} else if user != "" {
+			creds = user + "@"
+		}
+	}
+
+	// "mariadb://user:pw@db/npg" 형태가 동작하도록 기본 포트를 채운다.
+	// 드라이버는 tcp(...) 안에 명시적인 주소를 요구한다.
+	host := u.Host
+	if host != "" && !strings.Contains(host, ":") {
+		host += ":3306"
+	}
+
+	network := "tcp(" + host + ")"
+	if host == "" {
+		return "", nil, fmt.Errorf("DATABASE_URL is missing a host")
+	}
+
+	dbName := strings.TrimPrefix(u.Path, "/")
+	if dbName == "" {
+		return "", nil, fmt.Errorf("DATABASE_URL is missing a database name")
+	}
+
+	return creds + network + "/" + dbName, u.Query(), nil
+}
+
+// Redact는 로그에 남길 수 있도록 데이터베이스 URL에서 비밀번호를 지운다.
+func Redact(databaseURL string) string {
+	u, err := url.Parse(databaseURL)
+	if err != nil || u.User == nil {
+		return "(redacted)"
+	}
+	if _, hasPassword := u.User.Password(); hasPassword {
+		u.User = url.UserPassword(u.User.Username(), "****")
+	}
+	return u.String()
+}
+
+// ---------------------------------------------------------------------------
+// 프로세스 전역 dialect
+// ---------------------------------------------------------------------------
+
+// active는 이 프로세스가 이야기하는 백엔드다. 커넥션이 열리는 즉시
+// database.New()가 공표한다.
+//
+// 패키지 수준 값이 맞는 형태인 이유는 이 값이 실제로 프로세스 전역이기
+// 때문이다. NginxProxyGuard는 데이터베이스를 정확히 하나만 연다. 이게 필요한
+// 이유는 일부 리포지토리가 dialect를 들고 다니는 래퍼가 아니라 맨 *sql.DB로
+// 생성되고, 그중 몇몇 질의 — 배열과 JSON 컬럼을 건드리는 것들 — 는 두 백엔드가
+// 모두 받아주는 단일 표기가 없기 때문이다. 나머지는 전부 번역 드라이버를 통해
+// dialect 비의존으로 남는다.
+var active atomic.Value
+
+// SetActive는 이 프로세스 데이터베이스 커넥션의 dialect를 공표한다.
+//
+// 번역 결과는 문장 텍스트를 키로 캐시되고 재작성 규칙은 플레이버에 따라
+// 달라지므로, 플레이버가 바뀔 때마다 캐시를 버린다. 실제로는 기동 시 두 번 —
+// 한 번은 URL 스킴에서, 한 번은 서버 버전에서 — 일어나고 그 뒤로는 없다.
+func SetActive(k Kind) {
+	previous, _ := active.Load().(Kind)
+	active.Store(k)
+	if previous != k {
+		clearTranslationCache()
+	}
+}
+
+// Active는 SetActive가 공표한 dialect를 돌려준다. 커넥션이 열리기 전에는
+// Postgres가 기본값이다.
+func Active() Kind {
+	if k, ok := active.Load().(Kind); ok {
+		return k
+	}
+	return Postgres
+}
+
+// ActiveIsMySQLFamily는 리포지토리가 분기할 때 쓰는 축약형이다.
+func ActiveIsMySQLFamily() bool { return Active().IsMySQLFamily() }
+
+// targetFlavor는 재작성 규칙이 겨냥해야 할 플레이버다.
+//
+// 번역은 MySQL 계열 커넥션에서만 돌아간다. 따라서 active dialect가
+// Postgres이거나 설정되지 않았다는 것은 아직 플레이버가 공표되기 전이라는
+// 뜻이다. 버전 조회 자체를 수행하는 중이거나, 유닛 테스트 안이다. 그 상황의
+// 기본값으로 MariaDB가 맞는 이유는 DetectFlavor가 그것을 쓰는 이유와 같다.
+func targetFlavor() Kind {
+	if Active() == MySQL {
+		return MySQL
+	}
+	return MariaDB
+}

--- a/api/internal/database/dialect/driver.go
+++ b/api/internal/database/dialect/driver.go
@@ -1,0 +1,513 @@
+package dialect
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"io"
+	"sync"
+
+	"github.com/go-sql-driver/mysql"
+	"github.com/google/uuid"
+)
+
+// TranslatingDriverName은 NginxProxyGuard가 MariaDB와 MySQL에 대해 여는
+// database/sql 드라이버다. go-sql-driver/mysql을 감싸고, 지나가는 모든 문장을
+// PostgreSQL 문법에서 재작성한다(translate.go 참고).
+//
+// 재작성을 리포지토리마다가 아니라 드라이버 경계에서 하는 것이 이 작업을
+// 감당 가능하게 만든다. 래퍼가 database/sql 아래에 있으므로 준비된 문장,
+// 트랜잭션, 단발성 질의가 모두 같은 경로로 처리되고, 리포지토리 63개 파일은
+// Postgres 방언 질의문 한 벌을 그대로 유지한다.
+const TranslatingDriverName = "npg-mysql"
+
+func init() {
+	sql.Register(TranslatingDriverName, translatingDriver{})
+}
+
+// ---------------------------------------------------------------------------
+// 번역 캐시
+//
+// 리포지토리는 같은 문장을 끊임없이 다시 발행하고, 상당수는 동적 필터 때문에
+// fmt.Sprintf로 조립된다. 그래서 키 공간은 넓지만 반복이 심하다. 뮤텍스로
+// 보호하는 평범한 맵이면 충분하다. 항목별로 쫓아내지 않고 통째로 비우는 이유는
+// 워킹셋이 작아서, 가끔 한 번 비우는 비용이 질의마다 최근성을 추적하는 비용보다
+// 싸기 때문이다.
+// ---------------------------------------------------------------------------
+
+const translationCacheLimit = 4096
+
+type cacheEntry struct {
+	stmt *Statement
+	err  error
+}
+
+var (
+	cacheMu sync.RWMutex
+	cache   = map[string]cacheEntry{}
+)
+
+// clearTranslationCache는 캐시된 재작성 결과를 전부 버린다. 재작성 규칙이
+// MariaDB와 MySQL에서 다르므로, active 플레이버가 바뀔 때 호출된다.
+func clearTranslationCache() {
+	cacheMu.Lock()
+	cache = map[string]cacheEntry{}
+	cacheMu.Unlock()
+}
+
+func translateCached(query string) (*Statement, error) {
+	cacheMu.RLock()
+	hit, ok := cache[query]
+	cacheMu.RUnlock()
+	if ok {
+		return hit.stmt, hit.err
+	}
+
+	translated, err := Translate(query)
+
+	cacheMu.Lock()
+	if len(cache) >= translationCacheLimit {
+		cache = make(map[string]cacheEntry, translationCacheLimit)
+	}
+	cache[query] = cacheEntry{stmt: translated, err: err}
+	cacheMu.Unlock()
+
+	return translated, err
+}
+
+// reorder는 호출자의 인자를 재작성된 문장이 기대하는 위치로 대응시킨다.
+// Postgres 플레이스홀더는 순번 기반이고 반복될 수 있으므로, 같은 인자가 여러
+// `?` 슬롯에 들어갈 수 있다.
+//
+// synthesised는 번역기가 ArgSynthesisedUUID로 표시한 슬롯에 넣을 값이다. 실행
+// 한 번당 하나이며, 쓰기와 재조회가 같은 행을 가리키도록 둘이 공유한다.
+func reorder(args []driver.NamedValue, order []int, synthesised string) ([]driver.NamedValue, error) {
+	if order == nil {
+		return args, nil
+	}
+	out := make([]driver.NamedValue, len(order))
+	for i, src := range order {
+		if src == ArgSynthesisedUUID {
+			out[i] = driver.NamedValue{Ordinal: i + 1, Value: synthesised}
+			continue
+		}
+		if src < 0 || src >= len(args) {
+			return nil, errors.New("dialect: translated statement references a missing argument")
+		}
+		out[i] = driver.NamedValue{Ordinal: i + 1, Value: args[src].Value}
+	}
+	return out, nil
+}
+
+// needsSynthesis는 계획의 어느 단계든 드라이버가 만든 값을 기대하는지
+// 판별한다.
+func needsSynthesis(s *Statement) bool {
+	for ; s != nil; s = s.FollowUp {
+		for _, src := range s.ArgOrder {
+			if src == ArgSynthesisedUUID {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// inputCount는 *호출자*가 넘기는 인자 개수다. 재작성된 문장의 `?` 개수와는
+// 다르다. 두 번 쓰인 Postgres 플레이스홀더는 인자 하나에서 바인딩되는 `?` 두
+// 개가 된다. database/sql은 순열을 적용하기 전에 호출자의 슬라이스를
+// NumInput()과 대조하므로, 순열 이전의 개수를 알려줘야 한다. 2단계 계획에서는
+// 호출자가 한 쌍에 대해 인자 목록 하나만 넘기므로 두 단계를 아울러 센다.
+func inputCount(s *Statement) int {
+	highest := -1
+	for ; s != nil; s = s.FollowUp {
+		for _, src := range s.ArgOrder {
+			// 합성 슬롯은 드라이버가 채우는 것이지 호출자가 넘기는 것이
+			// 아니다.
+			if src != ArgSynthesisedUUID && src > highest {
+				highest = src
+			}
+		}
+	}
+	return highest + 1
+}
+
+// ---------------------------------------------------------------------------
+// 드라이버 / 커넥터
+// ---------------------------------------------------------------------------
+
+type translatingDriver struct{}
+
+func (translatingDriver) Open(dsn string) (driver.Conn, error) {
+	inner, err := mysql.MySQLDriver{}.Open(dsn)
+	if err != nil {
+		return nil, err
+	}
+	return &conn{inner: inner}, nil
+}
+
+func (d translatingDriver) OpenConnector(dsn string) (driver.Connector, error) {
+	inner, err := mysql.MySQLDriver{}.OpenConnector(dsn)
+	if err != nil {
+		return nil, err
+	}
+	return &connector{inner: inner, drv: d}, nil
+}
+
+type connector struct {
+	inner driver.Connector
+	drv   translatingDriver
+}
+
+func (c *connector) Connect(ctx context.Context) (driver.Conn, error) {
+	inner, err := c.inner.Connect(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &conn{inner: inner}, nil
+}
+
+func (c *connector) Driver() driver.Driver { return c.drv }
+
+// ---------------------------------------------------------------------------
+// 커넥션
+// ---------------------------------------------------------------------------
+
+type conn struct {
+	inner driver.Conn
+}
+
+func (c *conn) Prepare(query string) (driver.Stmt, error) {
+	return c.PrepareContext(context.Background(), query)
+}
+
+func (c *conn) PrepareContext(ctx context.Context, query string) (driver.Stmt, error) {
+	plan, err := translateCached(query)
+	if err != nil {
+		return nil, err
+	}
+	inner, err := c.prepareTranslated(ctx, plan.SQL)
+	if err != nil {
+		return nil, err
+	}
+	return &stmt{owner: c, inner: inner, plan: plan}, nil
+}
+
+// prepareTranslated는 이미 재작성된 SQL을 번역기를 거치지 않고 준비한다.
+// 2단계 계획의 두 번째 단계에 쓴다.
+func (c *conn) prepareTranslated(ctx context.Context, sql string) (driver.Stmt, error) {
+	if p, ok := c.inner.(driver.ConnPrepareContext); ok {
+		return p.PrepareContext(ctx, sql)
+	}
+	return c.inner.Prepare(sql)
+}
+
+func (c *conn) Close() error { return c.inner.Close() }
+
+func (c *conn) Begin() (driver.Tx, error) { return c.inner.Begin() }
+
+func (c *conn) BeginTx(ctx context.Context, opts driver.TxOptions) (driver.Tx, error) {
+	if b, ok := c.inner.(driver.ConnBeginTx); ok {
+		return b.BeginTx(ctx, opts)
+	}
+	return c.inner.Begin()
+}
+
+func (c *conn) ExecContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Result, error) {
+	e, ok := c.inner.(driver.ExecerContext)
+	if !ok {
+		return nil, driver.ErrSkip
+	}
+	plan, err := translateCached(query)
+	if err != nil {
+		return nil, err
+	}
+	if plan.FollowUp != nil || needsSynthesis(plan) {
+		// 2단계 계획에는 트랜잭션과 준비된 두 번째 문장이 필요하다.
+		// database/sql이 두 가지를 모두 처리하는 Prepare 경로로 되돌아가게
+		// 둔다.
+		return nil, driver.ErrSkip
+	}
+	mapped, err := reorder(args, plan.ArgOrder, "")
+	if err != nil {
+		return nil, err
+	}
+	return e.ExecContext(ctx, plan.SQL, mapped)
+}
+
+func (c *conn) QueryContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
+	q, ok := c.inner.(driver.QueryerContext)
+	if !ok {
+		return nil, driver.ErrSkip
+	}
+	plan, err := translateCached(query)
+	if err != nil {
+		return nil, err
+	}
+	if plan.FollowUp != nil || needsSynthesis(plan) {
+		return nil, driver.ErrSkip
+	}
+	mapped, err := reorder(args, plan.ArgOrder, "")
+	if err != nil {
+		return nil, err
+	}
+	return q.QueryContext(ctx, plan.SQL, mapped)
+}
+
+func (c *conn) Ping(ctx context.Context) error {
+	if p, ok := c.inner.(driver.Pinger); ok {
+		return p.Ping(ctx)
+	}
+	return nil
+}
+
+func (c *conn) ResetSession(ctx context.Context) error {
+	if r, ok := c.inner.(driver.SessionResetter); ok {
+		return r.ResetSession(ctx)
+	}
+	return nil
+}
+
+func (c *conn) IsValid() bool {
+	if v, ok := c.inner.(driver.Validator); ok {
+		return v.IsValid()
+	}
+	return true
+}
+
+// CheckNamedValue는 go-sql-driver에 위임한다. 그쪽이 추가로 받아주는 타입들
+// (json.RawMessage, uint64 등)이 계속 동작하게 하기 위해서다. 이게 없으면 래퍼가
+// database/sql의 더 엄격한 기본 변환기로 되돌아가, 하위 드라이버가 잘 처리하는
+// 값을 거부하게 된다.
+func (c *conn) CheckNamedValue(nv *driver.NamedValue) error {
+	if ck, ok := c.inner.(driver.NamedValueChecker); ok {
+		return ck.CheckNamedValue(nv)
+	}
+	return driver.ErrSkip
+}
+
+// ---------------------------------------------------------------------------
+// 문장
+// ---------------------------------------------------------------------------
+
+type stmt struct {
+	owner *conn
+	inner driver.Stmt
+	plan  *Statement
+}
+
+func (s *stmt) Close() error { return s.inner.Close() }
+
+func (s *stmt) NumInput() int {
+	if s.plan.ArgOrder == nil && s.plan.FollowUp == nil {
+		return s.inner.NumInput()
+	}
+	return inputCount(s.plan)
+}
+
+func (s *stmt) Exec(args []driver.Value) (driver.Result, error) {
+	return s.ExecContext(context.Background(), valuesToNamed(args))
+}
+
+func (s *stmt) Query(args []driver.Value) (driver.Rows, error) {
+	return s.QueryContext(context.Background(), valuesToNamed(args))
+}
+
+// ExecContext는 2단계 계획의 쓰기 쪽만 실행한다. 호출자가 요청한 것은 행이
+// 아니라 결과이므로 재조회는 헛일이 된다.
+func (s *stmt) ExecContext(ctx context.Context, args []driver.NamedValue) (driver.Result, error) {
+	mapped, err := reorder(args, s.plan.ArgOrder, newSynthesisedID())
+	if err != nil {
+		return nil, err
+	}
+	return execStmt(ctx, s.inner, mapped)
+}
+
+func (s *stmt) QueryContext(ctx context.Context, args []driver.NamedValue) (driver.Rows, error) {
+	if s.plan.FollowUp != nil {
+		return s.queryWriteThenRead(ctx, args)
+	}
+	mapped, err := reorder(args, s.plan.ArgOrder, newSynthesisedID())
+	if err != nil {
+		return nil, err
+	}
+	return queryStmt(ctx, s.inner, mapped)
+}
+
+// queryWriteThenRead는 쓰기와 그에 딸린 SELECT를 계획이 정한 순서대로 하나의
+// 원자적 단위로 수행한다.
+//
+// 트랜잭션을 커밋하기 전에 행을 전부 메모리로 읽어 둔다. MySQL 드라이버는
+// 결과를 커넥션에서 스트리밍하므로, 열린 커서를 돌려주고 나중에 커밋하면
+// 커넥션이 교착되거나 그 행을 만든 트랜잭션 바깥에서 읽게 된다. 이 방식으로
+// 번역되는 문장은 모두 행 하나를 쓰고 그 하나를 다시 읽으므로 버퍼는 한 행
+// 깊이다.
+func (s *stmt) queryWriteThenRead(ctx context.Context, args []driver.NamedValue) (driver.Rows, error) {
+	// 실행 한 번당 값 하나를 두 단계가 공유한다. 재조회를 쓰기가 건드린 행에
+	// 묶어 주는 것이 바로 이 값이다.
+	synthesised := newSynthesisedID()
+
+	writeArgs, err := reorder(args, s.plan.ArgOrder, synthesised)
+	if err != nil {
+		return nil, err
+	}
+	readArgs, err := reorder(args, s.plan.FollowUp.ArgOrder, synthesised)
+	if err != nil {
+		return nil, err
+	}
+
+	tx, err := s.owner.BeginTx(ctx, driver.TxOptions{})
+	if err != nil {
+		return nil, err
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+
+	read, err := s.owner.prepareTranslated(ctx, s.plan.FollowUp.SQL)
+	if err != nil {
+		return nil, err
+	}
+	defer read.Close()
+
+	runRead := func() (*bufferedRows, error) {
+		rows, err := queryStmt(ctx, read, readArgs)
+		if err != nil {
+			return nil, err
+		}
+		buffered, err := bufferRows(rows)
+		closeErr := rows.Close()
+		if err != nil {
+			return nil, err
+		}
+		if closeErr != nil {
+			return nil, closeErr
+		}
+		return buffered, nil
+	}
+
+	var buffered *bufferedRows
+
+	// DELETE ... RETURNING은 먼저 읽어야 한다. 쓰기가 끝나면 조회할 것이 남지
+	// 않는다.
+	if s.plan.FollowUpFirst {
+		if buffered, err = runRead(); err != nil {
+			return nil, err
+		}
+	}
+
+	if _, err := execStmt(ctx, s.inner, writeArgs); err != nil {
+		return nil, err
+	}
+
+	if !s.plan.FollowUpFirst {
+		if buffered, err = runRead(); err != nil {
+			return nil, err
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, err
+	}
+	committed = true
+
+	return buffered, nil
+}
+
+// newSynthesisedID는 드라이버가 MySQL을 대신해 넣을 키를 만든다.
+//
+// 스키마가 이 컬럼들의 기본값을 UUID()로 두고 있으므로, 여기서 만든 값은 서버가
+// 만들었을 값과 구별되지 않는다. 다만 INSERT 실행 전에 값을 알 수 있다는 이점이
+// 있고, RETURNING 절이 없는 서버에서 그 행을 다시 찾는 방법은 그것뿐이다.
+func newSynthesisedID() string {
+	return uuid.NewString()
+}
+
+func (s *stmt) CheckNamedValue(nv *driver.NamedValue) error {
+	if ck, ok := s.inner.(driver.NamedValueChecker); ok {
+		return ck.CheckNamedValue(nv)
+	}
+	return driver.ErrSkip
+}
+
+func execStmt(ctx context.Context, st driver.Stmt, args []driver.NamedValue) (driver.Result, error) {
+	if e, ok := st.(driver.StmtExecContext); ok {
+		return e.ExecContext(ctx, args)
+	}
+	return st.Exec(namedToValues(args))
+}
+
+func queryStmt(ctx context.Context, st driver.Stmt, args []driver.NamedValue) (driver.Rows, error) {
+	if q, ok := st.(driver.StmtQueryContext); ok {
+		return q.QueryContext(ctx, args)
+	}
+	return st.Query(namedToValues(args))
+}
+
+func namedToValues(args []driver.NamedValue) []driver.Value {
+	out := make([]driver.Value, len(args))
+	for i, a := range args {
+		out[i] = a.Value
+	}
+	return out
+}
+
+func valuesToNamed(args []driver.Value) []driver.NamedValue {
+	out := make([]driver.NamedValue, len(args))
+	for i, v := range args {
+		out[i] = driver.NamedValue{Ordinal: i + 1, Value: v}
+	}
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// 버퍼링된 행
+// ---------------------------------------------------------------------------
+
+type bufferedRows struct {
+	columns []string
+	values  [][]driver.Value
+	pos     int
+}
+
+func bufferRows(src driver.Rows) (*bufferedRows, error) {
+	columns := src.Columns()
+	out := &bufferedRows{columns: append([]string(nil), columns...)}
+
+	for {
+		row := make([]driver.Value, len(columns))
+		if err := src.Next(row); err != nil {
+			if errors.Is(err, io.EOF) {
+				return out, nil
+			}
+			return nil, err
+		}
+		// MySQL 드라이버는 자기 읽기 버퍼를 가리키는 슬라이스를 돌려주고 다음
+		// Next()에서 재사용하므로, 보관할 것은 반드시 복사해야 한다.
+		for i, v := range row {
+			if b, ok := v.([]byte); ok {
+				row[i] = append([]byte(nil), b...)
+			}
+		}
+		out.values = append(out.values, row)
+	}
+}
+
+func (r *bufferedRows) Columns() []string { return r.columns }
+
+func (r *bufferedRows) Close() error {
+	r.values = nil
+	return nil
+}
+
+func (r *bufferedRows) Next(dest []driver.Value) error {
+	if r.pos >= len(r.values) {
+		return io.EOF
+	}
+	copy(dest, r.values[r.pos])
+	r.pos++
+	return nil
+}

--- a/api/internal/database/dialect/errors.go
+++ b/api/internal/database/dialect/errors.go
@@ -1,0 +1,105 @@
+package dialect
+
+import (
+	"errors"
+
+	"github.com/go-sql-driver/mysql"
+	"github.com/lib/pq"
+)
+
+// 리포지토리가 분기하는 조건들의 드라이버별 오류 코드.
+const (
+	pgUniqueViolation     = "23505"
+	pgForeignKeyViolation = "23503"
+
+	mysqlDupEntry         = 1062 // ER_DUP_ENTRY
+	mysqlDupEntryWithKey  = 1586 // ER_DUP_ENTRY_WITH_KEY_NAME
+	mysqlNoReferencedRow  = 1216 // ER_NO_REFERENCED_ROW
+	mysqlNoReferencedRow2 = 1452 // ER_NO_REFERENCED_ROW_2
+	mysqlRowIsReferenced  = 1217 // ER_ROW_IS_REFERENCED
+	mysqlRowIsReferenced2 = 1451 // ER_ROW_IS_REFERENCED_2
+)
+
+// IsUniqueViolation은 기존 행과 충돌해서 데이터베이스가 행을 거부한 오류인지
+// 판별한다. 어느 백엔드든 동작한다.
+//
+// 리포지토리는 유니크 인덱스 경합을 500 대신 "이미 존재합니다" 메시지로 바꾸는
+// 데 이 함수를 쓴다. Kind 인자로 분기하지 않고 두 드라이버를 모두 확인하는
+// 이유는 호출자를 dialect 비의존으로 두기 위해서다. 하나의 오류가 둘 다에
+// 매칭되는 경우는 없다.
+func IsUniqueViolation(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	var pqErr *pq.Error
+	if errors.As(err, &pqErr) {
+		return pqErr.Code == pgUniqueViolation
+	}
+
+	var myErr *mysql.MySQLError
+	if errors.As(err, &myErr) {
+		return myErr.Number == mysqlDupEntry || myErr.Number == mysqlDupEntryWithKey
+	}
+
+	return false
+}
+
+// IsForeignKeyViolation은 외래 키 제약 위반인지 판별한다. 참조 대상 행이
+// 없거나, 자식 행이 아직 가리키고 있어 삭제할 수 없는 경우 모두 해당한다.
+func IsForeignKeyViolation(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	var pqErr *pq.Error
+	if errors.As(err, &pqErr) {
+		return pqErr.Code == pgForeignKeyViolation
+	}
+
+	var myErr *mysql.MySQLError
+	if errors.As(err, &myErr) {
+		switch myErr.Number {
+		case mysqlNoReferencedRow, mysqlNoReferencedRow2, mysqlRowIsReferenced, mysqlRowIsReferenced2:
+			return true
+		}
+	}
+
+	return false
+}
+
+// 멱등 DDL을 MySQL에서 다시 실행할 때 나오는 오류들. MariaDB와 달리 MySQL은
+// 대부분의 DDL에 IF NOT EXISTS 절이 없다. stripUnsupportedIfExists 참고.
+const (
+	mysqlTableExists   = 1050 // ER_TABLE_EXISTS_ERROR
+	mysqlDupFieldName  = 1060 // ER_DUP_FIELDNAME
+	mysqlDupKeyName    = 1061 // ER_DUP_KEYNAME
+	mysqlCantDropField = 1091 // ER_CANT_DROP_FIELD_OR_KEY
+	mysqlDupForeignKey = 1826 // ER_FK_DUP_NAME
+	mysqlDupCheck      = 3822 // ER_CHECK_CONSTRAINT_DUP_NAME
+)
+
+// IsAlreadyApplied는 해당 오류가 "이 스키마 변경은 이미 적용돼 있다"는 뜻인지,
+// 아니면 진짜 문제인지 판별한다.
+//
+// 마이그레이션 파일은 부팅할 때마다 다시 실행된다. MariaDB에서는 각 문장에
+// IF NOT EXISTS가 붙어 있어 재실행이 조용한 no-op이 된다. MySQL은 인덱스, 컬럼,
+// 외래 키에 그 절을 허용하지 않으므로 번역기가 제거하고, 그 결과 재실행 시
+// 중복 객체 오류가 난다. 이를 성공으로 취급해야 두 엔진의 마이그레이션 동작이
+// 같아진다. 문장이 만들려던 객체가 이미 존재한다는 사실이 증명된 상황이므로
+// 안전하다.
+func IsAlreadyApplied(err error) bool {
+	if err == nil {
+		return false
+	}
+	var myErr *mysql.MySQLError
+	if !errors.As(err, &myErr) {
+		return false
+	}
+	switch myErr.Number {
+	case mysqlTableExists, mysqlDupFieldName, mysqlDupKeyName,
+		mysqlCantDropField, mysqlDupForeignKey, mysqlDupCheck:
+		return true
+	}
+	return false
+}

--- a/api/internal/database/dialect/lex.go
+++ b/api/internal/database/dialect/lex.go
@@ -1,0 +1,235 @@
+package dialect
+
+import "strings"
+
+// 최소한의 SQL 렉서. translate.go의 재작성기가 코드와 절대 손대면 안 되는 것들
+// — 문자열 리터럴, 주석, 인용 식별자, 달러 인용 블록 — 을 구분할 수 있게 하는
+// 용도로만 존재한다. 의도적으로 파서가 아니다. 어휘 형태만 인식하고 문장 문법은
+// 전혀 모른다.
+
+type tokKind int
+
+const (
+	tkSpace tokKind = iota
+	tkComment
+	tkString     // '...' — escaped는 E'...' 형태로 쓰였는지를 나타낸다
+	tkDollarStr  // $tag$ ... $tag$
+	tkQuotedName // "..."
+	tkWord       // 맨 식별자 또는 키워드
+	tkNumber
+	tkPunct
+	tkParam // $N
+	// tkSynth는 호출자가 아니라 드라이버가 채우는 값이다. 방출기가 `?`를 쓰고
+	// ArgOrder에 해당 슬롯을 표시한다. MySQL은 INSERT한 행의 기본 키를 돌려줄
+	// 수 없으므로, 그 키를 미리 넘겨주는 데 쓴다(returning.go 참고).
+	tkSynth
+)
+
+type token struct {
+	kind tokKind
+	text string
+	// num은 tkParam 토큰의 순번이다($3 -> 3).
+	num int
+	// escaped는 Postgres의 E'' 접두사로 쓰인 tkString을 표시한다. 그 안에서
+	// 백슬래시는 이스케이프 문자이며, 이는 MySQL 계열의 기본 동작과 정확히 같다.
+	// 반면 평범한 '' 리터럴은 두 엔진에서 의미가 반대라 내보낼 때 다시
+	// 이스케이프해야 한다.
+	escaped bool
+}
+
+func isIdentStart(c byte) bool {
+	return c == '_' || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c >= 0x80
+}
+
+func isIdentPart(c byte) bool {
+	return isIdentStart(c) || (c >= '0' && c <= '9') || c == '$'
+}
+
+func isDigit(c byte) bool { return c >= '0' && c <= '9' }
+
+func isSpace(c byte) bool {
+	return c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == '\f' || c == '\v'
+}
+
+// multiCharOperators는 탐욕적으로 읽는다. 재작성 규칙이 연산자의 첫 글자가
+// 아니라 전체를 보고 매칭할 수 있게 하기 위해서다. 긴 것부터 나열한다.
+var multiCharOperators = []string{"#>>", "->>", "#>", "->", "::", "||", "<>", "!=", ">=", "<=", ":=", "@>", "<@"}
+
+func lex(sql string) []token {
+	var toks []token
+	i := 0
+	n := len(sql)
+
+	for i < n {
+		c := sql[i]
+
+		switch {
+		case isSpace(c):
+			j := i
+			for j < n && isSpace(sql[j]) {
+				j++
+			}
+			toks = append(toks, token{kind: tkSpace, text: sql[i:j]})
+			i = j
+
+		case c == '-' && i+1 < n && sql[i+1] == '-':
+			j := i
+			for j < n && sql[j] != '\n' {
+				j++
+			}
+			toks = append(toks, token{kind: tkComment, text: sql[i:j]})
+			i = j
+
+		case c == '/' && i+1 < n && sql[i+1] == '*':
+			// Postgres 블록 주석은 중첩된다. /* /* */ */ 구간을 통째로 먹도록
+			// 깊이를 추적한다.
+			depth := 1
+			j := i + 2
+			for j < n && depth > 0 {
+				if j+1 < n && sql[j] == '/' && sql[j+1] == '*' {
+					depth++
+					j += 2
+					continue
+				}
+				if j+1 < n && sql[j] == '*' && sql[j+1] == '/' {
+					depth--
+					j += 2
+					continue
+				}
+				j++
+			}
+			toks = append(toks, token{kind: tkComment, text: sql[i:j]})
+			i = j
+
+		case (c == 'E' || c == 'e') && i+1 < n && sql[i+1] == '\'':
+			body, next := scanSingleQuoted(sql, i+1)
+			toks = append(toks, token{kind: tkString, text: body, escaped: true})
+			i = next
+
+		case c == '\'':
+			body, next := scanSingleQuoted(sql, i)
+			toks = append(toks, token{kind: tkString, text: body})
+			i = next
+
+		case c == '"':
+			j := i + 1
+			for j < n {
+				if sql[j] == '"' {
+					if j+1 < n && sql[j+1] == '"' {
+						j += 2
+						continue
+					}
+					j++
+					break
+				}
+				j++
+			}
+			toks = append(toks, token{kind: tkQuotedName, text: sql[i:j]})
+			i = j
+
+		case c == '$':
+			if tag, end, ok := scanDollarQuote(sql, i); ok {
+				toks = append(toks, token{kind: tkDollarStr, text: tag})
+				i = end
+				continue
+			}
+			if i+1 < n && isDigit(sql[i+1]) {
+				j := i + 1
+				num := 0
+				for j < n && isDigit(sql[j]) {
+					num = num*10 + int(sql[j]-'0')
+					j++
+				}
+				toks = append(toks, token{kind: tkParam, text: sql[i:j], num: num})
+				i = j
+				continue
+			}
+			toks = append(toks, token{kind: tkPunct, text: "$"})
+			i++
+
+		case isIdentStart(c):
+			j := i
+			for j < n && isIdentPart(sql[j]) {
+				j++
+			}
+			toks = append(toks, token{kind: tkWord, text: sql[i:j]})
+			i = j
+
+		case isDigit(c) || (c == '.' && i+1 < n && isDigit(sql[i+1])):
+			j := i
+			for j < n && (isDigit(sql[j]) || sql[j] == '.') {
+				j++
+			}
+			toks = append(toks, token{kind: tkNumber, text: sql[i:j]})
+			i = j
+
+		default:
+			matched := false
+			for _, op := range multiCharOperators {
+				if strings.HasPrefix(sql[i:], op) {
+					toks = append(toks, token{kind: tkPunct, text: op})
+					i += len(op)
+					matched = true
+					break
+				}
+			}
+			if !matched {
+				toks = append(toks, token{kind: tkPunct, text: string(c)})
+				i++
+			}
+		}
+	}
+
+	return toks
+}
+
+// scanSingleQuoted는 start에서 시작하는 '...' 리터럴을 읽어 양쪽 따옴표를
+// 포함한 구간을 돌려준다. 인정하는 이스케이프는 작은따옴표 두 개뿐이며, 이는
+// standard_conforming_strings가 켜진 Postgres와 일치한다. 그쪽에서 백슬래시는
+// 평범한 문자이고, MySQL 계열용으로는 나중에 다시 이스케이프한다.
+func scanSingleQuoted(sql string, start int) (string, int) {
+	n := len(sql)
+	j := start + 1
+	for j < n {
+		if sql[j] == '\\' {
+			// E'' 리터럴 안에서만 의미가 있지만, 평범한 리터럴에서 다음
+			// 바이트를 건너뛰어도 무해하다. 닫는 따옴표 앞의 홀로 있는
+			// 백슬래시는 어느 엔진에서도 올바른 SQL이 아니다.
+			j += 2
+			continue
+		}
+		if sql[j] == '\'' {
+			if j+1 < n && sql[j+1] == '\'' {
+				j += 2
+				continue
+			}
+			j++
+			break
+		}
+		j++
+	}
+	if j > n {
+		j = n
+	}
+	return sql[start:j], j
+}
+
+// scanDollarQuote는 $$...$$와 $tag$...$tag$ 본문(PL/pgSQL DO 블록)을 인식한다.
+// 재작성기가 통째로 불투명하게 다루도록 구간 전체를 돌려준다.
+func scanDollarQuote(sql string, start int) (string, int, bool) {
+	n := len(sql)
+	j := start + 1
+	for j < n && isIdentPart(sql[j]) && sql[j] != '$' {
+		j++
+	}
+	if j >= n || sql[j] != '$' {
+		return "", 0, false
+	}
+	tag := sql[start : j+1]
+	end := strings.Index(sql[j+1:], tag)
+	if end < 0 {
+		return sql[start:], n, true
+	}
+	stop := j + 1 + end + len(tag)
+	return sql[start:stop], stop, true
+}

--- a/api/internal/database/dialect/mysql_test.go
+++ b/api/internal/database/dialect/mysql_test.go
@@ -1,0 +1,194 @@
+package dialect
+
+import (
+	"strings"
+	"testing"
+)
+
+// withFlavor는 주어진 서버 플레이버로 fn을 실행하고 이전 값을 되돌린다. 재작성
+// 규칙이 프로세스 전역 active dialect를 읽으므로, 플레이버는 인자로 넘기는 게
+// 아니라 설정해야 한다.
+func withFlavor(t *testing.T, k Kind, fn func()) {
+	t.Helper()
+	previous := Active()
+	SetActive(k)
+	defer SetActive(previous)
+	fn()
+}
+
+func TestMySQLStripsUnsupportedIfExists(t *testing.T) {
+	// MySQL은 이 스키마가 IF NOT EXISTS를 쓰는 자리 중 CREATE TABLE에서만
+	// 받아준다. 절을 제거하면 재실행 시 중복 객체 오류가 나는데, 마이그레이션
+	// 러너가 그것을 성공으로 인식한다. IsAlreadyApplied 참고.
+	tests := []struct{ name, in, want string }{
+		{
+			"CREATE INDEX loses the clause",
+			`CREATE INDEX IF NOT EXISTS idx_a ON t (a)`,
+			`CREATE INDEX idx_a ON t (a)`,
+		},
+		{
+			"ADD COLUMN loses the clause",
+			`ALTER TABLE t ADD COLUMN IF NOT EXISTS c INT DEFAULT 0`,
+			`ALTER TABLE t ADD COLUMN c INT DEFAULT 0`,
+		},
+		{
+			"FOREIGN KEY loses the clause",
+			`ALTER TABLE t ADD CONSTRAINT fk FOREIGN KEY IF NOT EXISTS (a) REFERENCES u(id) ON DELETE CASCADE`,
+			`ALTER TABLE t ADD CONSTRAINT fk FOREIGN KEY (a) REFERENCES u(id) ON DELETE CASCADE`,
+		},
+		{
+			"DROP INDEX loses the clause",
+			`ALTER TABLE t DROP INDEX IF EXISTS idx_a`,
+			`ALTER TABLE t DROP INDEX idx_a`,
+		},
+		{
+			"CREATE TABLE keeps it",
+			`CREATE TABLE IF NOT EXISTS t (a INT)`,
+			`CREATE TABLE IF NOT EXISTS t (a INT)`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			withFlavor(t, MySQL, func() {
+				got, _ := mustTranslate(t, tc.in)
+				if got != tc.want {
+					t.Errorf("\n got %q\nwant %q", got, tc.want)
+				}
+			})
+			withFlavor(t, MariaDB, func() {
+				// MariaDB는 전부 지원한다. 아무것도 바뀌면 안 된다.
+				got, _ := mustTranslate(t, tc.in)
+				if got != normalise(tc.in) {
+					t.Errorf("MariaDB statement was altered:\n got %q\nwant %q", got, normalise(tc.in))
+				}
+			})
+		})
+	}
+}
+
+func TestMySQLCompressionSyntax(t *testing.T) {
+	in := `CREATE TABLE IF NOT EXISTS logs (a TEXT) ENGINE=InnoDB PAGE_COMPRESSED=1 PAGE_COMPRESSION_LEVEL=1`
+
+	withFlavor(t, MySQL, func() {
+		got, _ := mustTranslate(t, in)
+		want := `CREATE TABLE IF NOT EXISTS logs (a TEXT) ENGINE=InnoDB COMPRESSION='zlib'`
+		if got != want {
+			t.Errorf("\n got %q\nwant %q", got, want)
+		}
+	})
+	withFlavor(t, MariaDB, func() {
+		got, _ := mustTranslate(t, in)
+		if !strings.Contains(got, "PAGE_COMPRESSED=1") {
+			t.Errorf("MariaDB lost its own compression attributes: %s", got)
+		}
+	})
+}
+
+func TestMySQLEmulatesInsertReturning(t *testing.T) {
+	// MySQL에는 RETURNING이 아예 없다. 행의 키를 드라이버가 만들어 명시적으로
+	// 삽입하는 것이 그 행을 다시 찾는 유일한 방법이다.
+	withFlavor(t, MySQL, func() {
+		write, read, writeOrder, readOrder := mustSplit(t,
+			`INSERT INTO access_lists (name, description) VALUES ($1, $2) RETURNING id, name`)
+
+		wantWrite := `INSERT INTO access_lists (name, description, id) VALUES (?, ?, ?)`
+		if write != wantWrite {
+			t.Errorf("write:\n got %q\nwant %q", write, wantWrite)
+		}
+		if want := `SELECT id, name FROM access_lists WHERE id = ?`; read != want {
+			t.Errorf("read:\n got %q\nwant %q", read, want)
+		}
+
+		// 쓰기의 세 번째 슬롯과 읽기의 유일한 슬롯을 드라이버가 같은 생성 값으로
+		// 채운다.
+		if len(writeOrder) != 3 || writeOrder[2] != ArgSynthesisedUUID {
+			t.Errorf("write argOrder = %v, want the third slot synthesised", writeOrder)
+		}
+		if len(readOrder) != 1 || readOrder[0] != ArgSynthesisedUUID {
+			t.Errorf("read argOrder = %v, want a synthesised slot", readOrder)
+		}
+	})
+
+	// MariaDB는 INSERT ... RETURNING을 지원하므로 건드리면 안 된다.
+	withFlavor(t, MariaDB, func() {
+		got, err := Translate(`INSERT INTO access_lists (name) VALUES ($1) RETURNING id`)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.FollowUp != nil {
+			t.Error("MariaDB should run INSERT ... RETURNING natively")
+		}
+	})
+}
+
+func TestMySQLInsertReturningKeepsACallerSuppliedKey(t *testing.T) {
+	// 호출자가 이미 키를 준 경우에는 합성할 것이 없다. 재조회는 호출자가
+	// 바인딩한 값을 키로 쓴다.
+	withFlavor(t, MySQL, func() {
+		write, read, _, readOrder := mustSplit(t,
+			`INSERT INTO access_lists (id, name) VALUES ($1, $2) RETURNING id, name`)
+
+		if want := `INSERT INTO access_lists (id, name) VALUES (?, ?)`; write != want {
+			t.Errorf("write:\n got %q\nwant %q", write, want)
+		}
+		if want := `SELECT id, name FROM access_lists WHERE id = ?`; read != want {
+			t.Errorf("read:\n got %q\nwant %q", read, want)
+		}
+		if len(readOrder) != 1 || readOrder[0] != 0 {
+			t.Errorf("read argOrder = %v, want [0]", readOrder)
+		}
+	})
+}
+
+func TestMySQLEmulatesDeleteReturning(t *testing.T) {
+	// UPDATE와 달리 나중에 다시 조회할 것이 없으므로, SELECT를 먼저 실행하고
+	// 드라이버가 그 행들을 들고 있어야 한다.
+	withFlavor(t, MySQL, func() {
+		got, err := Translate(`DELETE FROM sso_login_states WHERE state = $1 RETURNING provider_id, nonce`)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.FollowUp == nil {
+			t.Fatal("expected DELETE ... RETURNING to be split")
+		}
+		if !got.FollowUpFirst {
+			t.Error("the SELECT must run before the DELETE")
+		}
+		if want := `DELETE FROM sso_login_states WHERE state = ?`; normalise(got.SQL) != want {
+			t.Errorf("write:\n got %q\nwant %q", normalise(got.SQL), want)
+		}
+		if want := `SELECT provider_id, nonce FROM sso_login_states WHERE state = ?`; normalise(got.FollowUp.SQL) != want {
+			t.Errorf("read:\n got %q\nwant %q", normalise(got.FollowUp.SQL), want)
+		}
+	})
+
+	withFlavor(t, MariaDB, func() {
+		got, err := Translate(`DELETE FROM t WHERE a = $1 RETURNING id`)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.FollowUp != nil {
+			t.Error("MariaDB should run DELETE ... RETURNING natively")
+		}
+	})
+}
+
+func TestMySQLRefusesUnboundedDeleteReturning(t *testing.T) {
+	withFlavor(t, MySQL, func() {
+		if _, err := Translate(`DELETE FROM t RETURNING id`); err == nil {
+			t.Fatal("expected a DELETE ... RETURNING with no WHERE to be refused")
+		}
+	})
+}
+
+func TestDetectFlavorReadsTheServerVersion(t *testing.T) {
+	// URL 스킴은 선언이 아니라 습관이다. MariaDB를 가리키는 mysql:// URL도
+	// 여전히 MariaDB로 다뤄져야 한다.
+	if got := Detect("mysql://u:p@db/npg"); got != MariaDB {
+		t.Errorf("Detect chose %q; the scheme should only select the driver", got)
+	}
+	if !MySQL.IsMySQLFamily() || !MariaDB.IsMySQLFamily() || Postgres.IsMySQLFamily() {
+		t.Error("IsMySQLFamily misclassifies a backend")
+	}
+}

--- a/api/internal/database/dialect/mysqlddl.go
+++ b/api/internal/database/dialect/mysqlddl.go
@@ -1,0 +1,131 @@
+package dialect
+
+import "strings"
+
+// MySQL에만 적용하는 DDL 재작성.
+//
+// MariaDB는 MySQL이 받아주지 않는 편의 문법 몇 가지를 허용하고, 생성된 스키마는
+// 그것들을 쓴다. 마이그레이션 파일을 멱등하고 재실행 가능하게 만들어 주는 게
+// 바로 그 문법들이기 때문이다. 1600줄짜리 스키마를 두 벌 유지하는 대신, 같은
+// 파일을 MySQL로 보내는 길에 재작성하고, 그 결과로 나오는 "이미 존재함" 오류는
+// 마이그레이션 러너가 정상으로 취급한다. dialect.IsAlreadyApplied 참고.
+
+// ddlIfExistsKeepers는 MySQL이 IF [NOT] EXISTS 절을 허용하는 문장들이다.
+// 나머지에서는 이 절을 제거한다.
+//
+// 문장을 여는 두 단어를 키로 쓴다. `CREATE TABLE IF NOT EXISTS`(허용)와
+// `CREATE INDEX IF NOT EXISTS`(거부)를 가르는 게 바로 그 두 단어이기 때문이다.
+var ddlIfExistsKeepers = map[[2]string]bool{
+	{"CREATE", "TABLE"}:    true,
+	{"DROP", "TABLE"}:      true,
+	{"CREATE", "DATABASE"}: true,
+	{"DROP", "DATABASE"}:   true,
+	{"CREATE", "SCHEMA"}:   true,
+	{"DROP", "SCHEMA"}:     true,
+	{"DROP", "VIEW"}:       true,
+}
+
+// stripUnsupportedIfExists는 MySQL이 거부하는 IF NOT EXISTS / IF EXISTS 절을
+// 제거한다. CREATE INDEX, ADD COLUMN, ADD ... FOREIGN KEY, DROP INDEX가 대상이다.
+//
+// 이 절이 문장을 재실행 가능하게 만들어 주므로, 제거하면 두 번째 실행이
+// no-op이 아니라 중복 객체 오류가 된다. 마이그레이션 러너가 그 오류들을 성공으로
+// 분류하는 이유다.
+func stripUnsupportedIfExists(toks []token) []token {
+	if keepsIfExists(toks) {
+		return toks
+	}
+
+	for i := 0; i < len(toks); i++ {
+		if !isWord(toks[i], "IF") {
+			continue
+		}
+		next := nextCode(toks, i+1)
+		if next < 0 {
+			continue
+		}
+
+		last := -1
+		if isWord(toks[next], "NOT") {
+			if e := nextCode(toks, next+1); e >= 0 && isWord(toks[e], "EXISTS") {
+				last = e
+			}
+		} else if isWord(toks[next], "EXISTS") {
+			// `IF EXISTS (SELECT ...)`는 DDL 절이 아니라 술어다.
+			if p := nextCode(toks, next+1); p >= 0 && isPunct(toks[p], "(") {
+				continue
+			}
+			last = next
+		}
+		if last < 0 {
+			continue
+		}
+
+		toks = splice(toks, i, last, nil)
+		i--
+	}
+	return toks
+}
+
+// keepsIfExists는 이 문장의 선두 키워드가 MySQL이 해당 절을 허용하는 형태인지
+// 판별한다.
+func keepsIfExists(toks []token) bool {
+	first := nextCode(toks, 0)
+	if first < 0 || toks[first].kind != tkWord {
+		return false
+	}
+	second := nextCode(toks, first+1)
+	if second < 0 || toks[second].kind != tkWord {
+		return false
+	}
+	key := [2]string{
+		strings.ToUpper(toks[first].text),
+		strings.ToUpper(toks[second].text),
+	}
+	return ddlIfExistsKeepers[key]
+}
+
+// rewriteTableCompression은 MariaDB의 페이지 압축 속성을 MySQL 것으로 바꾼다.
+//
+// 하는 일은 같다. 페이지를 압축하고 남는 공간만큼 파일에 hole punch를 한다.
+// 다만 MariaDB는 PAGE_COMPRESSED=1에 zlib 레벨을 따로 적고, MySQL은 레벨 선택
+// 없이 COMPRESSION='zlib'으로 적는다.
+func rewriteTableCompression(toks []token) []token {
+	for i := 0; i < len(toks); i++ {
+		if toks[i].kind != tkWord {
+			continue
+		}
+		switch strings.ToUpper(toks[i].text) {
+		case "PAGE_COMPRESSED":
+			end, ok := assignmentEnd(toks, i)
+			if !ok {
+				continue
+			}
+			toks = splice(toks, i, end, []token{kw("COMPRESSION"), raw("="), str("'zlib'")})
+
+		case "PAGE_COMPRESSION_LEVEL":
+			// MySQL에는 대응하는 설정이 없다. 속성을 그냥 없앤다.
+			end, ok := assignmentEnd(toks, i)
+			if !ok {
+				continue
+			}
+			toks = splice(toks, i, end, nil)
+			i--
+		}
+	}
+	return toks
+}
+
+// assignmentEnd는 name에서 시작하는 `NAME = value` 테이블 옵션에서 값의 인덱스를
+// 돌려준다.
+func assignmentEnd(toks []token, name int) (int, bool) {
+	eq := nextCode(toks, name+1)
+	if eq < 0 || !isPunct(toks[eq], "=") {
+		return 0, false
+	}
+	value := nextCode(toks, eq+1)
+	if value < 0 {
+		return 0, false
+	}
+	return value, true
+}

--- a/api/internal/database/dialect/returning.go
+++ b/api/internal/database/dialect/returning.go
@@ -1,0 +1,518 @@
+package dialect
+
+import (
+	"fmt"
+	"strings"
+)
+
+// MariaDB는 INSERT와 DELETE에는 RETURNING을 지원하지만 UPDATE에는, 그리고
+// ON DUPLICATE KEY UPDATE와 함께 쓰는 경우에는 지원하지 않는다. MySQL은 아예
+// 지원하지 않는다. 이 프로젝트는 그런 형태를 스무 곳 남짓에서 쓰는데, 모두 방금
+// 쓴 행을 다시 읽기 위해서다.
+//
+// 그 호출부들을 갈라내는 대신, 해당 형태의 문장을 둘로 나눈다. 쓰기와, 같은
+// 행을 다시 읽는 SELECT다. 드라이버가 이 쌍을 한 트랜잭션 안에서 실행하고 결과를
+// 버퍼링하므로, 호출자에게는 여전히 행을 돌려주는 질의 하나로 보인다
+// (driver.go 참고).
+//
+// 분할은 동등함이 증명될 때만 시도한다. WHERE 절이 SET 절에서 대입하는 컬럼을
+// 검사하는 UPDATE는 다시 조회할 수 없다. 매칭됐던 행이 더 이상 매칭되지 않기
+// 때문이다. 그런 경우 잘못된 집합을 조용히 돌려주는 대신 거부한다.
+
+// splitPlan은 RETURNING 문장을 수행할 쓰기와 호출자의 행을 만들어 낼 SELECT로
+// 쪼갠 것이다.
+type splitPlan struct {
+	write     []token
+	read      []token
+	readFirst bool
+}
+
+// splitReturning은 문장의 RETURNING 절을 흉내내야 하는지, 그렇다면 어떻게
+// 해야 하는지 정한다. 계획이 nil이면 대상 서버가 자체적으로 처리한다는 뜻이다.
+//
+// 플레이버별 지원 현황:
+//
+//	                          MariaDB   MySQL
+//	INSERT ... RETURNING        yes      no
+//	DELETE ... RETURNING        yes      no
+//	UPDATE ... RETURNING         no      no
+//	upsert  ... RETURNING        no      no
+func splitReturning(toks []token) (*splitPlan, error) {
+	if findTopLevel(toks, "RETURNING") < 0 {
+		return nil, nil
+	}
+	verb := nextCode(toks, 0)
+	if verb < 0 {
+		return nil, nil
+	}
+
+	switch {
+	case isWord(toks[verb], "UPDATE"):
+		return splitUpdateReturning(toks)
+	case isWord(toks[verb], "DELETE"):
+		if targetFlavor() != MySQL {
+			return nil, nil
+		}
+		return splitDeleteReturning(toks)
+	case isWord(toks[verb], "INSERT"):
+		return splitInsertReturning(toks)
+	}
+	return nil, nil
+}
+
+// splitUpdateReturning은
+//
+//	UPDATE t SET a = $1 WHERE id = $2 RETURNING a, b
+//
+// 을 UPDATE와 같은 술어를 쓰는 SELECT로 나눈다.
+//
+// 동등함이 증명될 때만 나눈다. WHERE 절이 SET 절에서 대입하는 컬럼을 검사하는
+// UPDATE는 다시 조회할 수 없으므로, 잘못된 집합을 조용히 돌려주는 대신
+// 거부한다.
+func splitUpdateReturning(toks []token) (*splitPlan, error) {
+	ret := findTopLevel(toks, "RETURNING")
+	where := findTopLevel(toks, "WHERE")
+	if where < 0 || where > ret {
+		return nil, fmt.Errorf(
+			"mariadb: UPDATE ... RETURNING without a WHERE clause cannot be re-selected safely")
+	}
+	set := findTopLevel(toks, "SET")
+	if set < 0 || set > where {
+		return nil, fmt.Errorf("mariadb: malformed UPDATE ... RETURNING")
+	}
+	if from := findTopLevel(toks, "FROM"); from > 0 && from < where {
+		return nil, fmt.Errorf(
+			"mariadb: UPDATE ... FROM ... RETURNING has no single-table re-select")
+	}
+
+	first := nextCode(toks, 0)
+	table := prevCode(toks, set-1)
+	if table < 0 || (toks[table].kind != tkWord && toks[table].kind != tkQuotedName) {
+		return nil, fmt.Errorf("mariadb: cannot identify the table in UPDATE ... RETURNING")
+	}
+	// 별칭(`UPDATE t AS x SET ...`)이 붙으면 재조회가 모호해진다.
+	if table != nextCode(toks, first+1) {
+		return nil, fmt.Errorf("mariadb: aliased UPDATE ... RETURNING is unsupported")
+	}
+
+	assigned := assignedColumns(toks, set, where)
+	for _, name := range referencedColumns(toks, where+1, ret) {
+		if assigned[strings.ToLower(name)] {
+			return nil, fmt.Errorf(
+				"mariadb: UPDATE ... RETURNING whose WHERE tests the updated column %q cannot be re-selected", name)
+		}
+	}
+
+	read := []token{kw("SELECT"), space()}
+	read = append(read, trimNoise(toks[ret+1:])...)
+	read = append(read, space(), kw("FROM"), space(), toks[table], space(), kw("WHERE"), space())
+	read = append(read, trimNoise(toks[where+1:ret])...)
+
+	return &splitPlan{write: append([]token(nil), toks[:ret]...), read: read}, nil
+}
+
+// splitDeleteReturning은 행을 지우기 전에 먼저 읽는다.
+//
+// MySQL에는 DELETE ... RETURNING이 없고, UPDATE와 달리 나중에 다시 조회할 것이
+// 남지 않는다. 그래서 SELECT를 먼저 실행하고, 삭제가 커밋될 때까지 드라이버가
+// 그 행들을 들고 있는다.
+func splitDeleteReturning(toks []token) (*splitPlan, error) {
+	ret := findTopLevel(toks, "RETURNING")
+	from := findTopLevel(toks, "FROM")
+	if from < 0 || from > ret {
+		return nil, fmt.Errorf("mysql: malformed DELETE ... RETURNING")
+	}
+	table := nextCode(toks, from+1)
+	if table < 0 || (toks[table].kind != tkWord && toks[table].kind != tkQuotedName) {
+		return nil, fmt.Errorf("mysql: cannot identify the table in DELETE ... RETURNING")
+	}
+	where := findTopLevel(toks, "WHERE")
+	if where < 0 || where > ret {
+		return nil, fmt.Errorf(
+			"mysql: DELETE ... RETURNING without a WHERE clause is refused; it would read the whole table")
+	}
+
+	read := []token{kw("SELECT"), space()}
+	read = append(read, trimNoise(toks[ret+1:])...)
+	read = append(read, space(), kw("FROM"), space(), toks[table], space(), kw("WHERE"), space())
+	read = append(read, trimNoise(toks[where+1:ret])...)
+
+	return &splitPlan{
+		write:     append([]token(nil), toks[:ret]...),
+		read:      read,
+		readFirst: true,
+	}, nil
+}
+
+// splitInsertReturning은 행을 돌려주는 INSERT를, 그 INSERT와 방금 쓴 행을 키로
+// 조회하는 SELECT로 나눈다.
+//
+// 여기에 도달하는 형태는 셋이다.
+//
+//   - 업서트. 어느 플레이버든 RETURNING과 ON DUPLICATE KEY UPDATE를 함께 쓸 수
+//     없기 때문이다. 충돌 대상은 유니크 키이므로, 거기 넣은 값이 문장이
+//     삽입했든 갱신했든 그 행을 특정해 준다.
+//   - MySQL에서의 평범한 INSERT. MySQL에는 RETURNING이 아예 없다. 키는 첫
+//     번째로 돌려주는 컬럼이다. 호출자가 그 값을 주지 않았다면 — 스키마가
+//     UUID()를 기본값으로 두고 있어 보통 그렇다 — 드라이버가 하나 만들어
+//     명시적으로 삽입하고, 재조회가 그것을 키로 삼는다.
+//   - MariaDB에서의 평범한 INSERT. 자체 지원하므로 계획을 만들지 않는다.
+func splitInsertReturning(toks []token) (*splitPlan, error) {
+	ret := findTopLevel(toks, "RETURNING")
+	conflict := findConflictClause(toks)
+	if conflict < 0 && targetFlavor() != MySQL {
+		return nil, nil
+	}
+
+	first := nextCode(toks, 0)
+	table := nextCode(toks, nextCode(toks, first+1)+1) // INSERT INTO <table>
+	if table < 0 || (toks[table].kind != tkWord && toks[table].kind != tkQuotedName) {
+		return nil, fmt.Errorf("mariadb: cannot identify the table in INSERT ... RETURNING")
+	}
+
+	columns, values, listEnd, err := insertColumnsAndValues(toks, table)
+	if err != nil {
+		return nil, err
+	}
+
+	var targets []conflictTarget
+	if conflict >= 0 {
+		targets, err = conflictTargetColumns(toks, conflict)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		// 키는 문장이 첫 번째로 돌려주는 것이다. 이 스키마에서는 전부 `id`다.
+		returned := trimNoise(splitTopLevel(toks[ret+1:])[0])
+		if len(returned) != 1 || (returned[0].kind != tkWord && returned[0].kind != tkQuotedName) {
+			return nil, fmt.Errorf(
+				"mysql: INSERT ... RETURNING must return a plain key column first for the row to be re-selected")
+		}
+		targets = []conflictTarget{{
+			column:  strings.Trim(returned[0].text, `"`),
+			compare: compareEqual,
+		}}
+	}
+
+	write := append([]token(nil), toks[:ret]...)
+
+	var predicate []token
+	for _, target := range targets {
+		idx := -1
+		for i, name := range columns {
+			if strings.EqualFold(name, target.column) {
+				idx = i
+				break
+			}
+		}
+
+		var value []token
+		switch {
+		case idx >= 0 && idx < len(values):
+			value = values[idx]
+		case conflict >= 0:
+			return nil, fmt.Errorf(
+				"mariadb: conflict target %q is not in the INSERT column list, so the written row cannot be re-selected", target.column)
+		default:
+			// 호출자가 주지 않았다. 드라이버가 만들게 하고, 서버가 정확히 그
+			// 값을 저장하도록 INSERT에 추가한다.
+			write = addSynthesisedColumn(write, listEnd, target.column)
+			value = []token{{kind: tkSynth}}
+		}
+
+		if len(predicate) > 0 {
+			predicate = append(predicate, space(), kw("AND"), space())
+		}
+		predicate = append(predicate, target.compare(kw(target.column), value)...)
+	}
+
+	read := []token{kw("SELECT"), space()}
+	read = append(read, trimNoise(toks[ret+1:])...)
+	read = append(read, space(), kw("FROM"), space(), toks[table], space(), kw("WHERE"), space())
+	read = append(read, predicate...)
+
+	return &splitPlan{write: write, read: read}, nil
+}
+
+// addSynthesisedColumn은 INSERT 컬럼 목록에 `, <컬럼>`을, VALUES 목록에 대응하는
+// 드라이버 제공 값을 덧붙인다.
+//
+// listEnd가 두 닫는 괄호의 위치를 들고 있어 다시 파싱하지 않고 양쪽을 늘릴 수
+// 있다. 값 목록을 먼저 편집해서 앞쪽 인덱스가 유효하게 남도록 한다.
+func addSynthesisedColumn(toks []token, listEnd insertListEnds, column string) []token {
+	toks = splice(toks, listEnd.values, listEnd.values,
+		[]token{raw(","), space(), {kind: tkSynth}, raw(")")})
+	return splice(toks, listEnd.columns, listEnd.columns,
+		[]token{raw(","), space(), kw(column), raw(")")})
+}
+
+// ---------------------------------------------------------------------------
+// 헬퍼
+// ---------------------------------------------------------------------------
+
+// findTopLevel은 괄호 바깥에서 word가 처음 나타나는 인덱스를 돌려준다.
+// 없으면 -1.
+func findTopLevel(toks []token, word string) int {
+	depth := 0
+	for i, t := range toks {
+		switch {
+		case isPunct(t, "("):
+			depth++
+		case isPunct(t, ")"):
+			depth--
+		case depth == 0 && isWord(t, word):
+			return i
+		}
+	}
+	return -1
+}
+
+// findConflictClause는 `ON CONFLICT`의 ON 인덱스를 돌려준다. 없으면 -1.
+func findConflictClause(toks []token) int {
+	depth := 0
+	for i, t := range toks {
+		switch {
+		case isPunct(t, "("):
+			depth++
+		case isPunct(t, ")"):
+			depth--
+		case depth == 0 && isWord(t, "ON"):
+			if j := nextCode(toks, i+1); j >= 0 && isWord(toks[j], "CONFLICT") {
+				return i
+			}
+		}
+	}
+	return -1
+}
+
+// assignedColumns는 SET부터 SET 절 끝까지의 모든 대입에서 좌변을 모은다.
+func assignedColumns(toks []token, set, end int) map[string]bool {
+	out := map[string]bool{}
+	depth := 0
+	expectTarget := true
+	for i := set + 1; i < end; i++ {
+		switch {
+		case isPunct(toks[i], "("):
+			depth++
+		case isPunct(toks[i], ")"):
+			depth--
+		case depth == 0 && isPunct(toks[i], ","):
+			expectTarget = true
+		case depth == 0 && expectTarget && (toks[i].kind == tkWord || toks[i].kind == tkQuotedName):
+			out[strings.ToLower(strings.Trim(toks[i].text, `"`))] = true
+			expectTarget = false
+		}
+	}
+	return out
+}
+
+// 술어가 읽는 컬럼 이름을 모을 때 건너뛸 키워드들. 덕분에
+// `WHERE status = 'pending' AND expires_at IS NOT NULL`에서 컬럼 이름 두 개만
+// 나온다.
+var sqlKeywords = map[string]bool{
+	"and": true, "or": true, "not": true, "is": true, "null": true, "in": true,
+	"like": true, "ilike": true, "between": true, "exists": true, "any": true,
+	"all": true, "true": true, "false": true, "case": true, "when": true,
+	"then": true, "else": true, "end": true, "select": true, "from": true,
+	"where": true, "as": true, "distinct": true, "collate": true, "escape": true,
+}
+
+// referencedColumns는 구간이 읽는 식별자들을 나열한다. 키워드와 함수 이름은
+// 무시한다.
+func referencedColumns(toks []token, from, to int) []string {
+	var out []string
+	for i := from; i < to && i < len(toks); i++ {
+		t := toks[i]
+		if t.kind != tkWord && t.kind != tkQuotedName {
+			continue
+		}
+		name := strings.Trim(t.text, `"`)
+		if sqlKeywords[strings.ToLower(name)] {
+			continue
+		}
+		// 뒤에 '('가 오는 이름은 컬럼이 아니라 함수 호출이다.
+		if n := nextCode(toks, i+1); n >= 0 && isPunct(toks[n], "(") {
+			continue
+		}
+		out = append(out, name)
+	}
+	return out
+}
+
+// insertListEnds는 INSERT의 두 괄호 목록을 각각 닫는 ')'의 인덱스를 기록한다.
+type insertListEnds struct {
+	columns int
+	values  int
+}
+
+// insertColumnsAndValues는 `INSERT INTO t (a, b) VALUES ($1, $2)`를 분해한다.
+func insertColumnsAndValues(toks []token, table int) ([]string, [][]token, insertListEnds, error) {
+	var ends insertListEnds
+
+	open := nextCode(toks, table+1)
+	if open < 0 || !isPunct(toks[open], "(") {
+		return nil, nil, ends, fmt.Errorf("mariadb: INSERT ... RETURNING without an explicit column list cannot be re-selected")
+	}
+	close := matchOpen(toks, open)
+	if close < 0 {
+		return nil, nil, ends, fmt.Errorf("mariadb: unbalanced INSERT column list")
+	}
+	ends.columns = close
+
+	var columns []string
+	for _, group := range splitTopLevel(toks[open+1 : close]) {
+		g := trimNoise(group)
+		if len(g) != 1 || (g[0].kind != tkWord && g[0].kind != tkQuotedName) {
+			return nil, nil, ends, fmt.Errorf("mariadb: unexpected INSERT column list entry")
+		}
+		columns = append(columns, strings.Trim(g[0].text, `"`))
+	}
+
+	valuesKw := nextCode(toks, close+1)
+	if valuesKw < 0 || !isWord(toks[valuesKw], "VALUES") {
+		return nil, nil, ends, fmt.Errorf("mariadb: INSERT ... SELECT ... RETURNING cannot be re-selected")
+	}
+	vopen := nextCode(toks, valuesKw+1)
+	if vopen < 0 || !isPunct(toks[vopen], "(") {
+		return nil, nil, ends, fmt.Errorf("mariadb: malformed VALUES clause")
+	}
+	vclose := matchOpen(toks, vopen)
+	if vclose < 0 {
+		return nil, nil, ends, fmt.Errorf("mariadb: unbalanced VALUES clause")
+	}
+	// 다중 행 VALUES 목록은 여러 행을 쓰므로 단일 행 재조회는 틀린 결과가
+	// 된다.
+	if n := nextCode(toks, vclose+1); n >= 0 && isPunct(toks[n], ",") {
+		return nil, nil, ends, fmt.Errorf("mariadb: multi-row INSERT ... RETURNING cannot be re-selected")
+	}
+
+	var values [][]token
+	for _, group := range splitTopLevel(toks[vopen+1 : vclose]) {
+		values = append(values, trimNoise(group))
+	}
+	if len(values) != len(columns) {
+		return nil, nil, ends, fmt.Errorf("mariadb: INSERT column and value counts differ")
+	}
+	ends.values = vclose
+	return columns, values, ends, nil
+}
+
+// conflictTarget은 ON CONFLICT 대상 목록의 한 항목이며, 그 컬럼을 INSERT가
+// 바인딩한 값과 어떻게 비교할지도 함께 담는다.
+type conflictTarget struct {
+	column  string
+	compare func(column token, value []token) []token
+}
+
+func compareEqual(column token, value []token) []token {
+	out := []token{column, space(), raw("="), space()}
+	return append(out, value...)
+}
+
+// compareCoalesced는 PostgreSQL의 COALESCE(col, 빈 문자열) 식 인덱스와 맞춘다.
+// NULL과 빈 문자열이 같은 키이므로 비교에서도 양쪽을 함께 접어야 한다.
+func compareCoalesced(column token, value []token) []token {
+	out := []token{kw("COALESCE"), raw("("), column, raw(","), space(), str("''"), raw(")"),
+		space(), raw("="), space(), kw("COALESCE"), raw("(")}
+	out = append(out, value...)
+	return append(out, raw(","), space(), str("''"), raw(")"))
+}
+
+// compareLowered는 `lower(col)` 식 인덱스와 맞춘다.
+func compareLowered(column token, value []token) []token {
+	out := []token{kw("LOWER"), raw("("), column, raw(")"), space(), raw("="), space(), kw("LOWER"), raw("(")}
+	out = append(out, value...)
+	return append(out, raw(")"))
+}
+
+// conflictTargetColumns는 `ON CONFLICT (a, b)`를 읽는다. 이 스키마가 대소문자
+// 무시 및 NULL 접기 유니크 인덱스에 쓰는 식 형태도 함께 처리한다. 대상 엔진은
+// 둘 다 생성 컬럼으로 재현하므로 업서트 자체에는 대상이 필요 없지만, 재조회는
+// 어느 행이 쓰였는지 알아야 한다.
+func conflictTargetColumns(toks []token, conflict int) ([]conflictTarget, error) {
+	open := nextCode(toks, nextCode(toks, conflict+1)+1)
+	if open < 0 || !isPunct(toks[open], "(") {
+		return nil, fmt.Errorf("mariadb: ON CONFLICT without a column target cannot be re-selected")
+	}
+	close := matchOpen(toks, open)
+	if close < 0 {
+		return nil, fmt.Errorf("mariadb: unbalanced ON CONFLICT target")
+	}
+
+	var out []conflictTarget
+	for _, group := range splitTopLevel(toks[open+1 : close]) {
+		target, err := parseConflictTarget(trimNoise(group))
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, target)
+	}
+	return out, nil
+}
+
+func parseConflictTarget(g []token) (conflictTarget, error) {
+	if len(g) == 1 && (g[0].kind == tkWord || g[0].kind == tkQuotedName) {
+		return conflictTarget{column: strings.Trim(g[0].text, `"`), compare: compareEqual}, nil
+	}
+
+	if len(g) > 1 && g[0].kind == tkWord {
+		fn := strings.ToLower(g[0].text)
+		if column, ok := soleIdentifierArgument(g); ok {
+			switch fn {
+			case "coalesce":
+				return conflictTarget{column: column, compare: compareCoalesced}, nil
+			case "lower":
+				return conflictTarget{column: column, compare: compareLowered}, nil
+			}
+		}
+	}
+
+	return conflictTarget{}, fmt.Errorf("mariadb: unsupported ON CONFLICT target expression")
+}
+
+// soleIdentifierArgument는 감싸는 호출에서 컬럼 이름 하나를 꺼낸다. pg_dump가
+// 내보내는 불필요한 괄호와 캐스트를 허용한다. `lower((name)::text)`가 가리키는
+// 컬럼은 `name`이다.
+func soleIdentifierArgument(g []token) (string, bool) {
+	var names []string
+	for _, t := range g[1:] {
+		switch t.kind {
+		case tkWord, tkQuotedName:
+			name := strings.Trim(t.text, `"`)
+			// `::` 뒤에 오는 캐스트 타입 이름은 컬럼이 아니다.
+			if sqlKeywords[strings.ToLower(name)] {
+				continue
+			}
+			names = append(names, name)
+		case tkString, tkNumber, tkPunct, tkSpace, tkComment:
+		default:
+			return "", false
+		}
+	}
+	// 캐스트는 타입 이름을 남긴다. 컬럼은 첫 번째 식별자다.
+	if len(names) == 0 {
+		return "", false
+	}
+	return names[0], true
+}
+
+// splitTopLevel은 괄호 안에 있지 않은 쉼표를 기준으로 토큰 구간을 나눈다.
+func splitTopLevel(toks []token) [][]token {
+	var out [][]token
+	depth, start := 0, 0
+	for i, t := range toks {
+		switch {
+		case isPunct(t, "("):
+			depth++
+		case isPunct(t, ")"):
+			depth--
+		case depth == 0 && isPunct(t, ","):
+			out = append(out, toks[start:i])
+			start = i + 1
+		}
+	}
+	if start <= len(toks) {
+		out = append(out, toks[start:])
+	}
+	return out
+}

--- a/api/internal/database/dialect/split.go
+++ b/api/internal/database/dialect/split.go
@@ -1,0 +1,58 @@
+package dialect
+
+import "strings"
+
+// SplitStatements는 SQL 스크립트를 최상위 세미콜론 기준으로 개별 문장으로 나눈다.
+// 문자열 리터럴, 주석, 달러 인용 블록, 괄호 안의 세미콜론은 무시한다.
+//
+// MySQL 계열 경로에 이 함수가 필요한 이유는 두 가지다. 번역기가 한 번에 한
+// 문장씩만 다루고(ON CONFLICT와 RETURNING 규칙이 단일 문장의 형태를 전제로
+// 한다), 서비스용 커넥션은 의도적으로 다중 문장 질의를 켜두지 않기 때문이다.
+// 서버에 맡기지 않고 Go에서 나누면 두 성질이 모두 유지된다.
+//
+// 빈 문장(`;;`이나 끝에 남은 세미콜론)은 버린다.
+func SplitStatements(script string) []string {
+	toks := lex(script)
+
+	var (
+		out     []string
+		current strings.Builder
+		depth   int
+		hasCode bool
+	)
+
+	// 주석만 들어 있는 덩어리는 문장이 아니므로 서버로 보내면 안 된다.
+	// 생성된 마이그레이션 파일에는 "-- skipped (...)" 메모가 잔뜩 들어 있다.
+	flush := func() {
+		if s := strings.TrimSpace(current.String()); s != "" && hasCode {
+			out = append(out, s)
+		}
+		current.Reset()
+		hasCode = false
+	}
+
+	for _, t := range toks {
+		if t.kind != tkSpace && t.kind != tkComment {
+			hasCode = true
+		}
+		if t.kind == tkPunct {
+			switch t.text {
+			case "(":
+				depth++
+			case ")":
+				if depth > 0 {
+					depth--
+				}
+			case ";":
+				if depth == 0 {
+					flush()
+					continue
+				}
+			}
+		}
+		current.WriteString(t.text)
+	}
+	flush()
+
+	return out
+}

--- a/api/internal/database/dialect/translate.go
+++ b/api/internal/database/dialect/translate.go
@@ -1,0 +1,1044 @@
+package dialect
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// Statement는 번역이 끝나 드라이버에 넘길 준비가 된 문장이다.
+//
+// ArgOrder는 방출된 각 `?`를 호출자의 인자 슬라이스로 되짚어 준다. ArgOrder[i]는
+// i번째 자리에 들어갈 인자의 0 기반 인덱스다. Postgres 플레이스홀더는 순번으로
+// 이름 붙고 반복되거나 순서가 뒤바뀔 수 있지만, MySQL 것은 철저히 위치 기반이라
+// 인자를 다시 배열해야 한다. ArgOrder가 nil이면 인자를 그대로 넘긴다는 뜻이다.
+//
+// FollowUp이 설정돼 있으면, 호출자가 요청한 행을 만들어 내기 위해 드라이버가
+// SQL 직후에 실행해야 하는 SELECT다. MariaDB가 UPDATE에도, ON DUPLICATE KEY
+// UPDATE 업서트에도 RETURNING을 지원하지 않기 때문에 필요하다. returning.go 참고.
+type Statement struct {
+	SQL      string
+	ArgOrder []int
+	FollowUp *Statement
+	// FollowUpFirst는 FollowUp을 SQL보다 *먼저* 실행해야 함을 뜻한다.
+	// DELETE ... RETURNING이 그런 경우로, 쓰기가 끝나면 행이 사라진다.
+	FollowUpFirst bool
+}
+
+// ArgSynthesisedUUID는 호출자의 인자가 아니라 드라이버가 직접 만든 UUID로 채울
+// ArgOrder 슬롯을 표시한다. 실행 한 번당 UUID 하나를 만들어 이 표시가 붙은 모든
+// 슬롯에 쓰며, 덕분에 쓰기와 재조회가 같은 행을 두고 합의할 수 있다.
+const ArgSynthesisedUUID = -1
+
+// Translate는 PostgreSQL 문장 하나를 대상 엔진의 대응 문장으로 재작성한다.
+//
+// 충실한 대응물이 없는 구문은 최선을 다한 재작성 대신 오류를 돌려준다. 실행은
+// 되지만 의미가 조금 다른 SQL을 조용히 만들어 내는 것이야말로 이 계층이 절대
+// 저지르면 안 되는 실패 방식이다. 오류를 받은 호출자는 개발 중에 즉시 알아채지만,
+// 미묘하게 잘못된 번역은 몇 달 뒤 대시보드 숫자가 망가진 형태로 드러난다.
+// 프로젝트가 실제로 쓰는 그런 구문은 전부 호출부에서 Kind로 분기해 처리한다.
+// 이 오류는 나머지를 막는 최후의 방어선이다.
+func Translate(query string) (*Statement, error) {
+	toks := lex(query)
+
+	if err := rejectUntranslatable(toks); err != nil {
+		return nil, err
+	}
+
+	plan, err := splitReturning(toks)
+	if err != nil {
+		return nil, err
+	}
+	if plan != nil {
+		write, err := translateTokens(plan.write)
+		if err != nil {
+			return nil, err
+		}
+		read, err := translateTokens(plan.read)
+		if err != nil {
+			return nil, err
+		}
+		write.FollowUp = read
+		write.FollowUpFirst = plan.readFirst
+		return write, nil
+	}
+
+	return translateTokens(toks)
+}
+
+// translateTokens는 한 문장의 토큰에 재작성 파이프라인을 적용한다.
+func translateTokens(toks []token) (*Statement, error) {
+	if targetFlavor() == MySQL {
+		toks = stripUnsupportedIfExists(toks)
+		toks = rewriteTableCompression(toks)
+	}
+
+	toks, err := rewriteOnConflict(toks)
+	if err != nil {
+		return nil, err
+	}
+	toks = rewriteAggregateFilter(toks)
+	toks, err = rewriteExpressions(toks)
+	if err != nil {
+		return nil, err
+	}
+
+	sql, order, err := emit(toks)
+	if err != nil {
+		return nil, err
+	}
+	return &Statement{SQL: sql, ArgOrder: order}, nil
+}
+
+// ---------------------------------------------------------------------------
+// 토큰 탐색 헬퍼
+// ---------------------------------------------------------------------------
+
+func isNoise(t token) bool { return t.kind == tkSpace || t.kind == tkComment }
+
+// nextCode는 i 이후(i 포함)에서 공백도 주석도 아닌 첫 토큰의 인덱스를 돌려준다.
+// 없으면 -1.
+func nextCode(toks []token, i int) int {
+	for ; i < len(toks); i++ {
+		if !isNoise(toks[i]) {
+			return i
+		}
+	}
+	return -1
+}
+
+// prevCode는 i 이전(i 포함)에서 공백도 주석도 아닌 첫 토큰의 인덱스를 돌려준다.
+// 없으면 -1.
+func prevCode(toks []token, i int) int {
+	for ; i >= 0; i-- {
+		if !isNoise(toks[i]) {
+			return i
+		}
+	}
+	return -1
+}
+
+func isWord(t token, word string) bool {
+	return t.kind == tkWord && strings.EqualFold(t.text, word)
+}
+
+func isPunct(t token, p string) bool {
+	return t.kind == tkPunct && t.text == p
+}
+
+// matchOpen은 open 위치의 '('를 닫는 ')'의 인덱스를 돌려준다. 없으면 -1.
+func matchOpen(toks []token, open int) int {
+	depth := 0
+	for i := open; i < len(toks); i++ {
+		if isPunct(toks[i], "(") {
+			depth++
+		} else if isPunct(toks[i], ")") {
+			depth--
+			if depth == 0 {
+				return i
+			}
+		}
+	}
+	return -1
+}
+
+// matchClose는 close 위치의 ')'에 대응하는 '('의 인덱스를 돌려준다. 없으면 -1.
+func matchClose(toks []token, close int) int {
+	depth := 0
+	for i := close; i >= 0; i-- {
+		if isPunct(toks[i], ")") {
+			depth++
+		} else if isPunct(toks[i], "(") {
+			depth--
+			if depth == 0 {
+				return i
+			}
+		}
+	}
+	return -1
+}
+
+// trimNoise는 잘라낸 구간의 앞뒤 공백·주석 토큰을 버린다. 다시 조립한 식이
+// 원본의 띄어쓰기를 물려받지 않게 하기 위해서다.
+func trimNoise(toks []token) []token {
+	start := 0
+	for start < len(toks) && isNoise(toks[start]) {
+		start++
+	}
+	end := len(toks)
+	for end > start && isNoise(toks[end-1]) {
+		end--
+	}
+	return toks[start:end]
+}
+
+func splice(toks []token, from, to int, with []token) []token {
+	out := make([]token, 0, len(toks)-(to-from+1)+len(with))
+	out = append(out, toks[:from]...)
+	out = append(out, with...)
+	out = append(out, toks[to+1:]...)
+	return out
+}
+
+// 토큰 생성자. 복합 리터럴은 인자 목록에서 타입을 생략할 수 없는데 이 재작성
+// 규칙들은 출력 대부분을 append(...) 안에서 만든다. 생성자를 두면 규칙이 읽기
+// 쉬워진다.
+func kw(text string) token  { return token{kind: tkWord, text: text} }
+func num(text string) token { return token{kind: tkNumber, text: text} }
+func str(text string) token { return token{kind: tkString, text: text} }
+func raw(text string) token { return token{kind: tkPunct, text: text} }
+func space() token          { return token{kind: tkSpace, text: " "} }
+
+// ---------------------------------------------------------------------------
+// 피연산자 스캔
+//
+// 몇몇 재작성은 키워드 한쪽에 붙어 있는 식이 필요하다. `x::date`는 DATE(x)가
+// 돼야 하고, `a ILIKE $1`은 패턴 뒤에 COLLATE를 붙여야 한다. 둘 다 그 식이 어디서
+// 시작하고 끝나는지 알아야 하는데, 함수 호출·수식된 이름·|| 연결이 끼면 토큰
+// 하나로 끝나지 않는다.
+// ---------------------------------------------------------------------------
+
+// operandStart는 end(포함)에서 끝나는 식의 첫 토큰 인덱스를 돌려준다.
+func operandStart(toks []token, end int) int {
+	i := prevCode(toks, end)
+	if i < 0 {
+		return -1
+	}
+
+	if isPunct(toks[i], ")") {
+		open := matchClose(toks, i)
+		if open < 0 {
+			return i
+		}
+		i = open
+		// 맨 단어 뒤에 오는 '('는 그 함수의 인자 목록이다.
+		if p := prevCode(toks, i-1); p >= 0 && toks[p].kind == tkWord {
+			i = p
+		}
+	}
+
+	// 수식된 이름을 거슬러 올라간다: schema.table.column.
+	for {
+		p := prevCode(toks, i-1)
+		if p < 0 || !isPunct(toks[p], ".") {
+			break
+		}
+		q := prevCode(toks, p-1)
+		if q < 0 || (toks[q].kind != tkWord && toks[q].kind != tkQuotedName) {
+			break
+		}
+		i = q
+	}
+	return i
+}
+
+// operandEnd는 start 이후(포함)에서 시작하는 식의 마지막 토큰 인덱스를
+// 돌려준다. || 연결 체인을 따라간다.
+func operandEnd(toks []token, start int) int {
+	i := nextCode(toks, start)
+	if i < 0 {
+		return -1
+	}
+
+	if isPunct(toks[i], "(") {
+		if close := matchOpen(toks, i); close >= 0 {
+			i = close
+		}
+	} else {
+		// 수식된 이름, 그리고 호출이라면 뒤따르는 인자 목록.
+		for {
+			n := nextCode(toks, i+1)
+			if n < 0 || !isPunct(toks[n], ".") {
+				break
+			}
+			q := nextCode(toks, n+1)
+			if q < 0 || (toks[q].kind != tkWord && toks[q].kind != tkQuotedName) {
+				break
+			}
+			i = q
+		}
+		if n := nextCode(toks, i+1); n >= 0 && isPunct(toks[n], "(") && toks[i].kind == tkWord {
+			if close := matchOpen(toks, n); close >= 0 {
+				i = close
+			}
+		}
+	}
+
+	// '||'를 건너뛰며 이어가서 `'%' || $1 || '%'`를 한 피연산자로 다룬다.
+	if n := nextCode(toks, i+1); n >= 0 && isPunct(toks[n], "||") {
+		if e := operandEnd(toks, n+1); e >= 0 {
+			return e
+		}
+	}
+	return i
+}
+
+// ---------------------------------------------------------------------------
+// 지원 불가 구문 검출
+// ---------------------------------------------------------------------------
+
+// pgOnlyFunctions는 기계적 재작성으로는 대응물을 만들 수 없는 함수들이다.
+// 이들이 필요한 호출부는 Kind로 분기해 자기 SQL을 제공한다. 번역기까지 도달한
+// 것은 드러낼 만한 버그다.
+var pgOnlyFunctions = map[string]string{
+	"array_agg":          "array aggregate",
+	"array_length":       "array function",
+	"array_to_string":    "array function",
+	"array_position":     "array function",
+	"unnest":             "array function",
+	"string_agg":         "use GROUP_CONCAT via a dialect branch",
+	"jsonb_set":          "jsonb function",
+	"jsonb_each":         "jsonb function",
+	"jsonb_each_text":    "jsonb function",
+	"jsonb_build_object": "jsonb function",
+	"to_jsonb":           "jsonb function",
+	"row_to_json":        "json function",
+	"generate_series":    "set-returning function",
+	"regexp_matches":     "use REGEXP via a dialect branch",
+
+	// 카탈로그와 크기 조회 함수들. 예전에는 알 수 없는 식별자인 채로 서버까지
+	// 가서 실패했다. 여기에 이름을 올려 두면 대신 TestEveryQueryTranslates에서
+	// 빌드 시점 실패가 된다.
+	"pg_database_size":          "use information_schema.tables via a dialect branch",
+	"pg_total_relation_size":    "use information_schema.tables via a dialect branch",
+	"pg_relation_size":          "use information_schema.tables via a dialect branch",
+	"pg_size_pretty":            "format the size in Go instead",
+	"hypertable_size":           "TimescaleDB-only",
+	"to_regclass":               "check information_schema.tables via a dialect branch",
+	"drop_chunks":               "TimescaleDB-only",
+	"drop_old_partitions":       "PL/pgSQL helper; MariaDB uses ALTER TABLE DROP PARTITION",
+	"create_monthly_partitions": "PL/pgSQL helper; MariaDB uses ALTER TABLE REORGANIZE PARTITION",
+}
+
+func rejectUntranslatable(toks []token) error {
+	depth := 0
+	for i, t := range toks {
+		switch {
+		case isPunct(t, "("):
+			depth++
+		case isPunct(t, ")"):
+			depth--
+		}
+
+		if t.kind == tkDollarStr {
+			return fmt.Errorf("mariadb: dollar-quoted PL/pgSQL body is PostgreSQL-only")
+		}
+
+		if t.kind == tkPunct {
+			switch t.text {
+			case "@>", "<@":
+				return fmt.Errorf("mariadb: containment operator %q has no equivalent", t.text)
+			case "->", "->>", "#>", "#>>":
+				return fmt.Errorf("mariadb: json operator %q has no equivalent; use JSON_EXTRACT via a dialect branch", t.text)
+			}
+		}
+
+		if t.kind == tkWord {
+			lower := strings.ToLower(t.text)
+			// 실제로 호출되는 이름만 걸러낸다. 우연히 같은 이름을 가진 컬럼은
+			// 건드리지 않는다.
+			if reason, bad := pgOnlyFunctions[lower]; bad {
+				if n := nextCode(toks, i+1); n >= 0 && isPunct(toks[n], "(") {
+					return fmt.Errorf("mariadb: %s() is PostgreSQL-only (%s)", lower, reason)
+				}
+			}
+			// `col = ANY($1)`은 배열을 IN 목록으로 풀어야 하는데, 슬라이스를
+			// 쥐고 있는 호출부만 할 수 있는 일이다.
+			if strings.EqualFold(t.text, "ANY") {
+				if n := nextCode(toks, i+1); n >= 0 && isPunct(toks[n], "(") {
+					return fmt.Errorf("mariadb: = ANY(array) has no equivalent; build an IN list via a dialect branch")
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// ON CONFLICT -> ON DUPLICATE KEY UPDATE
+// ---------------------------------------------------------------------------
+
+// rewriteOnConflict는 Postgres 업서트 문법을 변환한다.
+//
+// DO NOTHING은 INSERT IGNORE가 아니라 아무 일도 하지 않는 자기 대입
+// (`ON DUPLICATE KEY UPDATE c = c`)이 된다. IGNORE는 *모든* 오류를 경고로
+// 낮춘다. 외래 키 위반, 잘림, 잘못된 enum 값까지 전부. 그러면 소리 내어
+// 실패했어야 할 행이 대신 사라져 버린다. 자기 대입은 중복 키만 삼키는데,
+// 그것이 DO NOTHING이 약속하는 전부다.
+func rewriteOnConflict(toks []token) ([]token, error) {
+	for {
+		start := -1
+		for i := 0; i < len(toks); i++ {
+			if !isWord(toks[i], "ON") {
+				continue
+			}
+			if j := nextCode(toks, i+1); j >= 0 && isWord(toks[j], "CONFLICT") {
+				start = i
+				break
+			}
+		}
+		if start < 0 {
+			return toks, nil
+		}
+
+		cursor := nextCode(toks, nextCode(toks, start+1)+1) // token after CONFLICT
+		if cursor < 0 {
+			return nil, fmt.Errorf("mariadb: malformed ON CONFLICT clause")
+		}
+
+		conflictCol := ""
+		switch {
+		case isPunct(toks[cursor], "("):
+			close := matchOpen(toks, cursor)
+			if close < 0 {
+				return nil, fmt.Errorf("mariadb: unbalanced ON CONFLICT target list")
+			}
+			if c := nextCode(toks, cursor+1); c >= 0 && c < close {
+				conflictCol = toks[c].text
+			}
+			cursor = nextCode(toks, close+1)
+		case isWord(toks[cursor], "ON"):
+			// ON CONFLICT ON CONSTRAINT <name>
+			c := nextCode(toks, cursor+1)
+			if c < 0 || !isWord(toks[c], "CONSTRAINT") {
+				return nil, fmt.Errorf("mariadb: malformed ON CONFLICT ON CONSTRAINT clause")
+			}
+			cursor = nextCode(toks, nextCode(toks, c+1)+1)
+		}
+
+		// `ON CONFLICT (col) WHERE <술어> DO ...`는 PostgreSQL이 어느 부분
+		// 유니크 인덱스에 맞춰야 하는지를 지정한다. MySQL 계열은 위반된 유니크
+		// 키가 무엇이든 그것에 반응하고, 001_init.sql은 모든 부분 유니크
+		// 인덱스를 생성 컬럼 위의 진짜 유니크 키로 재현한다. 따라서 여기서 그
+		// 술어는 추가 의미가 없으므로 버린다.
+		if cursor >= 0 && isWord(toks[cursor], "WHERE") {
+			for cursor < len(toks) && !isWord(toks[cursor], "DO") {
+				cursor++
+			}
+			if cursor >= len(toks) {
+				cursor = -1
+			}
+		}
+
+		if cursor < 0 || !isWord(toks[cursor], "DO") {
+			return nil, fmt.Errorf("mariadb: malformed ON CONFLICT clause: expected DO")
+		}
+		action := nextCode(toks, cursor+1)
+		if action < 0 {
+			return nil, fmt.Errorf("mariadb: malformed ON CONFLICT clause: missing action")
+		}
+
+		switch {
+		case isWord(toks[action], "NOTHING"):
+			col := conflictCol
+			if col == "" {
+				col = firstInsertColumn(toks)
+			}
+			if col == "" {
+				return nil, fmt.Errorf("mariadb: cannot translate ON CONFLICT DO NOTHING without a conflict target or column list")
+			}
+			replacement := []token{
+				kw("ON"), space(),
+				kw("DUPLICATE"), space(),
+				kw("KEY"), space(),
+				kw("UPDATE"), space(),
+				kw(col), space(), raw("="), space(),
+				kw(col),
+			}
+			toks = splice(toks, start, action, replacement)
+
+		case isWord(toks[action], "UPDATE"):
+			set := nextCode(toks, action+1)
+			if set < 0 || !isWord(toks[set], "SET") {
+				return nil, fmt.Errorf("mariadb: malformed ON CONFLICT DO UPDATE clause: expected SET")
+			}
+			if err := checkUpsertTail(toks, set); err != nil {
+				return nil, err
+			}
+			replacement := []token{
+				kw("ON"), space(),
+				kw("DUPLICATE"), space(),
+				kw("KEY"), space(),
+				kw("UPDATE"),
+			}
+			toks = splice(toks, start, set, replacement)
+			toks = rewriteExcluded(toks)
+
+		default:
+			return nil, fmt.Errorf("mariadb: unsupported ON CONFLICT action %q", toks[action].text)
+		}
+	}
+}
+
+// checkUpsertTail은 표현할 수 없는 두 가지 업서트 형태를 거부한다. 조건부
+// DO UPDATE(... WHERE ...)와, 행까지 돌려주는 업서트다.
+func checkUpsertTail(toks []token, set int) error {
+	depth := 0
+	for i := set + 1; i < len(toks); i++ {
+		switch {
+		case isPunct(toks[i], "("):
+			depth++
+		case isPunct(toks[i], ")"):
+			depth--
+		case depth == 0 && isWord(toks[i], "WHERE"):
+			return fmt.Errorf("mariadb: conditional upsert (ON CONFLICT DO UPDATE ... WHERE) is unsupported")
+		case depth == 0 && isWord(toks[i], "RETURNING"):
+			return fmt.Errorf("mariadb: INSERT ... ON DUPLICATE KEY UPDATE cannot be combined with RETURNING")
+		}
+	}
+	return nil
+}
+
+// rewriteExcluded는 EXCLUDED 유사 행을 MySQL의 VALUES()로 바꾼다.
+func rewriteExcluded(toks []token) []token {
+	for i := 0; i < len(toks); i++ {
+		if !isWord(toks[i], "EXCLUDED") {
+			continue
+		}
+		dot := nextCode(toks, i+1)
+		if dot < 0 || !isPunct(toks[dot], ".") {
+			continue
+		}
+		col := nextCode(toks, dot+1)
+		if col < 0 || (toks[col].kind != tkWord && toks[col].kind != tkQuotedName) {
+			continue
+		}
+		toks = splice(toks, i, col, []token{
+			kw("VALUES"), raw("("), toks[col], raw(")"),
+		})
+	}
+	return toks
+}
+
+// firstInsertColumn은 `INSERT INTO t (a, b, ...)`에서 첫 컬럼을 꺼낸다.
+// DO NOTHING의 무의미 대입 대상으로 쓴다.
+func firstInsertColumn(toks []token) string {
+	i := nextCode(toks, 0)
+	if i < 0 || !isWord(toks[i], "INSERT") {
+		return ""
+	}
+	// INTO와 (수식됐을 수 있는) 테이블 이름을 건너뛰고 컬럼 목록으로 간다.
+	for i = nextCode(toks, i+1); i >= 0; i = nextCode(toks, i+1) {
+		if isPunct(toks[i], "(") {
+			if c := nextCode(toks, i+1); c >= 0 && (toks[c].kind == tkWord || toks[c].kind == tkQuotedName) {
+				return toks[c].text
+			}
+			return ""
+		}
+		if isWord(toks[i], "VALUES") || isWord(toks[i], "SELECT") {
+			return ""
+		}
+	}
+	return ""
+}
+
+// ---------------------------------------------------------------------------
+// 집계 함수의 FILTER (WHERE ...)
+// ---------------------------------------------------------------------------
+
+// rewriteAggregateFilter는 `AGG(expr) FILTER (WHERE cond)`를
+// `AGG(CASE WHEN (cond) THEN expr END)`로 바꾼다. 이것이 SQL 표준의 FILTER가
+// 뜻하는 바 그대로다. COUNT(*)는 COUNT(CASE WHEN cond THEN 1 END)가 된다.
+// 상수를 세는 것은 COUNT(*)가 세는 것과 같은 행을 세는 일이고, ELSE가 없어서
+// 생기는 NULL이 나머지를 제외한다.
+//
+// 오른쪽에서 왼쪽으로 훑는다. 앞선 재작성이 뒤쪽 인덱스를 무효화하지 않게
+// 하기 위해서다.
+func rewriteAggregateFilter(toks []token) []token {
+	for i := len(toks) - 1; i >= 0; i-- {
+		if !isWord(toks[i], "FILTER") {
+			continue
+		}
+		open := nextCode(toks, i+1)
+		if open < 0 || !isPunct(toks[open], "(") {
+			continue
+		}
+		close := matchOpen(toks, open)
+		if close < 0 {
+			continue
+		}
+		where := nextCode(toks, open+1)
+		if where < 0 || !isWord(toks[where], "WHERE") {
+			continue
+		}
+
+		aggClose := prevCode(toks, i-1)
+		if aggClose < 0 || !isPunct(toks[aggClose], ")") {
+			continue
+		}
+		aggOpen := matchClose(toks, aggClose)
+		if aggOpen < 0 {
+			continue
+		}
+		name := prevCode(toks, aggOpen-1)
+		if name < 0 || toks[name].kind != tkWord {
+			continue
+		}
+
+		condStart := nextCode(toks, where+1)
+		if condStart < 0 || condStart >= close {
+			continue
+		}
+		cond := trimNoise(append([]token(nil), toks[condStart:close]...))
+
+		args := trimNoise(append([]token(nil), toks[aggOpen+1:aggClose]...))
+		if len(args) == 1 && isPunct(args[0], "*") {
+			args = []token{num("1")}
+		}
+
+		replacement := []token{raw("("), kw("CASE"), space(), kw("WHEN"), space(), raw("(")}
+		replacement = append(replacement, cond...)
+		replacement = append(replacement, raw(")"), space(), kw("THEN"), space())
+		replacement = append(replacement, args...)
+		replacement = append(replacement, space(), kw("END"), raw(")"))
+
+		toks = splice(toks, aggOpen, close, replacement)
+	}
+	return toks
+}
+
+// ---------------------------------------------------------------------------
+// 식 수준 재작성
+// ---------------------------------------------------------------------------
+
+var intervalUnits = map[string]string{
+	"microsecond": "MICROSECOND", "microseconds": "MICROSECOND",
+	"millisecond": "MICROSECOND", "milliseconds": "MICROSECOND",
+	"second": "SECOND", "seconds": "SECOND", "sec": "SECOND", "secs": "SECOND",
+	"minute": "MINUTE", "minutes": "MINUTE", "min": "MINUTE", "mins": "MINUTE",
+	"hour": "HOUR", "hours": "HOUR",
+	"day": "DAY", "days": "DAY",
+	"week": "WEEK", "weeks": "WEEK",
+	"month": "MONTH", "months": "MONTH",
+	"year": "YEAR", "years": "YEAR",
+}
+
+var dateTruncFormats = map[string]string{
+	"minute": "%Y-%m-%d %H:%i:00",
+	"hour":   "%Y-%m-%d %H:00:00",
+	"day":    "%Y-%m-%d 00:00:00",
+	"month":  "%Y-%m-01 00:00:00",
+	"year":   "%Y-01-01 00:00:00",
+}
+
+// 두 번째 단어까지가 타입 이름인 경우들. `::double precision`이 두 단어를 모두
+// 먹어서 `precision`이 식별자로 남지 않게 한다.
+var twoWordCastTypes = map[string]string{
+	"character": "varying",
+	"double":    "precision",
+	"bit":       "varying",
+}
+
+func rewriteExpressions(toks []token) ([]token, error) {
+	for i := 0; i < len(toks); i++ {
+		t := toks[i]
+
+		switch {
+		case t.kind == tkPunct && t.text == "::":
+			var err error
+			toks, i, err = rewriteCast(toks, i)
+			if err != nil {
+				return nil, err
+			}
+
+		case isWord(t, "ILIKE"):
+			toks = rewriteILike(toks, i)
+
+		case isWord(t, "INTERVAL"):
+			var err error
+			toks, err = rewriteInterval(toks, i)
+			if err != nil {
+				return nil, err
+			}
+
+		case isWord(t, "FOR"):
+			toks = stripForUpdateOf(toks, i)
+
+		case t.kind == tkWord:
+			var err error
+			toks, err = rewriteFunctionCall(toks, i)
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+	return toks, nil
+}
+
+// rewriteCast는 Postgres의 `::타입` 캐스트를 제거한다. 제거하면 결과가 달라지는
+// 경우에는 변환한다. 스캔을 이어갈 인덱스를 돌려준다.
+func rewriteCast(toks []token, i int) ([]token, int, error) {
+	typeStart := nextCode(toks, i+1)
+	if typeStart < 0 || (toks[typeStart].kind != tkWord && toks[typeStart].kind != tkQuotedName) {
+		return toks, i, fmt.Errorf("mariadb: malformed cast after ::")
+	}
+
+	typeName := strings.ToLower(toks[typeStart].text)
+	typeEnd := typeStart
+
+	if second, ok := twoWordCastTypes[typeName]; ok {
+		if n := nextCode(toks, typeEnd+1); n >= 0 && isWord(toks[n], second) {
+			typeEnd = n
+		}
+	}
+	// timestamp/time [with|without] time zone
+	if typeName == "timestamp" || typeName == "time" {
+		if n := nextCode(toks, typeEnd+1); n >= 0 && (isWord(toks[n], "with") || isWord(toks[n], "without")) {
+			if z := nextCode(toks, nextCode(toks, n+1)+1); z >= 0 && isWord(toks[z], "zone") {
+				typeEnd = z
+			}
+		}
+	}
+	// 선택적 정밀도/길이: numeric(12,2), varchar(255).
+	if n := nextCode(toks, typeEnd+1); n >= 0 && isPunct(toks[n], "(") {
+		if close := matchOpen(toks, n); close >= 0 {
+			typeEnd = close
+		}
+	}
+	// 배열 접미사.
+	for {
+		n := nextCode(toks, typeEnd+1)
+		if n < 0 || !isPunct(toks[n], "[") {
+			break
+		}
+		c := nextCode(toks, n+1)
+		if c < 0 || !isPunct(toks[c], "]") {
+			break
+		}
+		typeEnd = c
+	}
+
+	switch typeName {
+	case "interval":
+		// 이 코드베이스는 보존 기간을 `($1 || ' days')::interval`로
+		// 파라미터화한다. MySQL 계열에는 interval *값*이 없고 INTERVAL n UNIT
+		// 문법만 있지만, 여기서 단위는 언제나 리터럴이다. 따라서 수량은 바인딩
+		// 파라미터로 남기고 단위만 SQL로 끌어올리면 된다.
+		start := operandStart(toks, i-1)
+		if start >= 0 {
+			if qty, unit, ok := parseConcatInterval(toks, start, i-1); ok {
+				replacement := []token{kw("INTERVAL"), space(), qty, space(), kw(unit)}
+				toks = splice(toks, start, typeEnd, replacement)
+				return toks, start + len(replacement) - 1, nil
+			}
+		}
+		return toks, i, fmt.Errorf(
+			"mariadb: cast to interval is unsupported unless written as ($n || ' <unit>')::interval")
+
+	case "date":
+		// 이것만은 제거하면 GROUP BY가 조용히 망가진다. 컬럼이 시각 부분을
+		// 그대로 유지해서 모든 행이 제각각의 버킷으로 흩어진다.
+		start := operandStart(toks, i-1)
+		if start < 0 {
+			return toks, i, fmt.Errorf("mariadb: cannot find operand for ::date")
+		}
+		operand := append([]token(nil), toks[start:i]...)
+		replacement := append([]token{kw("DATE"), raw("(")}, operand...)
+		replacement = append(replacement, raw(")"))
+		toks = splice(toks, start, typeEnd, replacement)
+		return toks, start + len(replacement) - 1, nil
+	}
+
+	// 나머지는 전부 제거한다. MySQL 계열은 어차피 주변 문맥의 타입을 값에
+	// 적용하고, 이 코드베이스의 캐스트는 Postgres에게 어느 오버로드를 고를지
+	// 알려주려고(text/uuid/inet/jsonb/enum) 존재하는데 MySQL 계열에는 그런
+	// 문제가 없다.
+	toks = splice(toks, i, typeEnd, nil)
+	return toks, i - 1, nil
+}
+
+// parseConcatInterval은 toks[start:end]에 걸친 `($n || ' days')`를 인식하고,
+// 수량 토큰과 단위 키워드를 돌려준다.
+func parseConcatInterval(toks []token, start, end int) (token, string, bool) {
+	open := nextCode(toks, start)
+	if open < 0 || open > end || !isPunct(toks[open], "(") {
+		return token{}, "", false
+	}
+	qty := nextCode(toks, open+1)
+	if qty < 0 || (toks[qty].kind != tkParam && toks[qty].kind != tkNumber) {
+		return token{}, "", false
+	}
+	pipe := nextCode(toks, qty+1)
+	if pipe < 0 || !isPunct(toks[pipe], "||") {
+		return token{}, "", false
+	}
+	lit := nextCode(toks, pipe+1)
+	if lit < 0 || toks[lit].kind != tkString {
+		return token{}, "", false
+	}
+	closing := nextCode(toks, lit+1)
+	if closing < 0 || closing > end || !isPunct(toks[closing], ")") {
+		return token{}, "", false
+	}
+
+	unit, ok := intervalUnits[strings.ToLower(strings.TrimSpace(strings.Trim(toks[lit].text, "'")))]
+	if !ok {
+		return token{}, "", false
+	}
+	return toks[qty], unit, true
+}
+
+// rewriteILike는 `a ILIKE b`를 `a LIKE b COLLATE utf8mb4_general_ci`로 바꾼다.
+//
+// 스키마는 Postgres처럼 `=`가 대소문자를 구분하도록 utf8mb4_bin을 쓰는데, 그러면
+// 평범한 LIKE도 대소문자를 구분하게 된다. 패턴 쪽에 대소문자 무시 콜레이션을
+// 명시하면 강제성이 가장 높은 콜레이션이 되어 비교 전체가 대소문자 무시로
+// 평가된다. 그것이 정확히 ILIKE의 의미다.
+func rewriteILike(toks []token, i int) []token {
+	toks[i] = kw("LIKE")
+	end := operandEnd(toks, i+1)
+	if end < 0 {
+		return toks
+	}
+	tail := []token{space(), kw("COLLATE"), space(), kw("utf8mb4_general_ci")}
+	return splice(toks, end, end, append([]token{toks[end]}, tail...))
+}
+
+// rewriteInterval은 `INTERVAL '7 days'`를 `INTERVAL 7 DAY`로 바꾼다.
+func rewriteInterval(toks []token, i int) ([]token, error) {
+	lit := nextCode(toks, i+1)
+	if lit < 0 || toks[lit].kind != tkString {
+		// 이미 대상 엔진 형태인 `INTERVAL 7 DAY`이거나 interval 컬럼 참조다.
+		// 할 일이 없다.
+		return toks, nil
+	}
+
+	body := strings.TrimSpace(strings.Trim(toks[lit].text, "'"))
+	fields := strings.Fields(body)
+	if len(fields) != 2 {
+		return nil, fmt.Errorf("mariadb: cannot translate INTERVAL %s", toks[lit].text)
+	}
+	qty, err := strconv.Atoi(fields[0])
+	if err != nil {
+		return nil, fmt.Errorf("mariadb: cannot translate INTERVAL %s", toks[lit].text)
+	}
+	unit, ok := intervalUnits[strings.ToLower(fields[1])]
+	if !ok {
+		return nil, fmt.Errorf("mariadb: unknown interval unit in %s", toks[lit].text)
+	}
+	if strings.HasPrefix(strings.ToLower(fields[1]), "milli") {
+		qty *= 1000
+	}
+
+	return splice(toks, i, lit, []token{
+		kw("INTERVAL"), space(),
+		num(strconv.Itoa(qty)), space(),
+		kw(unit),
+	}), nil
+}
+
+// stripForUpdateOf는 FOR UPDATE에서 `OF <테이블>` 한정자를 제거한다. MariaDB는
+// SKIP LOCKED는 지원하지만 조인 중 어느 테이블을 잠글지 지정하는 것은 지원하지
+// 않는다. 어차피 여기 쓰임새는 모두 주도 테이블을 잠근다.
+func stripForUpdateOf(toks []token, i int) []token {
+	upd := nextCode(toks, i+1)
+	if upd < 0 || !isWord(toks[upd], "UPDATE") {
+		return toks
+	}
+	of := nextCode(toks, upd+1)
+	if of < 0 || !isWord(toks[of], "OF") {
+		return toks
+	}
+	last := of
+	for {
+		name := nextCode(toks, last+1)
+		if name < 0 || (toks[name].kind != tkWord && toks[name].kind != tkQuotedName) {
+			break
+		}
+		if isWord(toks[name], "SKIP") || isWord(toks[name], "NOWAIT") {
+			break
+		}
+		last = name
+		comma := nextCode(toks, last+1)
+		if comma < 0 || !isPunct(toks[comma], ",") {
+			break
+		}
+		last = comma
+	}
+	return splice(toks, of, last, nil)
+}
+
+// rewriteFunctionCall은 의미는 같고 표기만 다른 소수의 내장 함수 이름을 바꾼다.
+func rewriteFunctionCall(toks []token, i int) ([]token, error) {
+	name := strings.ToLower(toks[i].text)
+
+	// CURRENT_TIMESTAMP는 키워드라 괄호가 있어도 없어도 유효하다.
+	if name == "current_timestamp" {
+		if n := nextCode(toks, i+1); n < 0 || !isPunct(toks[n], "(") {
+			toks[i] = kw("CURRENT_TIMESTAMP(6)")
+		}
+		return toks, nil
+	}
+
+	open := nextCode(toks, i+1)
+	if open < 0 || !isPunct(toks[open], "(") {
+		return toks, nil
+	}
+	close := matchOpen(toks, open)
+	if close < 0 {
+		return toks, nil
+	}
+
+	// CREATE INDEX의 `col(191)`은 호출이 아니라 접두사 길이다. 그리고 그것이
+	// 붙는 컬럼 중 하나의 이름이 말 그대로 `host`인데, 이는 이 규칙들이
+	// 재작성하는 함수이기도 하다. 정수 하나만 인자로 받는 호출은 이 함수들
+	// 어디에도 없으므로, 둘을 구분하는 믿을 만한 기준이 된다.
+	if isIndexPrefix(toks, open, close) {
+		return toks, nil
+	}
+
+	switch name {
+	case "gen_random_uuid", "uuid_generate_v4":
+		// UUID()는 버전 4가 아니라 1이다. 둘 다 36자 RFC 4122 문자열이고 이
+		// 프로젝트에서 버전을 들여다보는 곳은 없다.
+		return splice(toks, i, close, []token{kw("UUID"), raw("("), raw(")")}), nil
+
+	case "random":
+		return splice(toks, i, close, []token{kw("RAND"), raw("("), raw(")")}), nil
+
+	case "current_database":
+		return splice(toks, i, close, []token{kw("DATABASE"), raw("("), raw(")")}), nil
+
+	case "host":
+		// PostgreSQL의 host(inet)은 넷마스크를 뺀 주소를 만든다. MySQL 계열은
+		// 그 컬럼들을 VARCHAR(45)로 저장하므로 뗄 마스크가 없고, 호출 결과는
+		// 그냥 그 값이다. 호출만 재작성한다. `host`는 로그 테이블의 컬럼
+		// 이름이기도 하다.
+		arg := trimNoise(toks[open+1 : close])
+		if len(arg) == 0 {
+			return nil, fmt.Errorf("mariadb: host() with no argument")
+		}
+		return splice(toks, i, close, arg), nil
+
+	case "split_part":
+		// split_part(s, delim, n)과 SUBSTRING_INDEX(s, delim, n)은 n = 1일
+		// 때만 일치한다. 그 이상에서는 PostgreSQL이 n번째 필드를 돌려주는 반면
+		// MySQL 계열은 앞의 n개 필드를 이어 붙여 돌려준다.
+		args := splitTopLevel(toks[open+1 : close])
+		if len(args) != 3 {
+			return nil, fmt.Errorf("mariadb: split_part expects three arguments")
+		}
+		nth := trimNoise(args[2])
+		if len(nth) != 1 || nth[0].kind != tkNumber || nth[0].text != "1" {
+			return nil, fmt.Errorf(
+				"mariadb: split_part is only translatable for the first field; use SUBSTRING_INDEX via a dialect branch")
+		}
+		replacement := []token{kw("SUBSTRING_INDEX"), raw("(")}
+		replacement = append(replacement, trimNoise(args[0])...)
+		replacement = append(replacement, raw(","), space())
+		replacement = append(replacement, trimNoise(args[1])...)
+		replacement = append(replacement, raw(","), space(), num("1"), raw(")"))
+		return splice(toks, i, close, replacement), nil
+
+	case "now":
+		// 컬럼이 DATETIME(6)이다. 정밀도 인자가 없으면 NOW()가 초 단위로
+		// 잘려서, 같은 초에 쓰인 행들이 ORDER BY created_at DESC에서 동률이
+		// 된다.
+		if nextCode(toks, open+1) == close {
+			return splice(toks, i, close, []token{kw("NOW"), raw("("), num("6"), raw(")")}), nil
+		}
+		return toks, nil
+
+	case "date_trunc":
+		unitTok := nextCode(toks, open+1)
+		if unitTok < 0 || toks[unitTok].kind != tkString {
+			return nil, fmt.Errorf("mariadb: date_trunc requires a literal unit")
+		}
+		unit := strings.ToLower(strings.Trim(toks[unitTok].text, "'"))
+		format, ok := dateTruncFormats[unit]
+		if !ok {
+			return nil, fmt.Errorf("mariadb: unsupported date_trunc unit %q", unit)
+		}
+		comma := nextCode(toks, unitTok+1)
+		if comma < 0 || !isPunct(toks[comma], ",") {
+			return nil, fmt.Errorf("mariadb: malformed date_trunc call")
+		}
+		arg := trimNoise(append([]token(nil), toks[comma+1:close]...))
+
+		// DATE_FORMAT은 문자열을 돌려주는데 호출자들은 결과를 time.Time으로
+		// 스캔하므로 DATETIME으로 되돌린다.
+		replacement := []token{kw("CAST"), raw("("), kw("DATE_FORMAT"), raw("(")}
+		replacement = append(replacement, arg...)
+		replacement = append(replacement,
+			raw(","), space(), str("'"+format+"'"), raw(")"),
+			space(), kw("AS"), space(), kw("DATETIME"), raw(")"))
+		return splice(toks, i, close, replacement), nil
+
+	case "extract":
+		// EXTRACT(EPOCH FROM x) -> UNIX_TIMESTAMP(x). 나머지 필드 이름은 두
+		// 엔진에서 표기가 같다.
+		field := nextCode(toks, open+1)
+		if field < 0 || !isWord(toks[field], "EPOCH") {
+			return toks, nil
+		}
+		from := nextCode(toks, field+1)
+		if from < 0 || !isWord(toks[from], "FROM") {
+			return nil, fmt.Errorf("mariadb: malformed EXTRACT call")
+		}
+		arg := trimNoise(append([]token(nil), toks[from+1:close]...))
+		replacement := []token{kw("UNIX_TIMESTAMP"), raw("(")}
+		replacement = append(replacement, arg...)
+		replacement = append(replacement, raw(")"))
+		return splice(toks, i, close, replacement), nil
+	}
+
+	return toks, nil
+}
+
+// isIndexPrefix는 괄호 안에 정수 리터럴 하나만 들어 있는지 판별한다.
+func isIndexPrefix(toks []token, open, close int) bool {
+	inner := trimNoise(toks[open+1 : close])
+	return len(inner) == 1 && inner[0].kind == tkNumber && !strings.Contains(inner[0].text, ".")
+}
+
+// ---------------------------------------------------------------------------
+// 방출
+// ---------------------------------------------------------------------------
+
+func emit(toks []token) (string, []int, error) {
+	var b strings.Builder
+	var order []int
+	sawParam := false
+
+	for _, t := range toks {
+		switch t.kind {
+		case tkParam:
+			if t.num < 1 {
+				return "", nil, fmt.Errorf("mariadb: invalid placeholder %s", t.text)
+			}
+			sawParam = true
+			order = append(order, t.num-1)
+			b.WriteByte('?')
+
+		case tkSynth:
+			sawParam = true
+			order = append(order, ArgSynthesisedUUID)
+			b.WriteByte('?')
+
+		case tkString:
+			b.WriteString(escapeLiteral(t))
+
+		default:
+			b.WriteString(t.text)
+		}
+	}
+
+	if !sawParam {
+		return b.String(), nil, nil
+	}
+	return b.String(), order, nil
+}
+
+// escapeLiteral은 두 엔진의 백슬래시 규칙을 맞춘다.
+//
+// Postgres는(9.1부터 기본인 standard_conforming_strings가 켜진 상태) '...' 안의
+// 백슬래시를 평범한 문자로 다루지만 MySQL 계열은 이스케이프로 다룬다. E'...'로
+// 쓰인 리터럴은 이미 MySQL 계열과 같은 의미라 그대로 내보내지만, 평범한
+// 리터럴은 백슬래시를 두 배로 늘려야 한다. 그러지 않으면 '\d+' 같은 정규식
+// 패턴이 조용히 백슬래시를 잃는다.
+func escapeLiteral(t token) string {
+	if t.escaped || !strings.Contains(t.text, `\`) {
+		return t.text
+	}
+	return strings.ReplaceAll(t.text, `\`, `\\`)
+}

--- a/api/internal/database/dialect/translate_test.go
+++ b/api/internal/database/dialect/translate_test.go
@@ -1,0 +1,625 @@
+package dialect
+
+import (
+	"strings"
+	"testing"
+)
+
+// normalise는 공백을 접어서, 테스트가 재작성기가 우연히 내놓은 정확한 띄어쓰기가
+// 아니라 SQL의 형태를 검증하게 한다.
+func normalise(s string) string {
+	return strings.Join(strings.Fields(s), " ")
+}
+
+func mustTranslate(t *testing.T, in string) (string, []int) {
+	t.Helper()
+	got, err := Translate(in)
+	if err != nil {
+		t.Fatalf("Translate(%q) returned error: %v", in, err)
+	}
+	if got.FollowUp != nil {
+		t.Fatalf("Translate(%q) produced an unexpected follow-up statement", in)
+	}
+	return normalise(got.SQL), got.ArgOrder
+}
+
+// mustSplit은 쓰기와 재조회로 나뉠 것으로 기대되는 문장을 번역하고 두 쪽을 모두
+// 돌려준다.
+func mustSplit(t *testing.T, in string) (write, read string, writeOrder, readOrder []int) {
+	t.Helper()
+	got, err := Translate(in)
+	if err != nil {
+		t.Fatalf("Translate(%q) returned error: %v", in, err)
+	}
+	if got.FollowUp == nil {
+		t.Fatalf("Translate(%q) did not produce a follow-up statement", in)
+	}
+	return normalise(got.SQL), normalise(got.FollowUp.SQL), got.ArgOrder, got.FollowUp.ArgOrder
+}
+
+func TestTranslatePlaceholders(t *testing.T) {
+	tests := []struct {
+		name  string
+		in    string
+		want  string
+		order []int
+	}{
+		{
+			name:  "sequential",
+			in:    `SELECT * FROM users WHERE id = $1 AND name = $2`,
+			want:  `SELECT * FROM users WHERE id = ? AND name = ?`,
+			order: []int{0, 1},
+		},
+		{
+			// argOrder가 존재하는 이유 그 자체. MySQL은 위치로 바인딩하므로
+			// 재사용된 Postgres 플레이스홀더는 두 번 넘겨야 한다.
+			name:  "reused placeholder is duplicated",
+			in:    `SELECT * FROM t WHERE a = $1 OR b = $1 OR c = $2`,
+			want:  `SELECT * FROM t WHERE a = ? OR b = ? OR c = ?`,
+			order: []int{0, 0, 1},
+		},
+		{
+			name:  "out of order",
+			in:    `UPDATE t SET a = $2, b = $1 WHERE id = $3`,
+			want:  `UPDATE t SET a = ?, b = ? WHERE id = ?`,
+			order: []int{1, 0, 2},
+		},
+		{
+			name:  "placeholder inside a string literal is left alone",
+			in:    `SELECT '$1 is not a placeholder' , $1`,
+			want:  `SELECT '$1 is not a placeholder' , ?`,
+			order: []int{0},
+		},
+		{
+			name:  "placeholder inside a comment is left alone",
+			in:    "SELECT a -- $9 in a comment\n, $1 FROM t",
+			want:  `SELECT a -- $9 in a comment , ? FROM t`,
+			order: []int{0},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, order := mustTranslate(t, tc.in)
+			if got != tc.want {
+				t.Errorf("sql:\n got %q\nwant %q", got, tc.want)
+			}
+			if len(order) != len(tc.order) {
+				t.Fatalf("argOrder: got %v want %v", order, tc.order)
+			}
+			for i := range order {
+				if order[i] != tc.order[i] {
+					t.Fatalf("argOrder: got %v want %v", order, tc.order)
+				}
+			}
+		})
+	}
+}
+
+func TestTranslateNoPlaceholdersReturnsNilOrder(t *testing.T) {
+	got, err := Translate(`SELECT count(*) FROM users`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ArgOrder != nil {
+		t.Fatalf("expected nil ArgOrder for a parameterless query, got %v", got.ArgOrder)
+	}
+}
+
+func TestTranslateExpressions(t *testing.T) {
+	tests := []struct{ name, in, want string }{
+		{
+			"casts are dropped",
+			`SELECT id::text, config::jsonb, ip::inet FROM t WHERE u = $1::uuid`,
+			`SELECT id, config, ip FROM t WHERE u = ?`,
+		},
+		{
+			"two-word cast types are consumed whole",
+			`SELECT NULLIF($1::double precision, 0), $2::character varying`,
+			`SELECT NULLIF(?, 0), ?`,
+		},
+		{
+			// ::date를 제거하면 시각 부분이 남아 모든 행이 제각각의 GROUP BY
+			// 버킷으로 흩어진다.
+			"date cast becomes DATE()",
+			`SELECT created_at::date, count(*) FROM logs GROUP BY created_at::date`,
+			`SELECT DATE(created_at), count(*) FROM logs GROUP BY DATE(created_at)`,
+		},
+		{
+			"ILIKE becomes a case-insensitively collated LIKE",
+			`SELECT * FROM t WHERE host ILIKE $1`,
+			`SELECT * FROM t WHERE host LIKE ? COLLATE utf8mb4_general_ci`,
+		},
+		{
+			"ILIKE over a concatenation covers the whole operand",
+			`SELECT * FROM t WHERE host ILIKE '%' || $1 || '%'`,
+			`SELECT * FROM t WHERE host LIKE '%' || ? || '%' COLLATE utf8mb4_general_ci`,
+		},
+		{
+			"interval literals become interval expressions",
+			`SELECT * FROM logs WHERE created_at > NOW() - INTERVAL '24 hours'`,
+			`SELECT * FROM logs WHERE created_at > NOW(6) - INTERVAL 24 HOUR`,
+		},
+		{
+			"singular interval unit",
+			`SELECT NOW() + INTERVAL '7 days', NOW() - INTERVAL '35 seconds'`,
+			`SELECT NOW(6) + INTERVAL 7 DAY, NOW(6) - INTERVAL 35 SECOND`,
+		},
+		{
+			"uuid generation is renamed",
+			`INSERT INTO t (id) VALUES (gen_random_uuid())`,
+			`INSERT INTO t (id) VALUES (UUID())`,
+		},
+		{
+			"now keeps microsecond precision",
+			`UPDATE t SET updated_at = now() WHERE id = $1`,
+			`UPDATE t SET updated_at = NOW(6) WHERE id = ?`,
+		},
+		{
+			"bare CURRENT_TIMESTAMP keeps microsecond precision",
+			`SELECT CURRENT_TIMESTAMP`,
+			`SELECT CURRENT_TIMESTAMP(6)`,
+		},
+		{
+			"date_trunc becomes a formatted cast",
+			`SELECT date_trunc('hour', created_at) FROM logs`,
+			`SELECT CAST(DATE_FORMAT(created_at, '%Y-%m-%d %H:00:00') AS DATETIME) FROM logs`,
+		},
+		{
+			"epoch extraction becomes UNIX_TIMESTAMP",
+			`SELECT EXTRACT(EPOCH FROM created_at) FROM t`,
+			`SELECT UNIX_TIMESTAMP(created_at) FROM t`,
+		},
+		{
+			// 이 코드베이스가 쓰는 유일한 파라미터화된 interval 형태. 수량은
+			// 바인딩된 채로 두고 단위만 SQL로 끌어올린다.
+			"concatenated interval becomes INTERVAL n UNIT",
+			`DELETE FROM audit_logs WHERE created_at < NOW() - ($1 || ' days')::INTERVAL`,
+			`DELETE FROM audit_logs WHERE created_at < NOW(6) - INTERVAL ? DAY`,
+		},
+		{
+			"FOR UPDATE loses the table qualifier but keeps SKIP LOCKED",
+			`SELECT * FROM outbox o FOR UPDATE OF o SKIP LOCKED`,
+			`SELECT * FROM outbox o FOR UPDATE SKIP LOCKED`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, _ := mustTranslate(t, tc.in)
+			if got != tc.want {
+				t.Errorf("\n got %q\nwant %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestTranslateAggregateFilter(t *testing.T) {
+	tests := []struct{ name, in, want string }{
+		{
+			"COUNT(*) FILTER counts a constant",
+			`SELECT COUNT(*) FILTER (WHERE block_reason = 'waf') FROM logs`,
+			`SELECT COUNT(CASE WHEN (block_reason = 'waf') THEN 1 END) FROM logs`,
+		},
+		{
+			"aggregate argument is preserved",
+			`SELECT AVG(captcha_score) FILTER (WHERE captcha_score IS NOT NULL) FROM c`,
+			`SELECT AVG(CASE WHEN (captcha_score IS NOT NULL) THEN captcha_score END) FROM c`,
+		},
+		{
+			"nested inside COALESCE",
+			`SELECT COALESCE(AVG(solve_time) FILTER (WHERE solve_time IS NOT NULL), 0) FROM c`,
+			`SELECT COALESCE(AVG(CASE WHEN (solve_time IS NOT NULL) THEN solve_time END), 0) FROM c`,
+		},
+		{
+			"several filters in one select list",
+			`SELECT COUNT(*) FILTER (WHERE a), COUNT(*) FILTER (WHERE b) FROM t`,
+			`SELECT COUNT(CASE WHEN (a) THEN 1 END), COUNT(CASE WHEN (b) THEN 1 END) FROM t`,
+		},
+		{
+			"condition containing a placeholder keeps its argument slot",
+			`SELECT COUNT(*) FILTER (WHERE status = $1) FROM t WHERE id = $2`,
+			`SELECT COUNT(CASE WHEN (status = ?) THEN 1 END) FROM t WHERE id = ?`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, _ := mustTranslate(t, tc.in)
+			if got != tc.want {
+				t.Errorf("\n got %q\nwant %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestTranslateFilterKeepsArgumentOrder(t *testing.T) {
+	// FILTER 재작성은 토큰을 옮긴다. 조건 안의 플레이스홀더는 방출 순서대로
+	// 호출자의 인자에 계속 대응돼야 한다.
+	_, order := mustTranslate(t, `SELECT COUNT(*) FILTER (WHERE status = $2) FROM t WHERE id = $1`)
+	if len(order) != 2 || order[0] != 1 || order[1] != 0 {
+		t.Fatalf("argOrder: got %v want [1 0]", order)
+	}
+}
+
+func TestTranslateUpsert(t *testing.T) {
+	tests := []struct{ name, in, want string }{
+		{
+			// INSERT IGNORE가 아니라 아무 일도 하지 않는 자기 대입. IGNORE는
+			// 외래 키 위반과 잘림 오류까지 삼킨다.
+			"DO NOTHING uses the conflict target column",
+			`INSERT INTO t (id, name) VALUES ($1, $2) ON CONFLICT (id) DO NOTHING`,
+			`INSERT INTO t (id, name) VALUES (?, ?) ON DUPLICATE KEY UPDATE id = id`,
+		},
+		{
+			"DO NOTHING without a target falls back to the first inserted column",
+			`INSERT INTO t (slug, name) VALUES ($1, $2) ON CONFLICT DO NOTHING`,
+			`INSERT INTO t (slug, name) VALUES (?, ?) ON DUPLICATE KEY UPDATE slug = slug`,
+		},
+		{
+			"DO UPDATE maps EXCLUDED onto VALUES()",
+			`INSERT INTO t (id, a, b) VALUES ($1, $2, $3)
+			 ON CONFLICT (id) DO UPDATE SET a = EXCLUDED.a, b = EXCLUDED.b`,
+			`INSERT INTO t (id, a, b) VALUES (?, ?, ?) ON DUPLICATE KEY UPDATE a = VALUES(a), b = VALUES(b)`,
+		},
+		{
+			"composite conflict target",
+			`INSERT INTO t (a, b, c) VALUES ($1, $2, $3) ON CONFLICT (a, b) DO UPDATE SET c = EXCLUDED.c`,
+			`INSERT INTO t (a, b, c) VALUES (?, ?, ?) ON DUPLICATE KEY UPDATE c = VALUES(c)`,
+		},
+		{
+			"non-EXCLUDED assignments survive",
+			`INSERT INTO t (id, n) VALUES ($1, $2) ON CONFLICT (id) DO UPDATE SET n = t.n + 1, updated_at = now()`,
+			`INSERT INTO t (id, n) VALUES (?, ?) ON DUPLICATE KEY UPDATE n = t.n + 1, updated_at = NOW(6)`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, _ := mustTranslate(t, tc.in)
+			if got != tc.want {
+				t.Errorf("\n got %q\nwant %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestTranslateStringLiterals(t *testing.T) {
+	tests := []struct{ name, in, want string }{
+		{
+			// Postgres는 평범한 문자열에서 \를 문자 그대로 다루지만 MySQL
+			// 계열은 이스케이프로 다루므로 두 배로 늘려야 한다.
+			"backslashes in plain literals are doubled",
+			`SELECT '\d+' AS pattern`,
+			`SELECT '\\d+' AS pattern`,
+		},
+		{
+			// E''는 이미 "백슬래시는 이스케이프"라는 뜻이고 이는 MySQL 계열의
+			// 기본 해석과 같으므로 본문이 그대로 통과한다.
+			"E-prefixed literals lose the prefix and keep their escapes",
+			`SELECT E'\\.env' AS pattern`,
+			`SELECT '\\.env' AS pattern`,
+		},
+		{
+			"doubled quotes are untouched",
+			`SELECT 'it''s fine'`,
+			`SELECT 'it''s fine'`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, _ := mustTranslate(t, tc.in)
+			if got != tc.want {
+				t.Errorf("\n got %q\nwant %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestTranslateQuotedIdentifiersSurvive(t *testing.T) {
+	// 로그 테이블에는 이름이 말 그대로 "timestamp"인 컬럼이 있다. 커넥션에
+	// ANSI_QUOTES가 켜져 있으므로 큰따옴표가 계속 유효하다.
+	got, _ := mustTranslate(t, `SELECT "timestamp", host FROM logs_partitioned WHERE "timestamp" > $1`)
+	want := `SELECT "timestamp", host FROM logs_partitioned WHERE "timestamp" > ?`
+	if got != want {
+		t.Errorf("\n got %q\nwant %q", got, want)
+	}
+}
+
+func TestTranslateRejectsUntranslatable(t *testing.T) {
+	tests := []struct{ name, in, wantSubstring string }{
+		{"array containment", `SELECT * FROM c WHERE events @> ARRAY[$1]::text[]`, "containment"},
+		{"any over array", `SELECT * FROM t WHERE slug = ANY($1)`, "ANY"},
+		{"array_length", `SELECT array_length(ip_ranges, 1) FROM p`, "array_length"},
+		{"json arrow", `SELECT payload->'fields'->>'subject' FROM n`, "json operator"},
+		{"jsonb_set", `UPDATE n SET config = jsonb_set(config, '{a}', $1)`, "jsonb_set"},
+		{"update returning whose predicate is updated", `UPDATE t SET status = $1 WHERE status = 'pending' RETURNING id`, "cannot be re-selected"},
+		{"update returning without a predicate", `UPDATE t SET a = $1 RETURNING id`, "without a WHERE"},
+		{"conditional upsert", `INSERT INTO t (id) VALUES ($1) ON CONFLICT (id) DO UPDATE SET a = 1 WHERE t.b = 2`, "conditional upsert"},
+		{"interval cast from an opaque value", `SELECT NOW() - $1::interval`, "interval"},
+		{"plpgsql block", `DO $$ BEGIN NULL; END $$`, "PostgreSQL-only"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := Translate(tc.in)
+			if err == nil {
+				t.Fatalf("expected an error for %q", tc.in)
+			}
+			if !strings.Contains(err.Error(), tc.wantSubstring) {
+				t.Errorf("error %q does not mention %q", err, tc.wantSubstring)
+			}
+		})
+	}
+}
+
+func TestTranslateAllowsSupportedReturning(t *testing.T) {
+	// MariaDB는 INSERT와 DELETE에 RETURNING을 지원하며, 이 프로젝트가 쓰는
+	// 지점이 바로 그곳이다.
+	for _, q := range []string{
+		`INSERT INTO t (a) VALUES ($1) RETURNING id`,
+		`DELETE FROM t WHERE id = $1 RETURNING id`,
+	} {
+		if _, err := Translate(q); err != nil {
+			t.Errorf("Translate(%q): unexpected error %v", q, err)
+		}
+	}
+}
+
+func TestDetect(t *testing.T) {
+	tests := []struct {
+		url  string
+		want Kind
+	}{
+		{"postgres://u:p@db:5432/npg?sslmode=disable", Postgres},
+		{"postgresql://u:p@db:5432/npg", Postgres},
+		{"mysql://u:p@db:3306/npg", MariaDB},
+		{"mariadb://u:p@db:3306/npg", MariaDB},
+		{"MariaDB://u:p@db/npg", MariaDB},
+		{"u:p@tcp(db:3306)/npg", MariaDB},
+		{"", Postgres},
+		{"nonsense", Postgres},
+	}
+	for _, tc := range tests {
+		if got := Detect(tc.url); got != tc.want {
+			t.Errorf("Detect(%q) = %q, want %q", tc.url, got, tc.want)
+		}
+	}
+}
+
+func TestMySQLDSN(t *testing.T) {
+	dsn, err := MySQLDSN("mariadb://npg:secret@db/nginx_proxy_guard", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.HasPrefix(dsn, "npg:secret@tcp(db:3306)/nginx_proxy_guard?") {
+		t.Errorf("unexpected DSN prefix: %s", dsn)
+	}
+	for _, required := range []string{
+		"parseTime=true",
+		"loc=UTC",
+		"clientFoundRows=true",
+		"collation=utf8mb4_bin",
+		"ANSI_QUOTES",
+		"PIPES_AS_CONCAT",
+	} {
+		if !strings.Contains(dsn, strings.ReplaceAll(required, ",", "%2C")) && !strings.Contains(dsn, required) {
+			t.Errorf("DSN is missing %q: %s", required, dsn)
+		}
+	}
+	if strings.Contains(dsn, "multiStatements") {
+		t.Errorf("serving DSN must not allow multi-statement queries: %s", dsn)
+	}
+
+	migration, err := MySQLDSN("mariadb://npg:secret@db/nginx_proxy_guard", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(migration, "multiStatements=true") {
+		t.Errorf("migration DSN must allow multi-statement execution: %s", migration)
+	}
+}
+
+func TestMySQLDSNPreservesExplicitPortAndParams(t *testing.T) {
+	dsn, err := MySQLDSN("mysql://u:p@10.0.0.5:3307/npg?tls=skip-verify", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(dsn, "u:p@tcp(10.0.0.5:3307)/npg?") {
+		t.Errorf("unexpected DSN: %s", dsn)
+	}
+	if !strings.Contains(dsn, "tls=skip-verify") {
+		t.Errorf("operator-supplied parameter was dropped: %s", dsn)
+	}
+}
+
+func TestMySQLDSNRejectsIncomplete(t *testing.T) {
+	for _, url := range []string{
+		"mariadb://user@/npg",
+		"mariadb://user@db/",
+	} {
+		if _, err := MySQLDSN(url, false); err == nil {
+			t.Errorf("expected an error for %q", url)
+		}
+	}
+}
+
+func TestRedactHidesPassword(t *testing.T) {
+	got := Redact("mariadb://npg:supersecret@db:3306/npg")
+	if strings.Contains(got, "supersecret") {
+		t.Fatalf("password leaked: %s", got)
+	}
+	if !strings.Contains(got, "npg") {
+		t.Fatalf("redaction removed too much: %s", got)
+	}
+}
+
+func TestTranslateSplitsUpdateReturning(t *testing.T) {
+	// MariaDB에는 UPDATE ... RETURNING이 없으므로, 문장은 쓰기와 같은 술어를 쓰는
+	// 재조회로 나뉜다. 드라이버가 이 쌍을 한 트랜잭션에서 실행한다.
+	write, read, writeOrder, readOrder := mustSplit(t,
+		`UPDATE proxy_hosts SET enabled = $1, updated_at = now() WHERE id = $2 RETURNING id, domain_names, enabled`)
+
+	if want := `UPDATE proxy_hosts SET enabled = ?, updated_at = NOW(6) WHERE id = ?`; write != want {
+		t.Errorf("write:\n got %q\nwant %q", write, want)
+	}
+	if want := `SELECT id, domain_names, enabled FROM proxy_hosts WHERE id = ?`; read != want {
+		t.Errorf("read:\n got %q\nwant %q", read, want)
+	}
+	if len(writeOrder) != 2 || writeOrder[0] != 0 || writeOrder[1] != 1 {
+		t.Errorf("write argOrder = %v, want [0 1]", writeOrder)
+	}
+	if len(readOrder) != 1 || readOrder[0] != 1 {
+		t.Errorf("read argOrder = %v, want [1]", readOrder)
+	}
+}
+
+func TestTranslateSplitsUpsertReturning(t *testing.T) {
+	// RETURNING과 ON DUPLICATE KEY UPDATE도 함께 쓸 수 없다. 재조회는 충돌
+	// 대상에 넣은 값을 키로 삼는데, 업서트가 삽입했든 갱신했든 그 값이 쓰인 행을
+	// 특정해 준다.
+	write, read, _, readOrder := mustSplit(t,
+		`INSERT INTO rate_limits (proxy_host_id, enabled, burst_size)
+		 VALUES ($1, $2, $3)
+		 ON CONFLICT (proxy_host_id) DO UPDATE SET enabled = EXCLUDED.enabled
+		 RETURNING id, proxy_host_id, enabled`)
+
+	wantWrite := `INSERT INTO rate_limits (proxy_host_id, enabled, burst_size) VALUES (?, ?, ?) ` +
+		`ON DUPLICATE KEY UPDATE enabled = VALUES(enabled)`
+	if write != wantWrite {
+		t.Errorf("write:\n got %q\nwant %q", write, wantWrite)
+	}
+	if want := `SELECT id, proxy_host_id, enabled FROM rate_limits WHERE proxy_host_id = ?`; read != want {
+		t.Errorf("read:\n got %q\nwant %q", read, want)
+	}
+	if len(readOrder) != 1 || readOrder[0] != 0 {
+		t.Errorf("read argOrder = %v, want [0]", readOrder)
+	}
+}
+
+func TestTranslateUpsertWithPartialIndexPredicate(t *testing.T) {
+	// `ON CONFLICT (col) WHERE ...`는 부분 유니크 인덱스를 지정한다. 대상 엔진은
+	// 위반된 유니크 키가 무엇이든 그것에 반응하고, 스키마가 그 인덱스들을 진짜
+	// 유니크 키로 재현하므로 술어는 버린다.
+	got, _ := mustTranslate(t,
+		`INSERT INTO banned_ips (ip_address, reason) VALUES ($1, $2)
+		 ON CONFLICT (ip_address) WHERE proxy_host_id IS NULL DO UPDATE SET reason = EXCLUDED.reason`)
+	want := `INSERT INTO banned_ips (ip_address, reason) VALUES (?, ?) ON DUPLICATE KEY UPDATE reason = VALUES(reason)`
+	if got != want {
+		t.Errorf("\n got %q\nwant %q", got, want)
+	}
+}
+
+func TestMySQLDSNTranslatesPostgresParameters(t *testing.T) {
+	// 잘 돌아가던 PostgreSQL URL을 복사해 스킴만 바꾸는 것이 MySQL 계열을 시험해
+	// 보는 가장 자연스러운 방법이다. go-sql-driver는 알 수 없는 파라미터를
+	// `SET <name>=<value>`로 재생하므로, sslmode가 남아 있으면
+	// "Unknown system variable 'sslmode'"로 접속이 실패한다. 진짜 원인은 전혀
+	// 알려주지 않는 오류다.
+	tests := []struct {
+		name         string
+		url          string
+		wantContains []string
+		wantAbsent   []string
+	}{
+		{
+			name:         "sslmode=disable becomes tls=false",
+			url:          "mariadb://u:p@db/npg?sslmode=disable",
+			wantContains: []string{"tls=false"},
+			wantAbsent:   []string{"sslmode"},
+		},
+		{
+			name:         "verifying sslmode becomes tls=true",
+			url:          "mariadb://u:p@db/npg?sslmode=verify-full",
+			wantContains: []string{"tls=true"},
+			wantAbsent:   []string{"sslmode"},
+		},
+		{
+			name:         "an explicit tls parameter wins over sslmode",
+			url:          "mariadb://u:p@db/npg?sslmode=disable&tls=skip-verify",
+			wantContains: []string{"tls=skip-verify"},
+			wantAbsent:   []string{"sslmode", "tls=false"},
+		},
+		{
+			name:         "connect_timeout is renamed and given a unit",
+			url:          "mariadb://u:p@db/npg?connect_timeout=10",
+			wantContains: []string{"timeout=10s"},
+			wantAbsent:   []string{"connect_timeout"},
+		},
+		{
+			name:       "other libpq parameters are dropped",
+			url:        "mariadb://u:p@db/npg?search_path=public&application_name=npg&sslrootcert=/ca.pem",
+			wantAbsent: []string{"search_path", "application_name", "sslrootcert"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dsn, err := MySQLDSN(tc.url, false)
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, want := range tc.wantContains {
+				if !strings.Contains(dsn, want) {
+					t.Errorf("DSN is missing %q: %s", want, dsn)
+				}
+			}
+			for _, absent := range tc.wantAbsent {
+				if strings.Contains(dsn, absent) {
+					t.Errorf("DSN still carries %q: %s", absent, dsn)
+				}
+			}
+		})
+	}
+}
+
+func TestTranslateLeavesIndexPrefixesAlone(t *testing.T) {
+	// `host`는 로그 테이블의 컬럼이면서 PostgreSQL의 inet 함수이기도 하다.
+	// DDL에서 `host(191)`은 접두사 길이다. 진짜 인자를 받는 호출만 재작성한다.
+	got, _ := mustTranslate(t,
+		`CREATE INDEX idx_logs_created_host ON logs (created_at DESC, host(191))`)
+	want := `CREATE INDEX idx_logs_created_host ON logs (created_at DESC, host(191))`
+	if got != want {
+		t.Errorf("\n got %q\nwant %q", got, want)
+	}
+}
+
+func TestTranslateInetAndTextFunctions(t *testing.T) {
+	tests := []struct{ name, in, want string }{
+		{
+			// PostgreSQL은 넷마스크를 뺀 inet을 만들지만, 대상 엔진의 컬럼은
+			// 이미 뗄 것이 없는 평범한 VARCHAR다.
+			"host() unwraps to its argument",
+			`SELECT * FROM logs WHERE host(client_ip) LIKE $1`,
+			`SELECT * FROM logs WHERE client_ip LIKE ?`,
+		},
+		{
+			"split_part on the first field becomes SUBSTRING_INDEX",
+			`SELECT split_part(request_uri, '?', 1) AS path FROM logs`,
+			`SELECT SUBSTRING_INDEX(request_uri, '?', 1) AS path FROM logs`,
+		},
+		{
+			"current_database becomes DATABASE",
+			`SELECT current_database()`,
+			`SELECT DATABASE()`,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, _ := mustTranslate(t, tc.in)
+			if got != tc.want {
+				t.Errorf("\n got %q\nwant %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestTranslateRejectsAmbiguousSplitPart(t *testing.T) {
+	// 첫 필드를 넘어가면 두 함수의 동작이 갈린다. PostgreSQL은 n번째 필드를,
+	// MySQL 계열은 앞의 n개를 이어 붙여 돌려준다.
+	if _, err := Translate(`SELECT split_part(a, ',', 2) FROM t`); err == nil {
+		t.Fatal("expected split_part with n>1 to be rejected")
+	}
+}

--- a/api/internal/database/migration.go
+++ b/api/internal/database/migration.go
@@ -16,6 +16,12 @@ var migrationFS embed.FS
 // 001_init.sql runs only once (on fresh install)
 // Upgrade statements run every time for existing installations
 func (db *DB) RunMigrations() error {
+	// MySQL 계열 엔진은 자체 스키마 파일을 쓰고 복구할 TimescaleDB 이력도 없다.
+	// migration_mysqlfamily.go 참고. 이 아래로는 전부 PostgreSQL 전용이다.
+	if db.kind.IsMySQLFamily() {
+		return db.runMySQLFamilyMigrations()
+	}
+
 	// Create migrations tracking table (for version tracking only)
 	_, err := db.Exec(`
 		CREATE TABLE IF NOT EXISTS schema_migrations (
@@ -2525,10 +2531,11 @@ func (db *DB) runTrgmIndexMigration() error {
 // ExploitRulesAutoDisableSQL is the one-shot UPDATE + system_logs entry used by
 // RunMigrations (embedded inside upgradeSQL) and by integration tests that need
 // to exercise the migration independently. It is safe to run repeatedly:
-// - ADD COLUMN IF NOT EXISTS is a no-op after the first run.
-// - The UPDATE filters on auto_disabled_at IS NULL, so it only touches rows the
-//   migration has not yet marked. Admins who have re-enabled the rules keep
-//   their choice.
+//   - ADD COLUMN IF NOT EXISTS is a no-op after the first run.
+//   - The UPDATE filters on auto_disabled_at IS NULL, so it only touches rows the
+//     migration has not yet marked. Admins who have re-enabled the rules keep
+//     their choice.
+//
 // See GitHub Issue #123.
 const ExploitRulesAutoDisableSQL = `
 ALTER TABLE public.exploit_block_rules ADD COLUMN IF NOT EXISTS auto_disabled_at timestamp with time zone;

--- a/api/internal/database/migration_mysqlfamily.go
+++ b/api/internal/database/migration_mysqlfamily.go
@@ -1,0 +1,214 @@
+package database
+
+import (
+	"embed"
+	"fmt"
+	"log"
+	"strings"
+
+	"nginx-proxy-guard/internal/database/dialect"
+)
+
+//go:embed migrations/mariadb/*.sql
+var mariadbMigrationFS embed.FS
+
+// MySQL 계열 엔진용 마이그레이션 파일들. 적용 순서대로다.
+//
+// migrations/mariadb/ 아래에 있는 이유는 그 방언으로 쓰였기 때문이다. MySQL도
+// 똑같은 파일을 실행하며, MySQL이 거부하는 소수의 구문만 번역기가 실행 도중
+// 재작성한다.
+//
+//   - 001_init.sql은 신규 설치 시 한 번만 실행되며, scripts/pg2mariadb-schema.py가
+//     PostgreSQL 스키마에서 생성한다.
+//   - 002_upgrades.sql은 migration.go의 업그레이드 목록에서 생성되고, 그것과
+//     마찬가지로 부팅할 때마다 재실행된다. 기존 설치가 현재 바이너리가 기대하는
+//     상태를 따라잡게 하기 위해서다.
+//   - 003_mariadb.sql은 손으로 작성한 파일로, 두 생성기 모두 유도할 수 없는
+//     것들을 담는다. 역시 부팅할 때마다 재실행된다.
+const (
+	mariadbInitFile     = "migrations/mariadb/001_init.sql"
+	mariadbUpgradesFile = "migrations/mariadb/002_upgrades.sql"
+	mariadbSupplement   = "migrations/mariadb/003_mariadb.sql"
+)
+
+// runMySQLFamilyMigrations는 MariaDB나 MySQL 데이터베이스를 이 바이너리가
+// 기대하는 스키마 상태로 만든다.
+//
+// 둘 다 같은 파일 세 개를 실행한다. MySQL은 생성된 스키마가 쓰는 편의 문법 몇
+// 가지 — 인덱스, 컬럼, 외래 키의 IF NOT EXISTS — 를 거부하므로 번역기가 내보낼
+// 때 제거하고, 그 결과로 나오는 중복 객체 오류를 여기서 "이미 적용됨"으로
+// 인식한다(dialect.IsAlreadyApplied 참고). 겉으로 드러나는 동작은 동일하다.
+//
+// PostgreSQL 경로의 계약을 그대로 따른다. 기본 스키마는 한 번만 적용하고
+// 기록하며, 이후 업그레이드 문장은 부팅할 때마다 각자의 Exec으로 재실행해서
+// 하나가 실패해도 나머지를 건너뛰지 않게 한다. 실패는 기동을 중단시키는 대신
+// 로그로 남기고 MigrationHealth()에 기록한다. 부분적으로만 마이그레이션된
+// 스키마는 개별 기능을 저하시킬 뿐이지만, 부팅을 거부하면 프록시 전체가
+// 내려간다.
+func (db *DB) runMySQLFamilyMigrations() error {
+	if _, err := db.Exec(`
+		CREATE TABLE IF NOT EXISTS schema_migrations (
+			version VARCHAR(255) NOT NULL PRIMARY KEY,
+			applied_at DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6)
+		) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin
+	`); err != nil {
+		return fmt.Errorf("failed to create migrations table: %w", err)
+	}
+
+	var applied int
+	if err := db.QueryRow(
+		`SELECT COUNT(*) FROM schema_migrations WHERE version = '001_init'`,
+	).Scan(&applied); err != nil {
+		return fmt.Errorf("failed to check migration status: %w", err)
+	}
+
+	if applied == 0 {
+		log.Printf("[Migration] Running the initial %s schema (001_init.sql)...", db.kind)
+		// 기본 스키마는 온전히 적용돼야 한다. 절반만 만들어진 테이블 집합은
+		// 업그레이드 재실행으로 고칠 수 있는 것이 아니다.
+		if err := db.execMigrationFile(mariadbInitFile, false); err != nil {
+			return fmt.Errorf("failed to apply the %s schema: %w", db.kind, err)
+		}
+		if _, err := db.Exec(`INSERT INTO schema_migrations (version) VALUES ('001_init')`); err != nil {
+			return fmt.Errorf("failed to update migration version: %w", err)
+		}
+		log.Printf("[Migration] Initial %s schema applied", db.kind)
+	} else {
+		log.Println("[Migration] Schema already initialized, running upgrades only...")
+	}
+
+	for _, file := range []string{mariadbUpgradesFile, mariadbSupplement} {
+		if err := db.execMigrationFile(file, true); err != nil {
+			return err
+		}
+	}
+
+	if count, lastErr := db.MigrationHealth(); count > 0 {
+		log.Printf("[Migration] ERROR: %d upgrade statement(s) failed — schema may be partially migrated and affected features can return errors until a restart retries them. Last failure: %s", count, lastErr)
+	}
+
+	if err := db.applyExploitRulesAutoDisable(); err != nil {
+		log.Printf("Warning: exploit rules auto-disable migration failed: %v", err)
+	}
+
+	// PostgreSQL 경로와 달리 의도적으로 빠진 것들: TimescaleDB 전환,
+	// 하이퍼테이블과 청크 복구, pg_trgm 인덱스 생성, 레거시 logs ->
+	// logs_partitioned 백필. 전부 PostgreSQL 설치에만 있을 수 있는 과거를
+	// 고치는 작업이다. 이쪽 설치는 처음부터 파티션 테이블로 시작하고, 파티션
+	// 관리는 마이그레이션이 아니라 파티션 스케줄러가 맡는다.
+
+	log.Println("Schema migration completed")
+	return nil
+}
+
+// overlyBroadExploitRuleIDs는 키워드 패턴이 평범한 검색어와 CMS 질의 문자열에도
+// 걸리는 시스템 규칙 세 개다. Issue #123에서 기본 비활성으로 바꿨다. 자세한
+// 이유는 ExploitRulesAutoDisableSQL 참고.
+var overlyBroadExploitRuleIDs = []string{
+	"a5cb921c-2c10-475b-8753-a56e2af1e5ba", // SQL Commands
+	"41d1f7bf-9179-44cb-b41a-1685ce88d965", // SQL Keywords
+	"aa90285b-2986-46f9-80e6-99946327cd24", // XSS Special Characters
+}
+
+// applyExploitRulesAutoDisable은 ExploitRulesAutoDisableSQL의 MySQL 계열
+// 대응물이다.
+//
+// PostgreSQL 버전이 PL/pgSQL DO 블록인 이유는 감사 로그를 남길지 ROW_COUNT로
+// 분기해야 하기 때문이다. MariaDB에도 MySQL에도 저장 루틴 밖에서는 그런 수단이
+// 없으므로 분기를 Go에 둔다. 문장 두 개, 가드, 멱등성은 모두 같다. UPDATE는
+// auto_disabled_at이 NULL인 행만 건드리므로, 규칙을 다시 켠 관리자의 선택은
+// 유지되고 반복 부팅은 no-op이 된다.
+func (db *DB) applyExploitRulesAutoDisable() error {
+	result, err := db.Exec(`
+		UPDATE exploit_block_rules
+		SET enabled = false, auto_disabled_at = NOW(6)
+		WHERE id IN (?, ?, ?)
+		  AND is_system = true
+		  AND enabled = true
+		  AND auto_disabled_at IS NULL`,
+		overlyBroadExploitRuleIDs[0], overlyBroadExploitRuleIDs[1], overlyBroadExploitRuleIDs[2],
+	)
+	if err != nil {
+		return fmt.Errorf("failed to auto-disable overly-broad exploit rules: %w", err)
+	}
+
+	affected, err := result.RowsAffected()
+	if err != nil || affected == 0 {
+		return nil
+	}
+
+	details := fmt.Sprintf(
+		`{"rule_ids": ["%s"], "reason": %q, "rollback_hint": %q}`,
+		strings.Join(overlyBroadExploitRuleIDs, `", "`),
+		"github issue #123: simple keyword matching produces false positives on legitimate search queries",
+		"set enabled=true in the UI; the migration will not touch these rows again once auto_disabled_at is set",
+	)
+	message := fmt.Sprintf(
+		"Auto-disabled %d overly-broad exploit rule(s) to prevent false positives on search/CMS endpoints. Review and optionally re-enable at /waf/exploit-rules.",
+		affected)
+
+	if _, err := db.Exec(`
+		INSERT INTO system_logs (source, level, message, details, component)
+		VALUES ('internal', 'info', ?, ?, 'exploit_rules_migration')`,
+		message, details,
+	); err != nil {
+		return fmt.Errorf("failed to record the auto-disable audit entry: %w", err)
+	}
+	return nil
+}
+
+// execMigrationFile은 내장된 마이그레이션 파일 하나를 문장 단위로 적용한다.
+//
+// 통째로 보내지 않고 Go에서 문장을 나누는 이유는 셋이다. 드라이버의 번역기가 한
+// 번에 한 문장씩만 다루고, 서비스용 커넥션은 다중 문장 질의를 켜두지 않으며,
+// 문장 단위 실행이라야 하나가 실패해도 배치 전체를 중단하지 않고 넘어갈 수
+// 있다.
+//
+// tolerate가 설정되면 실패한 문장은 로그와 기록만 남기고 나머지는 계속
+// 실행된다. v2.13.4 이후 PostgreSQL 업그레이드 루프가 지켜 온 계약이다.
+func (db *DB) execMigrationFile(name string, tolerate bool) error {
+	content, err := mariadbMigrationFS.ReadFile(name)
+	if err != nil {
+		return fmt.Errorf("failed to read %s: %w", name, err)
+	}
+
+	statements := dialect.SplitStatements(string(content))
+	log.Printf("[Migration] %s: %d statements", name, len(statements))
+
+	applied, alreadyThere := 0, 0
+	for _, stmt := range statements {
+		_, err := db.Exec(stmt)
+		if err == nil {
+			applied++
+			continue
+		}
+		// MySQL에서는 번역기가 서버가 거부하는 IF NOT EXISTS 절을 제거하므로,
+		// 마이그레이션을 다시 실행하면 아무 일도 하지 않는 대신 객체가
+		// 중복이라고 알려 온다. 결과는 같으며 실패가 아니다.
+		if dialect.IsAlreadyApplied(err) {
+			alreadyThere++
+			continue
+		}
+		if !tolerate {
+			return fmt.Errorf("%s: %w\nstatement: %s", name, err, truncateStatement(stmt))
+		}
+		desc := fmt.Sprintf("%s: %s", name, truncateStatement(stmt))
+		log.Printf("Warning: upgrade %q failed: %v", desc, err)
+		db.RecordMigrationFailure(desc, err)
+	}
+
+	if alreadyThere > 0 {
+		log.Printf("[Migration] %s: %d applied, %d already in place", name, applied, alreadyThere)
+	}
+	return nil
+}
+
+// truncateStatement는 마이그레이션 로그를 읽을 만하게 유지한다. 시드 INSERT는
+// 수 킬로바이트에 이르는데 그 뒷부분은 실패에 대해 알려주는 게 없다.
+func truncateStatement(stmt string) string {
+	stmt = strings.Join(strings.Fields(stmt), " ")
+	if len(stmt) > 160 {
+		return stmt[:160] + "..."
+	}
+	return stmt
+}

--- a/api/internal/database/migrations/mariadb/001_init.sql
+++ b/api/internal/database/migrations/mariadb/001_init.sql
@@ -1,0 +1,1651 @@
+-- Nginx Proxy Guard — MariaDB/MySQL 초기 스키마
+--
+-- 생성된 파일입니다. 직접 수정하지 마세요.
+-- 원본   : api/internal/database/migrations/001_init.sql (PostgreSQL)
+-- 재생성 : python3 scripts/pg2mariadb-schema.py
+--
+-- 멱등합니다. 모든 객체를 IF NOT EXISTS로 생성합니다.
+
+-- --------------------------------------------------------------------------
+-- Tables
+-- --------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS access_list_items (
+    id VARCHAR(36) NOT NULL DEFAULT (UUID()),
+    access_list_id VARCHAR(36) NOT NULL,
+    directive VARCHAR(10) NOT NULL,
+    address VARCHAR(255) NOT NULL,
+    description TEXT,
+    sort_order INT DEFAULT 0,
+    created_at DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    PRIMARY KEY (id),
+    CONSTRAINT access_list_items_directive_check CHECK (directive IN ('allow', 'deny'))
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+CREATE TABLE IF NOT EXISTS access_lists (
+    id VARCHAR(36) NOT NULL DEFAULT (UUID()),
+    name VARCHAR(255) NOT NULL,
+    description TEXT,
+    satisfy_any BOOLEAN DEFAULT true,
+    pass_auth BOOLEAN DEFAULT false,
+    created_at DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    PRIMARY KEY (id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+CREATE TABLE IF NOT EXISTS api_token_usage (
+    id VARCHAR(36) NOT NULL DEFAULT (UUID()),
+    token_id VARCHAR(36) NOT NULL,
+    endpoint VARCHAR(255) NOT NULL,
+    method VARCHAR(10) NOT NULL,
+    status_code INT,
+    client_ip VARCHAR(45),
+    user_agent TEXT,
+    request_body_size BIGINT,
+    response_time_ms INT,
+    created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    PRIMARY KEY (id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+CREATE TABLE IF NOT EXISTS api_tokens (
+    id VARCHAR(36) NOT NULL DEFAULT (UUID()),
+    user_id VARCHAR(36) NOT NULL,
+    name VARCHAR(255) NOT NULL,
+    token_hash VARCHAR(64) NOT NULL,
+    token_prefix VARCHAR(16) NOT NULL,
+    permissions JSON NOT NULL DEFAULT ('["*"]'),
+    allowed_ips TEXT,
+    rate_limit INT DEFAULT 1000,
+    expires_at DATETIME(6),
+    last_used_at DATETIME(6),
+    last_used_ip VARCHAR(45),
+    use_count BIGINT DEFAULT 0,
+    is_active BOOLEAN NOT NULL DEFAULT true,
+    revoked_at DATETIME(6),
+    revoked_reason VARCHAR(255),
+    created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+    PRIMARY KEY (id),
+    UNIQUE KEY api_tokens_token_hash_key (token_hash)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+CREATE TABLE IF NOT EXISTS audit_logs (
+    id VARCHAR(36) NOT NULL DEFAULT (UUID()),
+    user_id VARCHAR(36),
+    username VARCHAR(255) NOT NULL,
+    action VARCHAR(100) NOT NULL,
+    resource_type VARCHAR(255),
+    resource_id VARCHAR(255),
+    resource_name VARCHAR(255),
+    details JSON,
+    ip_address VARCHAR(45),
+    user_agent TEXT,
+    created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    PRIMARY KEY (id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin PAGE_COMPRESSED=1 PAGE_COMPRESSION_LEVEL=1;
+CREATE TABLE IF NOT EXISTS auth_providers (
+    id VARCHAR(36) NOT NULL DEFAULT (UUID()),
+    name VARCHAR(255) NOT NULL,
+    type VARCHAR(20) NOT NULL DEFAULT 'custom',
+    provider_url TEXT NOT NULL,
+    config JSON NOT NULL DEFAULT ('{}'),
+    timeout_ms INT NOT NULL DEFAULT 5000,
+    enabled BOOLEAN NOT NULL DEFAULT true,
+    container_name TEXT,
+    container_network TEXT,
+    container_port INT,
+    container_scheme TEXT,
+    last_resolved_ip TEXT,
+    last_reconcile_at DATETIME(6),
+    last_reconcile_status TEXT,
+    last_reconcile_error TEXT,
+    reconcile_fail_count INT NOT NULL DEFAULT 0,
+    created_at DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    PRIMARY KEY (id),
+    CONSTRAINT auth_providers_type_check CHECK (type IN ('authelia', 'authentik', 'custom'))
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+CREATE TABLE IF NOT EXISTS auth_sessions (
+    id VARCHAR(36) NOT NULL DEFAULT (UUID()),
+    user_id VARCHAR(36) NOT NULL,
+    token_hash VARCHAR(255) NOT NULL,
+    ip_address VARCHAR(45),
+    user_agent TEXT,
+    expires_at DATETIME(6) NOT NULL,
+    created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    PRIMARY KEY (id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+CREATE TABLE IF NOT EXISTS backups (
+    id VARCHAR(36) NOT NULL DEFAULT (UUID()),
+    filename VARCHAR(255) NOT NULL,
+    file_size BIGINT NOT NULL DEFAULT 0,
+    file_path VARCHAR(500) NOT NULL,
+    includes_config BOOLEAN NOT NULL DEFAULT true,
+    includes_certificates BOOLEAN NOT NULL DEFAULT true,
+    includes_database BOOLEAN NOT NULL DEFAULT true,
+    backup_type VARCHAR(20) NOT NULL DEFAULT 'manual',
+    description TEXT,
+    "status" VARCHAR(20) NOT NULL DEFAULT 'pending',
+    error_message TEXT,
+    checksum_sha256 VARCHAR(64),
+    created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    completed_at DATETIME(6),
+    PRIMARY KEY (id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+CREATE TABLE IF NOT EXISTS banned_ips (
+    id VARCHAR(36) NOT NULL DEFAULT (UUID()),
+    proxy_host_id VARCHAR(36),
+    ip_address VARCHAR(45) NOT NULL,
+    reason VARCHAR(255),
+    fail_count INT DEFAULT 0,
+    banned_at DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    expires_at DATETIME(6),
+    is_permanent BOOLEAN DEFAULT false,
+    created_at DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    is_auto_banned BOOLEAN DEFAULT false,
+    banned_ips_ip_global_key VARCHAR(768) AS (CASE WHEN proxy_host_id IS NULL THEN CONCAT_WS('\n', COALESCE(ip_address, '')) END) VIRTUAL,
+    banned_ips_ip_host_key VARCHAR(768) AS (CASE WHEN proxy_host_id IS NOT NULL THEN CONCAT_WS('\n', COALESCE(ip_address, ''), COALESCE(proxy_host_id, '')) END) VIRTUAL,
+    PRIMARY KEY (id),
+    UNIQUE KEY idx_banned_ips_ip_global_unique (banned_ips_ip_global_key),
+    UNIQUE KEY idx_banned_ips_ip_host_unique (banned_ips_ip_host_key)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+CREATE TABLE IF NOT EXISTS bot_filters (
+    id VARCHAR(36) NOT NULL DEFAULT (UUID()),
+    proxy_host_id VARCHAR(36) NOT NULL,
+    enabled BOOLEAN DEFAULT true,
+    block_bad_bots BOOLEAN DEFAULT true,
+    block_ai_bots BOOLEAN DEFAULT false,
+    allow_search_engines BOOLEAN DEFAULT true,
+    custom_blocked_agents TEXT,
+    custom_allowed_agents TEXT,
+    challenge_suspicious BOOLEAN DEFAULT false,
+    created_at DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    block_suspicious_clients BOOLEAN DEFAULT false,
+    disable_global BOOLEAN NOT NULL DEFAULT false,
+    PRIMARY KEY (id),
+    UNIQUE KEY bot_filters_proxy_host_id_key (proxy_host_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+CREATE TABLE IF NOT EXISTS certificate_history (
+    id VARCHAR(36) NOT NULL DEFAULT (UUID()),
+    certificate_id VARCHAR(36) NOT NULL,
+    action VARCHAR(50) NOT NULL,
+    "status" VARCHAR(50) NOT NULL,
+    message TEXT,
+    domain_names TEXT NOT NULL,
+    provider VARCHAR(50) NOT NULL,
+    expires_at DATETIME(6),
+    logs JSON,
+    created_at DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    PRIMARY KEY (id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+CREATE TABLE IF NOT EXISTS certificates (
+    id VARCHAR(36) NOT NULL DEFAULT (UUID()),
+    domain_names TEXT NOT NULL,
+    expires_at DATETIME(6),
+    certificate_path VARCHAR(512),
+    private_key_path VARCHAR(512),
+    provider VARCHAR(50) DEFAULT 'letsencrypt',
+    created_at DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+    dns_provider_id VARCHAR(36),
+    "status" VARCHAR(20) NOT NULL DEFAULT 'pending',
+    acme_account JSON DEFAULT ('{}'),
+    auto_renew BOOLEAN NOT NULL DEFAULT true,
+    renewal_attempted_at DATETIME(6),
+    issued_at DATETIME(6),
+    error_message TEXT,
+    certificate_pem TEXT,
+    private_key_pem TEXT,
+    issuer_certificate_pem TEXT,
+    PRIMARY KEY (id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+CREATE TABLE IF NOT EXISTS challenge_configs (
+    id VARCHAR(36) NOT NULL DEFAULT (UUID()),
+    proxy_host_id VARCHAR(36),
+    enabled BOOLEAN DEFAULT true,
+    challenge_type VARCHAR(20) DEFAULT 'recaptcha_v2',
+    site_key VARCHAR(255),
+    secret_key VARCHAR(255),
+    token_validity INT DEFAULT 86400,
+    min_score DECIMAL(3,2) DEFAULT 0.5,
+    apply_to VARCHAR(20) DEFAULT 'both',
+    page_title VARCHAR(255) DEFAULT 'Security Check',
+    page_message TEXT DEFAULT ('Please complete the security check to continue.'),
+    theme VARCHAR(10) DEFAULT 'light',
+    created_at DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+    PRIMARY KEY (id),
+    UNIQUE KEY challenge_configs_proxy_host_id_key (proxy_host_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+CREATE TABLE IF NOT EXISTS challenge_logs (
+    id VARCHAR(36) NOT NULL DEFAULT (UUID()),
+    proxy_host_id VARCHAR(36),
+    client_ip VARCHAR(45) NOT NULL,
+    user_agent TEXT,
+    result VARCHAR(20) NOT NULL,
+    trigger_reason VARCHAR(255),
+    captcha_score DECIMAL(3,2),
+    solve_time INT,
+    created_at DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    PRIMARY KEY (id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+CREATE TABLE IF NOT EXISTS challenge_tokens (
+    id VARCHAR(36) NOT NULL DEFAULT (UUID()),
+    proxy_host_id VARCHAR(36),
+    token_hash VARCHAR(64) NOT NULL,
+    client_ip VARCHAR(45) NOT NULL,
+    user_agent TEXT,
+    challenge_reason VARCHAR(255),
+    issued_at DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    expires_at DATETIME(6) NOT NULL,
+    use_count INT DEFAULT 0,
+    last_used_at DATETIME(6),
+    revoked BOOLEAN DEFAULT false,
+    revoked_at DATETIME(6),
+    revoked_reason VARCHAR(255),
+    PRIMARY KEY (id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+CREATE TABLE IF NOT EXISTS cloud_providers (
+    id VARCHAR(36) NOT NULL DEFAULT (UUID()),
+    name VARCHAR(100) NOT NULL,
+    slug VARCHAR(50) NOT NULL,
+    region VARCHAR(50) NOT NULL,
+    description TEXT,
+    ip_ranges TEXT NOT NULL DEFAULT ('{}'),
+    ip_ranges_url VARCHAR(500),
+    last_updated DATETIME(6),
+    enabled BOOLEAN DEFAULT true,
+    created_at DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+    PRIMARY KEY (id),
+    UNIQUE KEY cloud_providers_slug_key (slug)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+-- v2.24.7: logs_partitioned index ensure (documentation only — canonical
+-- execution lives in migration.go ensureLogsPartitionedIndexes).
+-- The background hypertable migration creates a NEW table (with only four
+-- idx_logs_ht_* basics) and renames the original to logs_partitioned_backup,
+-- which KEEPS every original idx_logs_part_* index name. From then on every
+-- `CREATE INDEX IF NOT EXISTS idx_logs_part_*` silently no-ops (the name
+-- exists — on the wrong table), so upgraded installs ran the hypertable
+-- with almost no indexes (incl. the pg_trgm search indexes from
+-- 011_trgm_indexes, whose one-shot schema_migrations gate also never re-ran).
+-- ensureLogsPartitionedIndexes runs after the swap and on every boot: it
+-- reclaims names squatted by logs_partitioned_backup (DROP INDEX — the backup
+-- is verification-only) and builds the canonical index set on the live table
+-- using timescaledb.transaction_per_chunk to keep ingest unblocked.
+-- v2.32.0: cloudflare_tunnel singleton (Phase 1 token mode)
+CREATE TABLE IF NOT EXISTS cloudflare_tunnel (
+    id VARCHAR(36) NOT NULL DEFAULT (UUID()),
+    enabled BOOLEAN DEFAULT false,
+    token TEXT NOT NULL DEFAULT (''),
+    mode VARCHAR(20) NOT NULL DEFAULT 'token',
+    created_at DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    singleton_key TINYINT AS (1) VIRTUAL,
+    PRIMARY KEY (id),
+    CONSTRAINT chk_cloudflare_tunnel_mode CHECK (mode IN ('token', 'managed')),
+    UNIQUE KEY idx_cloudflare_tunnel_singleton (singleton_key)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+CREATE TABLE IF NOT EXISTS dashboard_stats_daily (
+    id VARCHAR(36) NOT NULL DEFAULT (UUID()),
+    proxy_host_id VARCHAR(36),
+    day_bucket DATE NOT NULL,
+    total_requests BIGINT NOT NULL DEFAULT 0,
+    status_2xx BIGINT NOT NULL DEFAULT 0,
+    status_3xx BIGINT NOT NULL DEFAULT 0,
+    status_4xx BIGINT NOT NULL DEFAULT 0,
+    status_5xx BIGINT NOT NULL DEFAULT 0,
+    avg_response_time DOUBLE DEFAULT 0,
+    max_response_time DOUBLE DEFAULT 0,
+    bytes_sent BIGINT NOT NULL DEFAULT 0,
+    bytes_received BIGINT NOT NULL DEFAULT 0,
+    waf_blocked BIGINT NOT NULL DEFAULT 0,
+    rate_limited BIGINT NOT NULL DEFAULT 0,
+    bot_blocked BIGINT NOT NULL DEFAULT 0,
+    created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    PRIMARY KEY (id),
+    UNIQUE KEY dashboard_stats_daily_proxy_host_id_day_bucket_key (proxy_host_id, day_bucket)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+CREATE TABLE IF NOT EXISTS dashboard_stats_hourly (
+    id VARCHAR(36) NOT NULL DEFAULT (UUID()),
+    proxy_host_id VARCHAR(36),
+    hour_bucket DATETIME(6) NOT NULL,
+    total_requests BIGINT NOT NULL DEFAULT 0,
+    status_2xx BIGINT NOT NULL DEFAULT 0,
+    status_3xx BIGINT NOT NULL DEFAULT 0,
+    status_4xx BIGINT NOT NULL DEFAULT 0,
+    status_5xx BIGINT NOT NULL DEFAULT 0,
+    avg_response_time DOUBLE DEFAULT 0,
+    max_response_time DOUBLE DEFAULT 0,
+    min_response_time DOUBLE DEFAULT 0,
+    p95_response_time DOUBLE DEFAULT 0,
+    p99_response_time DOUBLE DEFAULT 0,
+    bytes_sent BIGINT NOT NULL DEFAULT 0,
+    bytes_received BIGINT NOT NULL DEFAULT 0,
+    waf_blocked BIGINT NOT NULL DEFAULT 0,
+    waf_detected BIGINT NOT NULL DEFAULT 0,
+    rate_limited BIGINT NOT NULL DEFAULT 0,
+    bot_blocked BIGINT NOT NULL DEFAULT 0,
+    top_countries JSON DEFAULT ('{}'),
+    top_paths JSON DEFAULT ('[]'),
+    top_ips JSON DEFAULT ('[]'),
+    created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    dashboard_stats_hourly_null_host_bucket_key VARCHAR(768) AS (CASE WHEN proxy_host_id IS NULL THEN CONCAT_WS('\n', COALESCE(CAST(hour_bucket AS CHAR), '')) END) VIRTUAL,
+    PRIMARY KEY (id),
+    UNIQUE KEY dashboard_stats_hourly_proxy_host_id_hour_bucket_key (proxy_host_id, hour_bucket),
+    UNIQUE KEY idx_dashboard_stats_hourly_null_host_bucket (dashboard_stats_hourly_null_host_bucket_key)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+CREATE TABLE IF NOT EXISTS dashboard_stats_hourly_partitioned (
+    id VARCHAR(36) NOT NULL DEFAULT (UUID()),
+    proxy_host_id VARCHAR(36),
+    hour_bucket DATETIME(6) NOT NULL,
+    total_requests BIGINT NOT NULL DEFAULT 0,
+    status_2xx BIGINT NOT NULL DEFAULT 0,
+    status_3xx BIGINT NOT NULL DEFAULT 0,
+    status_4xx BIGINT NOT NULL DEFAULT 0,
+    status_5xx BIGINT NOT NULL DEFAULT 0,
+    avg_response_time DOUBLE DEFAULT 0,
+    max_response_time DOUBLE DEFAULT 0,
+    min_response_time DOUBLE DEFAULT 0,
+    p95_response_time DOUBLE DEFAULT 0,
+    p99_response_time DOUBLE DEFAULT 0,
+    bytes_sent BIGINT NOT NULL DEFAULT 0,
+    bytes_received BIGINT NOT NULL DEFAULT 0,
+    waf_blocked BIGINT NOT NULL DEFAULT 0,
+    waf_detected BIGINT NOT NULL DEFAULT 0,
+    rate_limited BIGINT NOT NULL DEFAULT 0,
+    bot_blocked BIGINT NOT NULL DEFAULT 0,
+    top_countries JSON DEFAULT ('{}'),
+    top_paths JSON DEFAULT ('[]'),
+    top_ips JSON DEFAULT ('[]'),
+    created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    PRIMARY KEY (id, hour_bucket)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin
+PARTITION BY RANGE COLUMNS(hour_bucket) (
+    PARTITION p2025_12 VALUES LESS THAN ('2026-01-01 00:00:00'),
+    PARTITION p2026_01 VALUES LESS THAN ('2026-02-01 00:00:00'),
+    PARTITION p2026_02 VALUES LESS THAN ('2026-03-01 00:00:00'),
+    PARTITION p2026_03 VALUES LESS THAN ('2026-04-01 00:00:00'),
+    PARTITION p_max VALUES LESS THAN (MAXVALUE)
+);
+-- DDNS records (#154): keep registered hostnames' A records pointed at the server's public IPv4.
+CREATE TABLE IF NOT EXISTS ddns_records (
+    id VARCHAR(36) NOT NULL DEFAULT (UUID()) PRIMARY KEY,
+    hostname VARCHAR(253) NOT NULL,
+    dns_provider_id VARCHAR(36) NOT NULL,
+    record_type VARCHAR(8) NOT NULL DEFAULT 'A',
+    proxied BOOLEAN NOT NULL DEFAULT false,
+    ttl INT NOT NULL DEFAULT 1,
+    enabled BOOLEAN NOT NULL DEFAULT true,
+    last_ip VARCHAR(45) NOT NULL DEFAULT '',
+    last_synced_at DATETIME(6),
+    last_status VARCHAR(16) NOT NULL DEFAULT '',
+    last_error TEXT NOT NULL DEFAULT (''),
+    created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+CREATE TABLE IF NOT EXISTS dns_providers (
+    id VARCHAR(36) NOT NULL DEFAULT (UUID()),
+    name VARCHAR(100) NOT NULL,
+    provider_type VARCHAR(50) NOT NULL,
+    credentials JSON NOT NULL DEFAULT ('{}'),
+    is_default BOOLEAN NOT NULL DEFAULT false,
+    created_at DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+    dns_providers_default_key VARCHAR(768) AS (CASE WHEN is_default = true THEN CONCAT_WS('\n', COALESCE(CAST(is_default AS CHAR), '')) END) VIRTUAL,
+    PRIMARY KEY (id),
+    UNIQUE KEY idx_dns_providers_default (dns_providers_default_key)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+CREATE TABLE IF NOT EXISTS exploit_block_rules (
+    id VARCHAR(36) NOT NULL DEFAULT (UUID()),
+    category VARCHAR(50) NOT NULL,
+    name VARCHAR(100) NOT NULL,
+    pattern TEXT NOT NULL,
+    pattern_type VARCHAR(20) NOT NULL DEFAULT 'query_string',
+    description TEXT,
+    severity VARCHAR(20) DEFAULT 'warning',
+    enabled BOOLEAN DEFAULT true,
+    is_system BOOLEAN DEFAULT true,
+    sort_order INT DEFAULT 0,
+    auto_disabled_at DATETIME(6),
+    created_at DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    PRIMARY KEY (id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+CREATE TABLE IF NOT EXISTS fail2ban_configs (
+    id VARCHAR(36) NOT NULL DEFAULT (UUID()),
+    proxy_host_id VARCHAR(36) NOT NULL,
+    enabled BOOLEAN DEFAULT true,
+    max_retries INT DEFAULT 5,
+    find_time INT DEFAULT 600,
+    ban_time INT DEFAULT 3600,
+    fail_codes VARCHAR(100) DEFAULT '401,403,404',
+    action VARCHAR(20) DEFAULT 'block',
+    created_at DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    PRIMARY KEY (id),
+    UNIQUE KEY fail2ban_configs_proxy_host_id_key (proxy_host_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+CREATE TABLE IF NOT EXISTS filter_subscription_entries (
+    id VARCHAR(36) NOT NULL DEFAULT (UUID()) PRIMARY KEY,
+    subscription_id VARCHAR(36) NOT NULL,
+    value TEXT NOT NULL,
+    reason TEXT,
+    created_at DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    UNIQUE KEY uq_subscription_id_value (subscription_id, value(731))
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+-- Filter subscription entry exclusions (v2.8.0+)
+CREATE TABLE IF NOT EXISTS filter_subscription_entry_exclusions (
+    id VARCHAR(36) NOT NULL DEFAULT (UUID()) PRIMARY KEY,
+    subscription_id VARCHAR(36) NOT NULL,
+    value TEXT NOT NULL,
+    created_at DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    UNIQUE KEY uq_subscription_id_value (subscription_id, value(731))
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+CREATE TABLE IF NOT EXISTS filter_subscription_host_exclusions (
+    id VARCHAR(36) NOT NULL DEFAULT (UUID()) PRIMARY KEY,
+    subscription_id VARCHAR(36) NOT NULL,
+    proxy_host_id VARCHAR(36) NOT NULL,
+    created_at DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    UNIQUE KEY uq_subscription_id_proxy_host_id (subscription_id, proxy_host_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+-- Filter subscription tables (v2.7.0+)
+CREATE TABLE IF NOT EXISTS filter_subscriptions (
+    id VARCHAR(36) NOT NULL DEFAULT (UUID()) PRIMARY KEY,
+    name TEXT NOT NULL,
+    description TEXT,
+    url TEXT NOT NULL,
+    format VARCHAR(20) NOT NULL DEFAULT 'npg-json',
+    type VARCHAR(20) NOT NULL,
+    enabled BOOLEAN DEFAULT true,
+    refresh_type VARCHAR(20) NOT NULL DEFAULT 'interval',
+    refresh_value VARCHAR(50) NOT NULL DEFAULT '24h',
+    last_fetched_at DATETIME(6),
+    last_success_at DATETIME(6),
+    last_error TEXT,
+    entry_count INT DEFAULT 0,
+    exclude_private_ips BOOLEAN DEFAULT false,
+    created_at DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    UNIQUE KEY uq_filter_subscriptions_url (url(768))
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+CREATE TABLE IF NOT EXISTS geo_restrictions (
+    id VARCHAR(36) NOT NULL DEFAULT (UUID()),
+    proxy_host_id VARCHAR(36) NOT NULL,
+    mode VARCHAR(20) NOT NULL DEFAULT 'blacklist',
+    countries TEXT NOT NULL DEFAULT ('{}'),
+    enabled BOOLEAN DEFAULT true,
+    created_at DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    allowed_ips TEXT DEFAULT ('{}'),
+    challenge_mode BOOLEAN DEFAULT false,
+    blocked_cloud_providers TEXT DEFAULT ('{}'),
+    challenge_cloud_providers BOOLEAN DEFAULT false,
+    allow_search_bots_cloud_providers BOOLEAN DEFAULT false,
+    allow_private_ips BOOLEAN DEFAULT true,
+    allow_search_bots BOOLEAN DEFAULT false,
+    disable_global BOOLEAN NOT NULL DEFAULT false,
+    cloud_disable_global BOOLEAN NOT NULL DEFAULT false,
+    PRIMARY KEY (id),
+    CONSTRAINT geo_restrictions_mode_check CHECK (mode IN ('whitelist', 'blacklist')),
+    UNIQUE KEY geo_restrictions_proxy_host_id_key (proxy_host_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+CREATE TABLE IF NOT EXISTS geoip_update_history (
+    id VARCHAR(36) NOT NULL DEFAULT (UUID()),
+    "status" VARCHAR(20) NOT NULL DEFAULT 'pending',
+    trigger_type VARCHAR(20) NOT NULL DEFAULT 'manual',
+    started_at DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    completed_at DATETIME(6),
+    duration_ms INT,
+    database_version VARCHAR(50),
+    country_db_size BIGINT,
+    asn_db_size BIGINT,
+    error_message TEXT,
+    created_at DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    PRIMARY KEY (id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+-- Slice 2 (Bot Filter): singleton global_bot_filters (enabled OFF by default →
+-- zero behavior change on upgrade) + bot_filters.disable_global. Same 3-state,
+-- service-layer resolution, templates unchanged. Canonical execution in migration.go.
+CREATE TABLE IF NOT EXISTS global_bot_filters (
+    id VARCHAR(36) NOT NULL DEFAULT (UUID()),
+    enabled BOOLEAN DEFAULT false,
+    block_bad_bots BOOLEAN DEFAULT true,
+    block_ai_bots BOOLEAN DEFAULT false,
+    allow_search_engines BOOLEAN DEFAULT true,
+    block_suspicious_clients BOOLEAN DEFAULT false,
+    custom_blocked_agents TEXT,
+    custom_allowed_agents TEXT,
+    challenge_suspicious BOOLEAN DEFAULT false,
+    created_at DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    singleton_key TINYINT AS (1) VIRTUAL,
+    PRIMARY KEY (id),
+    UNIQUE KEY idx_global_bot_filters_singleton (singleton_key)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+-- Slice 4 (Cloud Provider): singleton global_cloud_providers (empty blocked list
+-- by default → zero behavior change on upgrade) + geo_restrictions.cloud_disable_global
+-- (SEPARATE from geo disable_global — a host can inherit geo yet override cloud).
+-- No explicit enabled flag: the global default is "active" when blocked_providers
+-- is non-empty. Service-layer resolution, templates unchanged. Canonical in migration.go.
+CREATE TABLE IF NOT EXISTS global_cloud_providers (
+    id VARCHAR(36) NOT NULL DEFAULT (UUID()),
+    blocked_providers TEXT NOT NULL DEFAULT ('{}'),
+    challenge_mode BOOLEAN DEFAULT false,
+    allow_search_bots BOOLEAN DEFAULT false,
+    created_at DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    singleton_key TINYINT AS (1) VIRTUAL,
+    PRIMARY KEY (id),
+    UNIQUE KEY idx_global_cloud_providers_singleton (singleton_key)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+CREATE TABLE IF NOT EXISTS global_exploit_rule_exclusions (
+    id VARCHAR(36) NOT NULL DEFAULT (UUID()),
+    rule_id VARCHAR(36) NOT NULL,
+    uri_pattern TEXT,
+    reason TEXT,
+    disabled_by VARCHAR(100),
+    created_at DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    uri_pattern_key VARCHAR(512) AS (COALESCE(uri_pattern, '')) VIRTUAL,
+    PRIMARY KEY (id),
+    UNIQUE KEY idx_global_exploit_exclusions_rule_uri_unique (rule_id, uri_pattern_key)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+-- v2.31.0 (#198): global default + per-host override for security options.
+-- Slice 1 (GeoIP): singleton global_geo_restrictions (enabled OFF by default →
+-- zero behavior change on upgrade) + geo_restrictions.disable_global for the
+-- per-host 3-state (inherit/override/disable). Resolution is service-layer;
+-- nginx templates are unchanged. Canonical execution in migration.go upgrades.
+CREATE TABLE IF NOT EXISTS global_geo_restrictions (
+    id VARCHAR(36) NOT NULL DEFAULT (UUID()),
+    enabled BOOLEAN DEFAULT false,
+    mode VARCHAR(20) NOT NULL DEFAULT 'blacklist',
+    countries TEXT NOT NULL DEFAULT ('{}'),
+    allowed_ips TEXT DEFAULT ('{}'),
+    allow_private_ips BOOLEAN DEFAULT true,
+    allow_search_bots BOOLEAN DEFAULT false,
+    challenge_mode BOOLEAN DEFAULT false,
+    created_at DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    singleton_key TINYINT AS (1) VIRTUAL,
+    PRIMARY KEY (id),
+    CONSTRAINT global_geo_restrictions_mode_check CHECK (mode IN ('whitelist', 'blacklist')),
+    UNIQUE KEY idx_global_geo_restrictions_singleton (singleton_key)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+-- Slice 5 (Rate Limit): singleton global_rate_limits (enabled OFF by default →
+-- zero behavior change on upgrade) + rate_limits.disable_global. The nginx
+-- limit_req zone stays per-host (unique zone name per host); the global default
+-- only supplies the RPS/burst/etc values an inheriting host's zone uses.
+-- Service-layer resolution, templates unchanged. Canonical in migration.go.
+CREATE TABLE IF NOT EXISTS global_rate_limits (
+    id VARCHAR(36) NOT NULL DEFAULT (UUID()),
+    enabled BOOLEAN DEFAULT false,
+    requests_per_second INT DEFAULT 50,
+    burst_size INT DEFAULT 100,
+    zone_size VARCHAR(10) DEFAULT '10m',
+    limit_by VARCHAR(20) DEFAULT 'ip',
+    limit_response INT DEFAULT 429,
+    whitelist_ips TEXT,
+    created_at DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    singleton_key TINYINT AS (1) VIRTUAL,
+    PRIMARY KEY (id),
+    UNIQUE KEY idx_global_rate_limits_singleton (singleton_key)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+-- Slice 3 (Security Headers): singleton global_security_headers (enabled OFF by
+-- default → zero behavior change on upgrade) + security_headers.disable_global.
+-- Same 3-state, service-layer resolution, templates unchanged. Canonical execution
+-- in migration.go.
+CREATE TABLE IF NOT EXISTS global_security_headers (
+    id VARCHAR(36) NOT NULL DEFAULT (UUID()),
+    enabled BOOLEAN DEFAULT false,
+    hsts_enabled BOOLEAN DEFAULT true,
+    hsts_max_age INT DEFAULT 31536000,
+    hsts_include_subdomains BOOLEAN DEFAULT true,
+    hsts_preload BOOLEAN DEFAULT false,
+    x_frame_options VARCHAR(50) DEFAULT 'SAMEORIGIN',
+    x_content_type_options BOOLEAN DEFAULT true,
+    x_xss_protection BOOLEAN DEFAULT true,
+    referrer_policy VARCHAR(100) DEFAULT 'strict-origin-when-cross-origin',
+    content_security_policy TEXT,
+    permissions_policy TEXT,
+    custom_headers JSON DEFAULT ('{}'),
+    created_at DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    singleton_key TINYINT AS (1) VIRTUAL,
+    PRIMARY KEY (id),
+    UNIQUE KEY idx_global_security_headers_singleton (singleton_key)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+CREATE TABLE IF NOT EXISTS global_settings (
+    id VARCHAR(36) NOT NULL DEFAULT (UUID()),
+    worker_processes INT NOT NULL DEFAULT 0,
+    worker_connections INT NOT NULL DEFAULT 8192,
+    worker_rlimit_nofile INT,
+    multi_accept BOOLEAN NOT NULL DEFAULT true,
+    use_epoll BOOLEAN NOT NULL DEFAULT true,
+    sendfile BOOLEAN NOT NULL DEFAULT true,
+    tcp_nopush BOOLEAN NOT NULL DEFAULT true,
+    tcp_nodelay BOOLEAN NOT NULL DEFAULT true,
+    keepalive_timeout INT NOT NULL DEFAULT 30,
+    keepalive_requests INT NOT NULL DEFAULT 1000,
+    types_hash_max_size INT NOT NULL DEFAULT 2048,
+    server_tokens BOOLEAN NOT NULL DEFAULT false,
+    client_body_buffer_size VARCHAR(20) NOT NULL DEFAULT '16k',
+    client_header_buffer_size VARCHAR(20) NOT NULL DEFAULT '4k',
+    client_max_body_size VARCHAR(20) NOT NULL DEFAULT '100m',
+    large_client_header_buffers VARCHAR(20) NOT NULL DEFAULT '4 16k',
+    client_body_timeout INT NOT NULL DEFAULT 60,
+    client_header_timeout INT NOT NULL DEFAULT 60,
+    send_timeout INT NOT NULL DEFAULT 60,
+    proxy_connect_timeout INT NOT NULL DEFAULT 60,
+    proxy_send_timeout INT NOT NULL DEFAULT 60,
+    proxy_read_timeout INT NOT NULL DEFAULT 60,
+    gzip_enabled BOOLEAN NOT NULL DEFAULT true,
+    gzip_vary BOOLEAN NOT NULL DEFAULT true,
+    gzip_proxied VARCHAR(50) NOT NULL DEFAULT 'any',
+    gzip_comp_level INT NOT NULL DEFAULT 6,
+    gzip_buffers VARCHAR(20) NOT NULL DEFAULT '16 8k',
+    gzip_http_version VARCHAR(10) NOT NULL DEFAULT '1.1',
+    gzip_min_length INT NOT NULL DEFAULT 256,
+    gzip_types TEXT NOT NULL DEFAULT ('text/plain text/css text/xml text/javascript application/json application/javascript application/xml application/xml+rss application/x-javascript image/svg+xml'),
+    ssl_protocols VARCHAR(100) NOT NULL DEFAULT 'TLSv1.2 TLSv1.3',
+    ssl_ciphers TEXT NOT NULL DEFAULT ('ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384'),
+    ssl_prefer_server_ciphers BOOLEAN NOT NULL DEFAULT true,
+    ssl_session_cache VARCHAR(50) NOT NULL DEFAULT 'shared:SSL:10m',
+    ssl_session_timeout VARCHAR(20) NOT NULL DEFAULT '1d',
+    ssl_session_tickets BOOLEAN NOT NULL DEFAULT false,
+    ssl_stapling BOOLEAN NOT NULL DEFAULT true,
+    ssl_stapling_verify BOOLEAN NOT NULL DEFAULT true,
+    ssl_ecdh_curve VARCHAR(255) NOT NULL DEFAULT 'X25519MLKEM768:X25519:secp256r1:secp384r1',
+    access_log_enabled BOOLEAN NOT NULL DEFAULT true,
+    access_log_strip_query BOOLEAN NOT NULL DEFAULT false,
+    error_log_level VARCHAR(20) NOT NULL DEFAULT 'warn',
+    resolver VARCHAR(255) DEFAULT '1.1.1.1 8.8.8.8 valid=300s',
+    resolver_timeout VARCHAR(20) DEFAULT '5s',
+    custom_http_config TEXT DEFAULT (''),
+    custom_stream_config TEXT DEFAULT (''),
+    created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    brotli_enabled BOOLEAN NOT NULL DEFAULT false,
+    brotli_comp_level INT NOT NULL DEFAULT 6,
+    brotli_types TEXT NOT NULL DEFAULT ('text/plain text/css text/xml text/javascript application/json application/javascript application/xml application/xml+rss image/svg+xml'),
+    direct_ip_access_action VARCHAR(20) DEFAULT 'allow',
+    enable_ipv6 BOOLEAN NOT NULL DEFAULT true,
+    limit_conn_zone_size VARCHAR(10) DEFAULT '10m',
+    limit_conn_per_ip INT DEFAULT 100,
+    limit_conn_enabled BOOLEAN DEFAULT false,
+    limit_req_zone_size VARCHAR(10) DEFAULT '10m',
+    limit_req_rate INT DEFAULT 50,
+    limit_req_burst INT DEFAULT 100,
+    limit_req_enabled BOOLEAN DEFAULT false,
+    reset_timedout_connection BOOLEAN DEFAULT true,
+    limit_rate INT DEFAULT 0,
+    limit_rate_after VARCHAR(10) DEFAULT '0',
+    proxy_buffer_size VARCHAR(20) NOT NULL DEFAULT '8k',
+    proxy_buffers VARCHAR(20) NOT NULL DEFAULT '8 32k',
+    proxy_busy_buffers_size VARCHAR(20) NOT NULL DEFAULT '128k',
+    proxy_max_temp_file_size VARCHAR(20) NOT NULL DEFAULT '1024m',
+    proxy_temp_file_write_size VARCHAR(20) NOT NULL DEFAULT '64k',
+    proxy_buffering VARCHAR(10) DEFAULT '',
+    proxy_request_buffering VARCHAR(10) DEFAULT '',
+    open_file_cache_enabled BOOLEAN NOT NULL DEFAULT true,
+    open_file_cache_max INT NOT NULL DEFAULT 10000,
+    open_file_cache_inactive VARCHAR(20) NOT NULL DEFAULT '60s',
+    open_file_cache_valid VARCHAR(20) NOT NULL DEFAULT '30s',
+    open_file_cache_min_uses INT NOT NULL DEFAULT 2,
+    open_file_cache_errors BOOLEAN NOT NULL DEFAULT true,
+    brotli_static BOOLEAN NOT NULL DEFAULT true,
+    connection_upgrade_empty VARCHAR(10) NOT NULL DEFAULT '',
+    brotli_min_length INT NOT NULL DEFAULT 1000,
+    PRIMARY KEY (id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+CREATE TABLE IF NOT EXISTS global_uri_blocks (
+    id VARCHAR(36) NOT NULL DEFAULT (UUID()),
+    enabled BOOLEAN DEFAULT true,
+    rules JSON DEFAULT ('[]'),
+    exception_ips TEXT DEFAULT ('{}'),
+    allow_private_ips BOOLEAN DEFAULT true,
+    created_at DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+    singleton_key TINYINT AS (1) VIRTUAL,
+    PRIMARY KEY (id),
+    UNIQUE KEY idx_global_uri_blocks_singleton (singleton_key)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+-- Slice 6 (WAF mode/paranoia): singleton global_waf (enabled OFF by default →
+-- zero behavior change on upgrade) + proxy_hosts.waf_use_global. A host with
+-- waf_use_global=true inherits the global enabled/mode/paranoia/threshold; the
+-- default false keeps every existing host on its own WAF columns. WAF/ModSecurity
+-- changes only take effect after a proxy container restart (reload does not
+-- reparse ModSec rules) — same systemic behavior as per-host WAF edits.
+-- Service-layer resolution onto the config-time host, templates unchanged.
+CREATE TABLE IF NOT EXISTS global_waf (
+    id VARCHAR(36) NOT NULL DEFAULT (UUID()),
+    enabled BOOLEAN DEFAULT false,
+    mode VARCHAR(20) DEFAULT 'detection',
+    paranoia_level INT DEFAULT 1,
+    anomaly_threshold INT DEFAULT 5,
+    created_at DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    singleton_key TINYINT AS (1) VIRTUAL,
+    PRIMARY KEY (id),
+    CONSTRAINT chk_global_waf_anomaly_threshold CHECK (((anomaly_threshold >= 1) AND (anomaly_threshold <= 100))),
+    CONSTRAINT chk_global_waf_paranoia_level CHECK (((paranoia_level >= 1) AND (paranoia_level <= 4))),
+    UNIQUE KEY idx_global_waf_singleton (singleton_key)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+CREATE TABLE IF NOT EXISTS global_waf_policy_history (
+    id VARCHAR(36) NOT NULL DEFAULT (UUID()),
+    rule_id VARCHAR(20) NOT NULL,
+    rule_category VARCHAR(255),
+    rule_description TEXT,
+    action VARCHAR(20) NOT NULL,
+    reason TEXT,
+    changed_by VARCHAR(255),
+    created_at DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    PRIMARY KEY (id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+CREATE TABLE IF NOT EXISTS global_waf_rule_exclusions (
+    id VARCHAR(36) NOT NULL DEFAULT (UUID()),
+    rule_id VARCHAR(20) NOT NULL,
+    rule_category VARCHAR(255),
+    rule_description TEXT,
+    reason TEXT,
+    disabled_by VARCHAR(255),
+    created_at DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    PRIMARY KEY (id),
+    UNIQUE KEY global_waf_rule_exclusions_rule_id_key (rule_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+CREATE TABLE IF NOT EXISTS host_exploit_rule_exclusions (
+    id VARCHAR(36) NOT NULL DEFAULT (UUID()),
+    proxy_host_id VARCHAR(36) NOT NULL,
+    rule_id VARCHAR(36) NOT NULL,
+    uri_pattern TEXT,
+    reason TEXT,
+    disabled_by VARCHAR(100),
+    created_at DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    uri_pattern_key VARCHAR(512) AS (COALESCE(uri_pattern, '')) VIRTUAL,
+    PRIMARY KEY (id),
+    UNIQUE KEY idx_host_exploit_exclusions_host_rule_uri_unique (proxy_host_id, rule_id, uri_pattern_key)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+CREATE TABLE IF NOT EXISTS ip_ban_history (
+    id VARCHAR(36) NOT NULL DEFAULT (UUID()),
+    event_type VARCHAR(10) NOT NULL,
+    ip_address VARCHAR(45) NOT NULL,
+    proxy_host_id VARCHAR(36),
+    domain_name VARCHAR(255),
+    reason TEXT,
+    source VARCHAR(50) NOT NULL,
+    ban_duration INT,
+    expires_at DATETIME(6),
+    is_permanent BOOLEAN DEFAULT false,
+    is_auto BOOLEAN DEFAULT false,
+    fail_count INT,
+    user_id VARCHAR(36),
+    user_email VARCHAR(255),
+    metadata JSON,
+    created_at DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    PRIMARY KEY (id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+-- v2.33.0: log_filter_presets (saved log filter presets, #210)
+CREATE TABLE IF NOT EXISTS log_filter_presets (
+    id VARCHAR(36) NOT NULL DEFAULT (UUID()),
+    name TEXT NOT NULL,
+    log_type TEXT NOT NULL DEFAULT ('access'),
+    filter JSON NOT NULL,
+    created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    PRIMARY KEY (id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+CREATE TABLE IF NOT EXISTS log_settings (
+    id VARCHAR(36) NOT NULL DEFAULT (UUID()),
+    retention_days INT NOT NULL DEFAULT 30,
+    max_logs_per_type BIGINT,
+    auto_cleanup_enabled BOOLEAN NOT NULL DEFAULT true,
+    created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+    system_log_retention_days INT NOT NULL DEFAULT 7,
+    enable_docker_logs BOOLEAN NOT NULL DEFAULT true,
+    filter_health_checks BOOLEAN NOT NULL DEFAULT true,
+    PRIMARY KEY (id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+CREATE TABLE IF NOT EXISTS login_attempts (
+    id VARCHAR(36) NOT NULL DEFAULT (UUID()),
+    ip_address VARCHAR(45) NOT NULL,
+    username VARCHAR(255),
+    success BOOLEAN NOT NULL DEFAULT false,
+    attempted_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    PRIMARY KEY (id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+CREATE TABLE IF NOT EXISTS logs (
+    id VARCHAR(36) NOT NULL DEFAULT (UUID()),
+    log_type ENUM('access', 'error', 'modsec') NOT NULL,
+    "timestamp" DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    host TEXT,
+    client_ip VARCHAR(45),
+    request_method TEXT,
+    request_uri TEXT,
+    request_protocol TEXT,
+    status_code INT,
+    body_bytes_sent BIGINT,
+    request_time DOUBLE,
+    upstream_response_time DOUBLE,
+    upstream_addr TEXT,
+    upstream_status TEXT,
+    http_referer TEXT,
+    http_user_agent TEXT,
+    http_x_forwarded_for TEXT,
+    severity ENUM('debug', 'info', 'notice', 'warn', 'error', 'crit', 'alert', 'emerg'),
+    error_message TEXT,
+    rule_id BIGINT,
+    rule_message TEXT,
+    rule_severity TEXT,
+    rule_data TEXT,
+    attack_type TEXT,
+    action_taken TEXT,
+    proxy_host_id VARCHAR(36),
+    raw_log TEXT,
+    created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    geo_country TEXT,
+    geo_country_code VARCHAR(2),
+    geo_city TEXT,
+    geo_asn TEXT,
+    geo_org TEXT,
+    block_reason ENUM('none', 'waf', 'bot_filter', 'rate_limit', 'geo_block', 'exploit_block', 'banned_ip', 'uri_block', 'cloud_provider_challenge', 'cloud_provider_block', 'access_denied', 'filter_subscription') DEFAULT 'none',
+    bot_category TEXT,
+    exploit_rule VARCHAR(50),
+    PRIMARY KEY (id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin PAGE_COMPRESSED=1 PAGE_COMPRESSION_LEVEL=1;
+CREATE TABLE IF NOT EXISTS logs_partitioned (
+    id VARCHAR(36) NOT NULL DEFAULT (UUID()),
+    log_type ENUM('access', 'error', 'modsec') NOT NULL,
+    "timestamp" DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    host TEXT,
+    client_ip VARCHAR(45),
+    request_method TEXT,
+    request_uri TEXT,
+    request_protocol TEXT,
+    status_code INT,
+    body_bytes_sent BIGINT,
+    request_time DOUBLE,
+    upstream_response_time DOUBLE,
+    upstream_addr TEXT,
+    upstream_status TEXT,
+    http_referer TEXT,
+    http_user_agent TEXT,
+    http_x_forwarded_for TEXT,
+    severity ENUM('debug', 'info', 'notice', 'warn', 'error', 'crit', 'alert', 'emerg'),
+    error_message TEXT,
+    rule_id BIGINT,
+    rule_message TEXT,
+    rule_severity TEXT,
+    rule_data TEXT,
+    attack_type TEXT,
+    action_taken TEXT,
+    proxy_host_id VARCHAR(36),
+    raw_log TEXT,
+    created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    geo_country TEXT,
+    geo_country_code VARCHAR(2),
+    geo_city TEXT,
+    geo_asn TEXT,
+    geo_org TEXT,
+    block_reason ENUM('none', 'waf', 'bot_filter', 'rate_limit', 'geo_block', 'exploit_block', 'banned_ip', 'uri_block', 'cloud_provider_challenge', 'cloud_provider_block', 'access_denied', 'filter_subscription') DEFAULT 'none',
+    bot_category TEXT,
+    exploit_rule VARCHAR(50),
+    PRIMARY KEY (id, created_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin PAGE_COMPRESSED=1 PAGE_COMPRESSION_LEVEL=1
+PARTITION BY RANGE COLUMNS(created_at) (
+    PARTITION p2025_12 VALUES LESS THAN ('2026-01-01 00:00:00'),
+    PARTITION p2026_01 VALUES LESS THAN ('2026-02-01 00:00:00'),
+    PARTITION p2026_02 VALUES LESS THAN ('2026-03-01 00:00:00'),
+    PARTITION p2026_03 VALUES LESS THAN ('2026-04-01 00:00:00'),
+    PARTITION p2026_04 VALUES LESS THAN ('2026-05-01 00:00:00'),
+    PARTITION p2026_05 VALUES LESS THAN ('2026-06-01 00:00:00'),
+    PARTITION p2026_06 VALUES LESS THAN ('2026-07-01 00:00:00'),
+    PARTITION p2026_07 VALUES LESS THAN ('2026-08-01 00:00:00'),
+    PARTITION p2026_08 VALUES LESS THAN ('2026-09-01 00:00:00'),
+    PARTITION p2026_09 VALUES LESS THAN ('2026-10-01 00:00:00'),
+    PARTITION p2026_10 VALUES LESS THAN ('2026-11-01 00:00:00'),
+    PARTITION p2026_11 VALUES LESS THAN ('2026-12-01 00:00:00'),
+    PARTITION p2026_12 VALUES LESS THAN ('2027-01-01 00:00:00'),
+    PARTITION p2027_01 VALUES LESS THAN ('2027-02-01 00:00:00'),
+    PARTITION p2027_02 VALUES LESS THAN ('2027-03-01 00:00:00'),
+    PARTITION p2027_03 VALUES LESS THAN ('2027-04-01 00:00:00'),
+    PARTITION p2027_04 VALUES LESS THAN ('2027-05-01 00:00:00'),
+    PARTITION p2027_05 VALUES LESS THAN ('2027-06-01 00:00:00'),
+    PARTITION p2027_06 VALUES LESS THAN ('2027-07-01 00:00:00'),
+    PARTITION p2027_07 VALUES LESS THAN ('2027-08-01 00:00:00'),
+    PARTITION p2027_08 VALUES LESS THAN ('2027-09-01 00:00:00'),
+    PARTITION p2027_09 VALUES LESS THAN ('2027-10-01 00:00:00'),
+    PARTITION p2027_10 VALUES LESS THAN ('2027-11-01 00:00:00'),
+    PARTITION p2027_11 VALUES LESS THAN ('2027-12-01 00:00:00'),
+    PARTITION p2027_12 VALUES LESS THAN ('2028-01-01 00:00:00'),
+    PARTITION p_max VALUES LESS THAN (MAXVALUE)
+);
+-- Notifications (#221). notification_channels is configuration; state and outbox
+-- are runtime. Foreign keys live in the ALTER section below.
+CREATE TABLE IF NOT EXISTS notification_channels (
+    id VARCHAR(36) NOT NULL DEFAULT (UUID()),
+    name VARCHAR(64) NOT NULL,
+    type VARCHAR(16) NOT NULL,
+    enabled BOOLEAN NOT NULL DEFAULT true,
+    config JSON NOT NULL DEFAULT ('{}'),
+    events TEXT NOT NULL DEFAULT ('{}'),
+    digest_events TEXT NOT NULL DEFAULT ('{}'),
+    rich_format BOOLEAN NOT NULL DEFAULT true,
+    language VARCHAR(8) NOT NULL DEFAULT 'en',
+    dashboard_url TEXT,
+    digest_enabled BOOLEAN NOT NULL DEFAULT false,
+    digest_hour SMALLINT NOT NULL DEFAULT 9,
+    allow_private_target BOOLEAN NOT NULL DEFAULT false,
+    template TEXT,
+    last_success_at DATETIME(6),
+    last_error_at DATETIME(6),
+    last_error TEXT,
+    consecutive_failures INT NOT NULL DEFAULT 0,
+    last_digest_on DATE,
+    created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    name_lower VARCHAR(64) AS (LOWER(name)) VIRTUAL,
+    PRIMARY KEY (id),
+    UNIQUE KEY notification_channels_name_key (name_lower)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+CREATE TABLE IF NOT EXISTS notification_outbox (
+    id BIGINT AUTO_INCREMENT NOT NULL,
+    channel_id VARCHAR(36) NOT NULL,
+    event_key VARCHAR(64) NOT NULL,
+    payload JSON NOT NULL,
+    "status" VARCHAR(16) NOT NULL DEFAULT 'queued',
+    attempts INT NOT NULL DEFAULT 0,
+    next_attempt_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    last_error TEXT,
+    created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    sent_at DATETIME(6),
+    PRIMARY KEY (id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+-- Edge triggering lives here: one row per thing that can be broken, so a failure
+-- that repeats every six hours produces one message rather than four a day.
+CREATE TABLE IF NOT EXISTS notification_state (
+    event_key VARCHAR(64) NOT NULL,
+    subject VARCHAR(255) NOT NULL,
+    subject_label VARCHAR(255),
+    state VARCHAR(16) NOT NULL,
+    since DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    last_detail TEXT,
+    PRIMARY KEY (event_key, subject)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+CREATE TABLE IF NOT EXISTS proxy_hosts (
+    id VARCHAR(36) NOT NULL DEFAULT (UUID()),
+    proxy_type VARCHAR(20) NOT NULL DEFAULT 'http',
+    domain_names TEXT NOT NULL,
+    forward_scheme VARCHAR(10) NOT NULL DEFAULT 'http',
+    forward_host VARCHAR(255) NOT NULL,
+    forward_port INT NOT NULL DEFAULT 80,
+    forward_container_name TEXT,
+    forward_container_network TEXT,
+    stream_listen_host VARCHAR(255) DEFAULT '',
+    stream_listen_port INT DEFAULT 0,
+    stream_protocol VARCHAR(10) DEFAULT 'tcp',
+    stream_ssl_preread BOOLEAN NOT NULL DEFAULT false,
+    stream_accept_proxy_protocol BOOLEAN NOT NULL DEFAULT false,
+    stream_send_proxy_protocol BOOLEAN NOT NULL DEFAULT false,
+    stream_proxy_connect_timeout INT DEFAULT 0,
+    stream_proxy_timeout INT DEFAULT 0,
+    ssl_enabled BOOLEAN NOT NULL DEFAULT false,
+    ssl_force_https BOOLEAN NOT NULL DEFAULT false,
+    ssl_http2 BOOLEAN NOT NULL DEFAULT true,
+    certificate_id VARCHAR(36),
+    allow_websocket_upgrade BOOLEAN NOT NULL DEFAULT true,
+    cache_enabled BOOLEAN NOT NULL DEFAULT false,
+    cache_static_only BOOLEAN NOT NULL DEFAULT true,
+    cache_ttl VARCHAR(20) NOT NULL DEFAULT '7d',
+    block_exploits BOOLEAN NOT NULL DEFAULT true,
+    custom_locations JSON DEFAULT ('[]'),
+    advanced_config TEXT DEFAULT (''),
+    waf_enabled BOOLEAN NOT NULL DEFAULT false,
+    waf_mode VARCHAR(20) DEFAULT 'detection',
+    access_list_id VARCHAR(36),
+    auth_provider_id VARCHAR(36),
+    auth_bypass_paths TEXT DEFAULT ('{}'),
+    enabled BOOLEAN NOT NULL DEFAULT true,
+    meta JSON DEFAULT ('{}'),
+    created_at DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+    ssl_http3 BOOLEAN NOT NULL DEFAULT false,
+    rate_limit_enabled BOOLEAN DEFAULT false,
+    fail2ban_enabled BOOLEAN DEFAULT false,
+    bot_filter_enabled BOOLEAN DEFAULT false,
+    security_headers_enabled BOOLEAN DEFAULT false,
+    waf_paranoia_level INT DEFAULT 1,
+    waf_anomaly_threshold INT DEFAULT 5,
+    block_exploits_exceptions TEXT DEFAULT (''),
+    proxy_connect_timeout INT DEFAULT 0,
+    proxy_send_timeout INT DEFAULT 0,
+    proxy_read_timeout INT DEFAULT 0,
+    proxy_buffering VARCHAR(10) DEFAULT '',
+    proxy_request_buffering VARCHAR(10) DEFAULT '',
+    client_max_body_size VARCHAR(20) DEFAULT '',
+    proxy_max_temp_file_size VARCHAR(20) DEFAULT '',
+    is_favorite BOOLEAN NOT NULL DEFAULT false,
+    config_status VARCHAR(20) NOT NULL DEFAULT 'ok',
+    config_error TEXT,
+    ddns_enabled BOOLEAN NOT NULL DEFAULT false,
+    ddns_provider_id VARCHAR(36),
+    ddns_proxied BOOLEAN NOT NULL DEFAULT false,
+    waf_use_global BOOLEAN NOT NULL DEFAULT false,
+    proxy_hosts_stream_listener_key VARCHAR(768) AS (CASE WHEN proxy_type = 'stream' AND enabled = true AND stream_listen_port > 0 THEN CONCAT_WS('\n', COALESCE(stream_listen_host, ''), COALESCE(CAST(stream_listen_port AS CHAR), ''), COALESCE(stream_protocol, '')) END) VIRTUAL,
+    PRIMARY KEY (id),
+    CONSTRAINT chk_waf_anomaly_threshold CHECK (((waf_anomaly_threshold >= 1) AND (waf_anomaly_threshold <= 100))),
+    CONSTRAINT chk_waf_paranoia_level CHECK (((waf_paranoia_level >= 1) AND (waf_paranoia_level <= 4))),
+    UNIQUE KEY idx_proxy_hosts_stream_listener_unique (proxy_hosts_stream_listener_key)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+CREATE TABLE IF NOT EXISTS rate_limits (
+    id VARCHAR(36) NOT NULL DEFAULT (UUID()),
+    proxy_host_id VARCHAR(36) NOT NULL,
+    enabled BOOLEAN DEFAULT true,
+    requests_per_second INT DEFAULT 10,
+    burst_size INT DEFAULT 20,
+    zone_size VARCHAR(10) DEFAULT '10m',
+    limit_by VARCHAR(20) DEFAULT 'ip',
+    limit_response INT DEFAULT 429,
+    whitelist_ips TEXT,
+    disable_global BOOLEAN NOT NULL DEFAULT false,
+    created_at DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    PRIMARY KEY (id),
+    UNIQUE KEY rate_limits_proxy_host_id_key (proxy_host_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+CREATE TABLE IF NOT EXISTS redirect_hosts (
+    id VARCHAR(36) NOT NULL DEFAULT (UUID()),
+    domain_names TEXT NOT NULL DEFAULT ('{}'),
+    forward_scheme VARCHAR(10) NOT NULL DEFAULT 'auto',
+    forward_domain_name VARCHAR(255) NOT NULL,
+    forward_path VARCHAR(1024) DEFAULT '',
+    preserve_path BOOLEAN DEFAULT true,
+    redirect_code INT DEFAULT 301,
+    ssl_enabled BOOLEAN DEFAULT false,
+    certificate_id VARCHAR(36),
+    ssl_force_https BOOLEAN DEFAULT true,
+    enabled BOOLEAN DEFAULT true,
+    block_exploits BOOLEAN DEFAULT false,
+    meta JSON DEFAULT ('{}'),
+    created_at DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    PRIMARY KEY (id),
+    CONSTRAINT redirect_hosts_redirect_code_check CHECK (redirect_code IN (301, 302, 307, 308))
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+CREATE TABLE IF NOT EXISTS role_permissions (
+    role_id VARCHAR(36) NOT NULL,
+    permission VARCHAR(64) NOT NULL,
+    PRIMARY KEY (role_id, permission)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+-- RBAC (#222). Roles are named permission sets; role_permissions holds the
+-- area:verb strings defined in model/permission.go. Constraints and the FK from
+-- users live in the ALTER section below, because a fresh install runs this file
+-- top to bottom and users is created before roles.
+CREATE TABLE IF NOT EXISTS roles (
+    id VARCHAR(36) NOT NULL DEFAULT (UUID()),
+    name VARCHAR(64) NOT NULL,
+    description TEXT,
+    is_superuser BOOLEAN NOT NULL DEFAULT false,
+    is_builtin BOOLEAN NOT NULL DEFAULT false,
+    created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    name_lower VARCHAR(64) AS (LOWER(name)) VIRTUAL,
+    PRIMARY KEY (id),
+    UNIQUE KEY roles_name_key (name_lower)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+-- Note: schema_migrations table is created by migration.go, not here
+CREATE TABLE IF NOT EXISTS security_headers (
+    id VARCHAR(36) NOT NULL DEFAULT (UUID()),
+    proxy_host_id VARCHAR(36) NOT NULL,
+    enabled BOOLEAN DEFAULT true,
+    hsts_enabled BOOLEAN DEFAULT true,
+    hsts_max_age INT DEFAULT 31536000,
+    hsts_include_subdomains BOOLEAN DEFAULT true,
+    hsts_preload BOOLEAN DEFAULT false,
+    x_frame_options VARCHAR(100) DEFAULT 'SAMEORIGIN',
+    x_content_type_options BOOLEAN DEFAULT true,
+    x_xss_protection BOOLEAN DEFAULT true,
+    referrer_policy VARCHAR(50) DEFAULT 'strict-origin-when-cross-origin',
+    content_security_policy TEXT,
+    permissions_policy TEXT,
+    custom_headers JSON,
+    disable_global BOOLEAN NOT NULL DEFAULT false,
+    created_at DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    PRIMARY KEY (id),
+    UNIQUE KEY security_headers_proxy_host_id_key (proxy_host_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+CREATE TABLE IF NOT EXISTS settings (
+    "key" VARCHAR(255) NOT NULL,
+    value JSON NOT NULL,
+    updated_at DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    PRIMARY KEY ("key")
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+-- Short-lived CSRF/PKCE state. Server-side rather than a cookie: the panel may
+-- be served over plain HTTP on a LAN, where SameSite/Secure cookies are a trap.
+CREATE TABLE IF NOT EXISTS sso_login_states (
+    state VARCHAR(64) NOT NULL,
+    provider_id VARCHAR(36) NOT NULL,
+    nonce VARCHAR(64) NOT NULL,
+    code_verifier VARCHAR(128) NOT NULL,
+    created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    expires_at DATETIME(6) NOT NULL,
+    PRIMARY KEY (state)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+-- OIDC SSO for the admin panel (#227). Distinct from auth_providers, which
+-- protects PROXIED HOSTS with ForwardAuth; these rows let someone sign in to
+-- THIS panel. Foreign keys live in the ALTER section below.
+CREATE TABLE IF NOT EXISTS sso_providers (
+    id VARCHAR(36) NOT NULL DEFAULT (UUID()),
+    slug VARCHAR(32) NOT NULL,
+    name VARCHAR(64) NOT NULL,
+    issuer_url TEXT NOT NULL,
+    client_id TEXT NOT NULL,
+    client_secret TEXT NOT NULL,
+    scopes TEXT NOT NULL DEFAULT ('openid profile email'),
+    callback_base_url TEXT,
+    enabled BOOLEAN NOT NULL DEFAULT true,
+    allow_jit BOOLEAN NOT NULL DEFAULT false,
+    allowed_email_domains TEXT NOT NULL DEFAULT ('{}'),
+    allowed_emails TEXT NOT NULL DEFAULT ('{}'),
+    group_claim VARCHAR(64) NOT NULL DEFAULT 'groups',
+    required_group TEXT,
+    default_role_id VARCHAR(36),
+    group_role_mappings JSON NOT NULL DEFAULT ('[]'),
+    created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    slug_lower VARCHAR(32) AS (LOWER(slug)) VIRTUAL,
+    PRIMARY KEY (id),
+    UNIQUE KEY sso_providers_slug_key (slug_lower)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+CREATE TABLE IF NOT EXISTS system_health (
+    id VARCHAR(36) NOT NULL DEFAULT (UUID()),
+    recorded_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    nginx_status VARCHAR(20) NOT NULL DEFAULT 'unknown',
+    nginx_workers INT DEFAULT 0,
+    nginx_connections_active INT DEFAULT 0,
+    nginx_connections_reading INT DEFAULT 0,
+    nginx_connections_writing INT DEFAULT 0,
+    nginx_connections_waiting INT DEFAULT 0,
+    db_status VARCHAR(20) NOT NULL DEFAULT 'unknown',
+    db_connections INT DEFAULT 0,
+    cpu_usage DOUBLE DEFAULT 0,
+    memory_usage DOUBLE DEFAULT 0,
+    disk_usage DOUBLE DEFAULT 0,
+    certs_total INT DEFAULT 0,
+    certs_expiring_soon INT DEFAULT 0,
+    certs_expired INT DEFAULT 0,
+    upstreams_total INT DEFAULT 0,
+    upstreams_healthy INT DEFAULT 0,
+    upstreams_unhealthy INT DEFAULT 0,
+    memory_total BIGINT DEFAULT 0,
+    memory_used BIGINT DEFAULT 0,
+    disk_total BIGINT DEFAULT 0,
+    disk_used BIGINT DEFAULT 0,
+    disk_path VARCHAR(255) DEFAULT '/',
+    network_in BIGINT DEFAULT 0,
+    network_out BIGINT DEFAULT 0,
+    uptime_seconds BIGINT DEFAULT 0,
+    hostname VARCHAR(255) DEFAULT '',
+    os VARCHAR(255) DEFAULT '',
+    platform VARCHAR(100) DEFAULT '',
+    kernel_version VARCHAR(255) DEFAULT '',
+    PRIMARY KEY (id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+CREATE TABLE IF NOT EXISTS system_logs (
+    id VARCHAR(36) NOT NULL DEFAULT (UUID()),
+    source ENUM('docker_api', 'docker_nginx', 'docker_db', 'docker_ui', 'health_check', 'internal', 'scheduler', 'backup', 'certificate', 'audit', 'api_token') NOT NULL,
+    level ENUM('debug', 'info', 'warn', 'error', 'fatal') NOT NULL DEFAULT 'info',
+    message TEXT NOT NULL,
+    details JSON,
+    container_name VARCHAR(100),
+    component VARCHAR(100),
+    created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    PRIMARY KEY (id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin PAGE_COMPRESSED=1 PAGE_COMPRESSION_LEVEL=1;
+CREATE TABLE IF NOT EXISTS system_settings (
+    id VARCHAR(36) NOT NULL DEFAULT (UUID()),
+    geoip_enabled BOOLEAN NOT NULL DEFAULT false,
+    maxmind_license_key VARCHAR(255) DEFAULT '',
+    maxmind_account_id VARCHAR(100) DEFAULT '',
+    geoip_auto_update BOOLEAN NOT NULL DEFAULT true,
+    geoip_update_interval VARCHAR(20) NOT NULL DEFAULT '7d',
+    geoip_last_updated DATETIME(6),
+    geoip_database_version VARCHAR(100) DEFAULT '',
+    acme_enabled BOOLEAN NOT NULL DEFAULT true,
+    acme_email VARCHAR(255) DEFAULT '',
+    acme_staging BOOLEAN NOT NULL DEFAULT false,
+    acme_auto_renew BOOLEAN NOT NULL DEFAULT true,
+    acme_renew_days_before INT NOT NULL DEFAULT 30,
+    acme_dns_provider VARCHAR(50) DEFAULT '',
+    acme_dns_credentials JSON DEFAULT ('{}'),
+    notification_email VARCHAR(255) DEFAULT '',
+    notify_cert_expiry BOOLEAN NOT NULL DEFAULT true,
+    notify_cert_expiry_days INT NOT NULL DEFAULT 14,
+    notify_security_events BOOLEAN NOT NULL DEFAULT true,
+    notify_backup_complete BOOLEAN NOT NULL DEFAULT false,
+    log_retention_days INT NOT NULL DEFAULT 30,
+    stats_retention_days INT NOT NULL DEFAULT 90,
+    backup_retention_count INT NOT NULL DEFAULT 10,
+    auto_backup_enabled BOOLEAN NOT NULL DEFAULT false,
+    auto_backup_schedule VARCHAR(50) DEFAULT '0 2 * * *',
+    created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    access_log_retention_days INT NOT NULL DEFAULT 1095,
+    waf_log_retention_days INT NOT NULL DEFAULT 90,
+    error_log_retention_days INT NOT NULL DEFAULT 30,
+    system_log_retention_days INT NOT NULL DEFAULT 30,
+    audit_log_retention_days INT NOT NULL DEFAULT 1095,
+    raw_log_enabled BOOLEAN NOT NULL DEFAULT true,
+    raw_log_retention_days INT NOT NULL DEFAULT 7,
+    raw_log_max_size_mb INT NOT NULL DEFAULT 100,
+    raw_log_rotate_count INT NOT NULL DEFAULT 5,
+    raw_log_compress_rotated BOOLEAN NOT NULL DEFAULT true,
+    bot_filter_default_enabled BOOLEAN DEFAULT false,
+    bot_filter_default_block_bad_bots BOOLEAN DEFAULT true,
+    bot_filter_default_block_ai_bots BOOLEAN DEFAULT false,
+    bot_filter_default_allow_search_engines BOOLEAN DEFAULT true,
+    bot_filter_default_challenge_suspicious BOOLEAN DEFAULT false,
+    bot_filter_default_custom_blocked_agents TEXT DEFAULT (''),
+    bot_list_bad_bots TEXT DEFAULT ('AhrefsBot SemrushBot DotBot MJ12bot BLEXBot DataForSeoBot serpstatbot AspiegelBot BacklinkCrawler Exabot Screaming Frog MegaIndex LinkpadBot Nimbostratus-Bot TurnitinBot PetalBot Seekport Crawler Bytespider MauiBot Sogou web spider YandexBot Baiduspider'),
+    bot_list_ai_bots TEXT DEFAULT ('GPTBot ChatGPT-User Claude-Web ClaudeBot anthropic-ai Amazonbot CCBot Google-Extended FacebookBot PerplexityBot YouBot Cohere-ai'),
+    bot_list_search_engines TEXT DEFAULT ('Googlebot Bingbot DuckDuckBot Slurp facebot Twitterbot LinkedInBot WhatsApp TelegramBot Discordbot Slackbot Applebot'),
+    bot_list_suspicious_clients TEXT DEFAULT ('curl Wget libwww-perl python-requests Python-urllib Python-httpx httpx aiohttp Java Go-http-client Go-http http_requester HttpClient Apache-HttpClient okhttp node-fetch axios got request fetch urllib http.client requests scrapy mechanize phantom headless puppeteer playwright selenium chromedriver geckodriver'),
+    bot_filter_default_block_suspicious_clients BOOLEAN DEFAULT false,
+    waf_auto_ban_enabled BOOLEAN DEFAULT false,
+    waf_auto_ban_threshold INT DEFAULT 10,
+    waf_auto_ban_window INT DEFAULT 300,
+    waf_auto_ban_duration INT DEFAULT 3600,
+    direct_ip_access_action VARCHAR(20) DEFAULT 'allow',
+    system_logs_enabled BOOLEAN NOT NULL DEFAULT true,
+    system_logs_levels JSON DEFAULT ('{"npm-guard-db": "warn", "npm-guard-ui": "warn", "npm-guard-api": "info", "npm-guard-proxy": "info"}'),
+    system_logs_exclude_patterns TEXT DEFAULT ('{"/health","/nginx_status","/.well-known/","HEAD /"}'),
+    system_logs_stdout_excluded TEXT DEFAULT ('{"npm-guard-proxy"}'),
+    ui_font_family VARCHAR(50) DEFAULT 'system',
+    ui_error_page_language VARCHAR(10) DEFAULT 'auto',
+    global_block_exploits_exceptions TEXT DEFAULT ('^/wp-json/ ^/api/v1/challenge/ ^/wp-admin/admin-ajax.php ^/webapi/'),
+    global_trusted_ips TEXT DEFAULT (''),
+    global_trusted_ips_bypass_waf BOOLEAN NOT NULL DEFAULT false,
+    ddns_check_interval_minutes INT NOT NULL DEFAULT 5,
+    PRIMARY KEY (id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+CREATE TABLE IF NOT EXISTS upstream_servers (
+    id VARCHAR(36) NOT NULL DEFAULT (UUID()),
+    upstream_id VARCHAR(36) NOT NULL,
+    address VARCHAR(255) NOT NULL,
+    port INT DEFAULT 80,
+    weight INT DEFAULT 1,
+    max_fails INT DEFAULT 3,
+    fail_timeout INT DEFAULT 30,
+    is_backup BOOLEAN DEFAULT false,
+    is_down BOOLEAN DEFAULT false,
+    is_healthy BOOLEAN DEFAULT true,
+    last_check_at DATETIME(6),
+    last_error TEXT,
+    created_at DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    PRIMARY KEY (id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+CREATE TABLE IF NOT EXISTS upstreams (
+    id VARCHAR(36) NOT NULL DEFAULT (UUID()),
+    proxy_host_id VARCHAR(36) NOT NULL,
+    name VARCHAR(255) NOT NULL,
+    scheme VARCHAR(10) NOT NULL DEFAULT 'http',
+    servers JSON NOT NULL DEFAULT ('[]'),
+    load_balance VARCHAR(20) DEFAULT 'round_robin',
+    health_check_enabled BOOLEAN DEFAULT false,
+    health_check_interval INT DEFAULT 30,
+    health_check_timeout INT DEFAULT 5,
+    health_check_path VARCHAR(255) DEFAULT '/',
+    health_check_expected_status INT DEFAULT 200,
+    keepalive INT DEFAULT 32,
+    is_healthy BOOLEAN DEFAULT true,
+    last_check_at DATETIME(6),
+    created_at DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    PRIMARY KEY (id),
+    UNIQUE KEY upstreams_proxy_host_id_key (proxy_host_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+CREATE TABLE IF NOT EXISTS uri_blocks (
+    id VARCHAR(36) NOT NULL DEFAULT (UUID()),
+    proxy_host_id VARCHAR(36) NOT NULL,
+    enabled BOOLEAN DEFAULT true,
+    rules JSON DEFAULT ('[]'),
+    exception_ips TEXT DEFAULT ('{}'),
+    allow_private_ips BOOLEAN DEFAULT true,
+    created_at DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+    PRIMARY KEY (id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+-- One row per (provider, IdP subject). The subject is the stable identifier;
+-- email is kept only for display and can change at the IdP.
+CREATE TABLE IF NOT EXISTS user_identities (
+    provider_id VARCHAR(36) NOT NULL,
+    subject TEXT NOT NULL,
+    user_id VARCHAR(36) NOT NULL,
+    email TEXT,
+    last_login_at DATETIME(6),
+    created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    PRIMARY KEY (provider_id, subject(191))
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+CREATE TABLE IF NOT EXISTS users (
+    id VARCHAR(36) NOT NULL DEFAULT (UUID()),
+    email VARCHAR(255) NOT NULL,
+    password_hash VARCHAR(255) NOT NULL,
+    name VARCHAR(255),
+    role VARCHAR(50) DEFAULT 'user',
+    created_at DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    username VARCHAR(255) NOT NULL,
+    is_initial_setup BOOLEAN NOT NULL DEFAULT true,
+    last_login_at DATETIME(6),
+    last_login_ip VARCHAR(45),
+    login_count INT NOT NULL DEFAULT 0,
+    totp_secret VARCHAR(255),
+    totp_enabled BOOLEAN NOT NULL DEFAULT false,
+    totp_verified_at DATETIME(6),
+    backup_codes TEXT,
+    language VARCHAR(10) DEFAULT 'ko',
+    font_family VARCHAR(100) DEFAULT 'system',
+    role_id VARCHAR(36),
+    must_change_password BOOLEAN NOT NULL DEFAULT false,
+    PRIMARY KEY (id),
+    UNIQUE KEY users_email_key (email)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+CREATE TABLE IF NOT EXISTS waf_policy_history (
+    id VARCHAR(36) NOT NULL DEFAULT (UUID()),
+    proxy_host_id VARCHAR(36) NOT NULL,
+    rule_id INT NOT NULL,
+    rule_category VARCHAR(100),
+    rule_description TEXT,
+    action VARCHAR(20) NOT NULL,
+    reason TEXT,
+    changed_by VARCHAR(255),
+    created_at DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    PRIMARY KEY (id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+CREATE TABLE IF NOT EXISTS waf_rule_change_events (
+    id VARCHAR(36) NOT NULL DEFAULT (UUID()),
+    proxy_host_id VARCHAR(36),
+    rule_id VARCHAR(20) NOT NULL,
+    action VARCHAR(20) NOT NULL,
+    rule_category VARCHAR(255),
+    rule_description TEXT,
+    reason TEXT,
+    changed_by VARCHAR(255),
+    created_at DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    PRIMARY KEY (id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+CREATE TABLE IF NOT EXISTS waf_rule_exclusions (
+    id VARCHAR(36) NOT NULL DEFAULT (UUID()),
+    proxy_host_id VARCHAR(36) NOT NULL,
+    rule_id INT NOT NULL,
+    rule_category VARCHAR(100),
+    rule_description TEXT,
+    reason TEXT,
+    disabled_by VARCHAR(255),
+    created_at DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    PRIMARY KEY (id),
+    UNIQUE KEY waf_rule_exclusions_proxy_host_id_rule_id_key (proxy_host_id, rule_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+CREATE TABLE IF NOT EXISTS waf_rule_snapshot_details (
+    id VARCHAR(36) NOT NULL DEFAULT (UUID()),
+    snapshot_id VARCHAR(36) NOT NULL,
+    rule_id VARCHAR(20) NOT NULL,
+    rule_category VARCHAR(255),
+    rule_description TEXT,
+    is_disabled BOOLEAN DEFAULT false,
+    reason TEXT,
+    PRIMARY KEY (id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+CREATE TABLE IF NOT EXISTS waf_rule_snapshots (
+    id VARCHAR(36) NOT NULL DEFAULT (UUID()),
+    proxy_host_id VARCHAR(36),
+    version_number INT NOT NULL,
+    snapshot_name VARCHAR(255),
+    rule_engine VARCHAR(20),
+    paranoia_level INT,
+    anomaly_threshold INT,
+    total_rules INT DEFAULT 0,
+    disabled_rules INT DEFAULT 0,
+    change_description TEXT,
+    created_by VARCHAR(255),
+    created_at DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    PRIMARY KEY (id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+
+-- --------------------------------------------------------------------------
+-- Indexes
+-- --------------------------------------------------------------------------
+-- idx_global_bot_filters_singleton is enforced by the singleton_key generated column on global_bot_filters
+CREATE UNIQUE INDEX IF NOT EXISTS idx_ddns_records_hostname_provider ON ddns_records (hostname, dns_provider_id);
+-- idx_global_cloud_providers_singleton is enforced by the singleton_key generated column on global_cloud_providers
+-- idx_global_geo_restrictions_singleton is enforced by the singleton_key generated column on global_geo_restrictions
+-- idx_global_rate_limits_singleton is enforced by the singleton_key generated column on global_rate_limits
+-- idx_global_waf_singleton is enforced by the singleton_key generated column on global_waf
+-- idx_cloudflare_tunnel_singleton is enforced by the singleton_key generated column on cloudflare_tunnel
+CREATE INDEX IF NOT EXISTS idx_log_filter_presets_log_type ON log_filter_presets (log_type(191));
+-- idx_global_security_headers_singleton is enforced by the singleton_key generated column on global_security_headers
+-- roles_name_key is enforced by generated column(s) name_lower on roles
+-- sso_providers_slug_key is enforced by generated column(s) slug_lower on sso_providers
+CREATE UNIQUE INDEX IF NOT EXISTS user_identities_user_provider_key ON user_identities (user_id, provider_id);
+CREATE INDEX IF NOT EXISTS sso_login_states_expires_at_idx ON sso_login_states (expires_at);
+-- notification_channels_name_key is enforced by generated column(s) name_lower on notification_channels
+CREATE INDEX IF NOT EXISTS notification_outbox_due_idx ON notification_outbox (status, next_attempt_at);
+CREATE INDEX IF NOT EXISTS idx_access_list_items_list_id ON access_list_items (access_list_id);
+CREATE INDEX IF NOT EXISTS idx_api_token_usage_created_at ON api_token_usage (created_at);
+CREATE INDEX IF NOT EXISTS idx_api_token_usage_token_id ON api_token_usage (token_id);
+CREATE INDEX IF NOT EXISTS idx_api_tokens_is_active ON api_tokens (is_active);  -- 부분 인덱스 술어 제거(최적화 목적일 뿐): WHERE (is_active = true)
+CREATE INDEX IF NOT EXISTS idx_api_tokens_token_hash ON api_tokens (token_hash);
+CREATE INDEX IF NOT EXISTS idx_api_tokens_user_id ON api_tokens (user_id);
+CREATE INDEX IF NOT EXISTS idx_audit_logs_action ON audit_logs (action);
+CREATE INDEX IF NOT EXISTS idx_audit_logs_created_at ON audit_logs (created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_audit_logs_resource_type ON audit_logs (resource_type);
+CREATE INDEX IF NOT EXISTS idx_audit_logs_user_created ON audit_logs (user_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_audit_logs_user_id ON audit_logs (user_id);
+CREATE INDEX IF NOT EXISTS idx_auth_sessions_expires_at ON auth_sessions (expires_at);
+CREATE INDEX IF NOT EXISTS idx_auth_sessions_token_hash ON auth_sessions (token_hash);
+CREATE INDEX IF NOT EXISTS idx_auth_sessions_user_id ON auth_sessions (user_id);
+CREATE INDEX IF NOT EXISTS idx_backups_created ON backups (created_at);
+CREATE INDEX IF NOT EXISTS idx_banned_ips_auto ON banned_ips (is_auto_banned, expires_at);
+CREATE INDEX IF NOT EXISTS idx_banned_ips_expires ON banned_ips (expires_at);
+-- idx_banned_ips_ip_global_unique is enforced by the banned_ips_ip_global_key generated column on banned_ips (WHERE proxy_host_id IS NULL)
+-- idx_banned_ips_ip_host_unique is enforced by the banned_ips_ip_host_key generated column on banned_ips (WHERE proxy_host_id IS NOT NULL)
+CREATE INDEX IF NOT EXISTS idx_banned_ips_lookup ON banned_ips (ip_address, expires_at, is_permanent);
+CREATE INDEX IF NOT EXISTS idx_banned_ips_proxy_host ON banned_ips (proxy_host_id);
+CREATE INDEX IF NOT EXISTS idx_certificates_auto_renew ON certificates (auto_renew);  -- 부분 인덱스 술어 제거(최적화 목적일 뿐): WHERE (auto_renew = true)
+-- skipped (gin 인덱스는 대응물이 없어 건너뜀): idx_certificates_domain_names
+CREATE INDEX IF NOT EXISTS idx_certificates_expires_at ON certificates (expires_at);
+CREATE INDEX IF NOT EXISTS idx_certificates_status ON certificates (status);
+CREATE INDEX IF NOT EXISTS idx_certificate_history_certificate_id ON certificate_history (certificate_id);
+CREATE INDEX IF NOT EXISTS idx_certificate_history_created_at ON certificate_history (created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_certificate_history_action ON certificate_history (action);
+CREATE INDEX IF NOT EXISTS idx_challenge_logs_created ON challenge_logs (created_at);
+CREATE INDEX IF NOT EXISTS idx_challenge_logs_ip ON challenge_logs (client_ip);
+CREATE INDEX IF NOT EXISTS idx_challenge_logs_proxy_host ON challenge_logs (proxy_host_id);
+CREATE INDEX IF NOT EXISTS idx_challenge_tokens_expires ON challenge_tokens (expires_at);
+CREATE INDEX IF NOT EXISTS idx_challenge_tokens_hash ON challenge_tokens (token_hash);
+CREATE INDEX IF NOT EXISTS idx_challenge_tokens_ip ON challenge_tokens (client_ip);
+CREATE INDEX IF NOT EXISTS idx_challenge_tokens_proxy_host ON challenge_tokens (proxy_host_id);
+CREATE INDEX IF NOT EXISTS idx_cloud_providers_enabled ON cloud_providers (enabled);
+CREATE INDEX IF NOT EXISTS idx_cloud_providers_region ON cloud_providers (region);
+CREATE INDEX IF NOT EXISTS idx_cloud_providers_slug ON cloud_providers (slug);
+-- idx_dns_providers_default is enforced by the dns_providers_default_key generated column on dns_providers (WHERE is_default = true)
+CREATE INDEX IF NOT EXISTS idx_exploit_rules_category ON exploit_block_rules (category);
+CREATE INDEX IF NOT EXISTS idx_exploit_rules_enabled ON exploit_block_rules (enabled);
+-- skipped (gin 인덱스는 대응물이 없어 건너뜀): idx_geo_restrictions_blocked_cloud
+CREATE INDEX IF NOT EXISTS idx_geo_restrictions_proxy_host ON geo_restrictions (proxy_host_id);
+CREATE INDEX IF NOT EXISTS idx_geoip_update_history_created_at ON geoip_update_history (created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_geoip_update_history_status ON geoip_update_history (status);
+-- idx_global_uri_blocks_singleton is enforced by the singleton_key generated column on global_uri_blocks
+CREATE INDEX IF NOT EXISTS idx_global_waf_policy_history_created_at ON global_waf_policy_history (created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_global_waf_policy_history_rule_id ON global_waf_policy_history (rule_id);
+CREATE INDEX IF NOT EXISTS idx_global_waf_rule_exclusions_rule_id ON global_waf_rule_exclusions (rule_id);
+CREATE INDEX IF NOT EXISTS idx_host_exploit_exclusions_host ON host_exploit_rule_exclusions (proxy_host_id);
+CREATE INDEX IF NOT EXISTS idx_host_exploit_exclusions_rule ON host_exploit_rule_exclusions (rule_id);
+-- idx_global_exploit_exclusions_rule_uri_unique is enforced by generated column(s) uri_pattern_key on global_exploit_rule_exclusions
+-- idx_host_exploit_exclusions_host_rule_uri_unique is enforced by generated column(s) uri_pattern_key on host_exploit_rule_exclusions
+CREATE INDEX IF NOT EXISTS idx_ip_ban_history_created_at ON ip_ban_history (created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_ip_ban_history_event_type ON ip_ban_history (event_type);
+CREATE INDEX IF NOT EXISTS idx_ip_ban_history_ip ON ip_ban_history (ip_address);
+CREATE INDEX IF NOT EXISTS idx_ip_ban_history_ip_created ON ip_ban_history (ip_address, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_ip_ban_history_proxy_host ON ip_ban_history (proxy_host_id);
+CREATE INDEX IF NOT EXISTS idx_ip_ban_history_source ON ip_ban_history (source);
+CREATE INDEX IF NOT EXISTS idx_ip_ban_history_user ON ip_ban_history (user_id);
+CREATE INDEX IF NOT EXISTS idx_login_attempts_ip ON login_attempts (ip_address, attempted_at);
+CREATE INDEX IF NOT EXISTS idx_logs_access_timestamp ON logs (timestamp DESC);  -- 부분 인덱스 술어 제거(최적화 목적일 뿐): WHERE (log_type = 'access'::public.log_type)
+CREATE INDEX IF NOT EXISTS idx_logs_block_reason ON logs (block_reason);  -- 부분 인덱스 술어 제거(최적화 목적일 뿐): WHERE (block_reason <> 'none'::public.block_reason)
+CREATE INDEX IF NOT EXISTS idx_logs_block_reason_created ON logs (block_reason, created_at DESC);  -- 부분 인덱스 술어 제거(최적화 목적일 뿐): WHERE ((block_reason IS NOT NULL) AND (block_reason <> 'none'::public.block_reason))
+CREATE INDEX IF NOT EXISTS idx_logs_bot_filter ON logs (block_reason, bot_category(191), timestamp DESC);  -- 부분 인덱스 술어 제거(최적화 목적일 뿐): WHERE (block_reason = 'bot_filter'::public.block_reason)
+CREATE INDEX IF NOT EXISTS idx_logs_client_ip ON logs (client_ip);
+CREATE INDEX IF NOT EXISTS idx_logs_created_at_desc ON logs (created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_logs_created_host ON logs (created_at DESC, host(191));  -- 부분 인덱스 술어 제거(최적화 목적일 뿐): WHERE (host IS NOT NULL)
+CREATE INDEX IF NOT EXISTS idx_logs_created_ip ON logs (created_at DESC, client_ip);  -- 부분 인덱스 술어 제거(최적화 목적일 뿐): WHERE (client_ip IS NOT NULL)
+CREATE INDEX IF NOT EXISTS idx_logs_created_status ON logs (created_at DESC, status_code);  -- 부분 인덱스 술어 제거(최적화 목적일 뿐): WHERE (status_code IS NOT NULL)
+CREATE INDEX IF NOT EXISTS idx_logs_created_type ON logs (created_at DESC, log_type);
+CREATE INDEX IF NOT EXISTS idx_logs_exploit_rule ON logs (exploit_rule);  -- 부분 인덱스 술어 제거(최적화 목적일 뿐): WHERE ((exploit_rule IS NOT NULL) AND ((exploit_rule)::text <> '-'::text))
+CREATE INDEX IF NOT EXISTS idx_logs_geo_asn ON logs (geo_asn(191));
+CREATE INDEX IF NOT EXISTS idx_logs_geo_country ON logs (geo_country_code, created_at DESC);  -- 부분 인덱스 술어 제거(최적화 목적일 뿐): WHERE (geo_country_code IS NOT NULL)
+CREATE INDEX IF NOT EXISTS idx_logs_geo_country_code ON logs (geo_country_code);
+CREATE INDEX IF NOT EXISTS idx_logs_geo_timestamp ON logs (timestamp DESC, geo_country_code);  -- 부분 인덱스 술어 제거(최적화 목적일 뿐): WHERE ((log_type = 'access'::public.log_type) AND (geo_country_code IS NOT NULL))
+CREATE INDEX IF NOT EXISTS idx_logs_host ON logs (host(191));
+CREATE INDEX IF NOT EXISTS idx_logs_host_timestamp ON logs (host(191), timestamp DESC);
+-- skipped (gin 인덱스는 대응물이 없어 건너뜀): idx_logs_host_trgm
+CREATE INDEX IF NOT EXISTS idx_logs_log_type ON logs (log_type);
+CREATE INDEX IF NOT EXISTS idx_logs_modsec_created ON logs (created_at DESC);  -- 부분 인덱스 술어 제거(최적화 목적일 뿐): WHERE (log_type = 'modsec'::public.log_type)
+CREATE INDEX IF NOT EXISTS idx_logs_part_host ON logs_partitioned (host(191));
+CREATE INDEX IF NOT EXISTS idx_logs_part_log_type ON logs_partitioned (log_type);
+CREATE INDEX IF NOT EXISTS idx_logs_part_timestamp ON logs_partitioned (timestamp DESC);
+CREATE INDEX IF NOT EXISTS idx_logs_part_type_timestamp ON logs_partitioned (log_type, timestamp DESC);
+CREATE INDEX IF NOT EXISTS idx_logs_partitioned_exploit_rule ON logs_partitioned (exploit_rule);  -- 부분 인덱스 술어 제거(최적화 목적일 뿐): WHERE ((exploit_rule IS NOT NULL) AND ((exploit_rule)::text <> '-'::text))
+CREATE INDEX IF NOT EXISTS idx_logs_part_block_reason_ts ON logs_partitioned (block_reason, timestamp DESC);  -- 부분 인덱스 술어 제거(최적화 목적일 뿐): WHERE (block_reason != 'none')
+CREATE INDEX IF NOT EXISTS idx_logs_part_client_ip ON logs_partitioned (client_ip);
+CREATE INDEX IF NOT EXISTS idx_logs_part_created_at ON logs_partitioned (created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_logs_part_status_code ON logs_partitioned (status_code);  -- 부분 인덱스 술어 제거(최적화 목적일 뿐): WHERE (status_code IS NOT NULL)
+CREATE INDEX IF NOT EXISTS idx_logs_part_host_ts ON logs_partitioned (host(191), timestamp DESC);
+CREATE INDEX IF NOT EXISTS idx_logs_part_status_ts ON logs_partitioned (status_code, timestamp DESC);  -- 부분 인덱스 술어 제거(최적화 목적일 뿐): WHERE (status_code IS NOT NULL)
+CREATE INDEX IF NOT EXISTS idx_logs_part_proxy_host_ts ON logs_partitioned (proxy_host_id, timestamp DESC);  -- 부분 인덱스 술어 제거(최적화 목적일 뿐): WHERE (proxy_host_id IS NOT NULL)
+CREATE INDEX IF NOT EXISTS idx_logs_part_geo_ts ON logs_partitioned (geo_country_code, timestamp DESC);  -- 부분 인덱스 술어 제거(최적화 목적일 뿐): WHERE (geo_country_code IS NOT NULL AND (geo_country_code)::text <> ''::text)
+CREATE INDEX IF NOT EXISTS idx_logs_part_type_created ON logs_partitioned (log_type, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_logs_proxy_host_id ON logs (proxy_host_id);  -- 부분 인덱스 술어 제거(최적화 목적일 뿐): WHERE (proxy_host_id IS NOT NULL)
+-- skipped (gin 인덱스는 대응물이 없어 건너뜀): idx_logs_request_uri_trgm
+CREATE INDEX IF NOT EXISTS idx_logs_rule_id ON logs (rule_id);  -- 부분 인덱스 술어 제거(최적화 목적일 뿐): WHERE (rule_id IS NOT NULL)
+CREATE INDEX IF NOT EXISTS idx_logs_severity ON logs (severity);  -- 부분 인덱스 술어 제거(최적화 목적일 뿐): WHERE (severity IS NOT NULL)
+CREATE INDEX IF NOT EXISTS idx_logs_status_code ON logs (status_code);  -- 부분 인덱스 술어 제거(최적화 목적일 뿐): WHERE (status_code IS NOT NULL)
+CREATE INDEX IF NOT EXISTS idx_logs_timestamp ON logs (timestamp DESC);
+CREATE INDEX IF NOT EXISTS idx_logs_type_timestamp ON logs (log_type, timestamp DESC);
+CREATE INDEX IF NOT EXISTS idx_proxy_hosts_created_at ON proxy_hosts (created_at DESC);
+-- skipped (gin 인덱스는 대응물이 없어 건너뜀): idx_proxy_hosts_domain_names
+CREATE INDEX IF NOT EXISTS idx_proxy_hosts_enabled ON proxy_hosts (enabled);
+-- skipped (gin 인덱스는 대응물이 없어 건너뜀): idx_redirect_hosts_domains
+CREATE INDEX IF NOT EXISTS idx_stats_daily_bucket ON dashboard_stats_daily (day_bucket);
+CREATE INDEX IF NOT EXISTS idx_stats_daily_host_bucket ON dashboard_stats_daily (proxy_host_id, day_bucket);
+CREATE INDEX IF NOT EXISTS idx_stats_hourly_bucket ON dashboard_stats_hourly (hour_bucket);
+CREATE INDEX IF NOT EXISTS idx_stats_hourly_host_bucket ON dashboard_stats_hourly (proxy_host_id, hour_bucket);
+CREATE INDEX IF NOT EXISTS idx_stats_hourly_part_bucket ON dashboard_stats_hourly_partitioned (hour_bucket);
+CREATE INDEX IF NOT EXISTS idx_stats_hourly_part_host ON dashboard_stats_hourly_partitioned (proxy_host_id, hour_bucket);
+CREATE INDEX IF NOT EXISTS idx_system_health_recorded ON system_health (recorded_at);
+CREATE INDEX IF NOT EXISTS idx_system_logs_container ON system_logs (container_name, created_at DESC);  -- 부분 인덱스 술어 제거(최적화 목적일 뿐): WHERE (container_name IS NOT NULL)
+CREATE INDEX IF NOT EXISTS idx_system_logs_created ON system_logs (created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_system_logs_level ON system_logs (level);
+CREATE INDEX IF NOT EXISTS idx_system_logs_source ON system_logs (source);
+CREATE INDEX IF NOT EXISTS idx_system_logs_source_created ON system_logs (source, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_system_logs_source_level_created ON system_logs (source, level, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_system_settings_updated ON system_settings (updated_at);
+CREATE INDEX IF NOT EXISTS idx_upstream_servers_upstream ON upstream_servers (upstream_id);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_uri_blocks_proxy_host ON uri_blocks (proxy_host_id);
+-- idx_proxy_hosts_stream_listener_unique is enforced by the proxy_hosts_stream_listener_key generated column on proxy_hosts (WHERE proxy_type = 'stream' AND enabled = true AND stream_listen_port > 0)
+CREATE INDEX IF NOT EXISTS idx_users_totp_enabled ON users (totp_enabled);  -- 부분 인덱스 술어 제거(최적화 목적일 뿐): WHERE (totp_enabled = true)
+CREATE INDEX IF NOT EXISTS idx_waf_policy_history_proxy_host ON waf_policy_history (proxy_host_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_waf_policy_history_rule ON waf_policy_history (rule_id);
+CREATE INDEX IF NOT EXISTS idx_waf_rule_changes_proxy_host ON waf_rule_change_events (proxy_host_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_waf_rule_changes_rule ON waf_rule_change_events (rule_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_waf_rule_exclusions_proxy_host ON waf_rule_exclusions (proxy_host_id);
+CREATE INDEX IF NOT EXISTS idx_waf_rule_exclusions_rule_id ON waf_rule_exclusions (rule_id);
+CREATE INDEX IF NOT EXISTS idx_waf_snapshot_details_snapshot ON waf_rule_snapshot_details (snapshot_id);
+CREATE INDEX IF NOT EXISTS idx_waf_snapshots_created_at ON waf_rule_snapshots (created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_waf_snapshots_proxy_host_version ON waf_rule_snapshots (proxy_host_id, version_number DESC);
+CREATE UNIQUE INDEX IF NOT EXISTS users_username_key ON users (username);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_ddns_records_hostname_provider ON ddns_records (hostname, dns_provider_id);
+-- skipped (gin 인덱스는 대응물이 없어 건너뜀): idx_logs_part_host_trgm
+-- skipped (gin 인덱스는 대응물이 없어 건너뜀): idx_logs_part_uri_trgm
+-- skipped (gin 인덱스는 대응물이 없어 건너뜀): idx_logs_part_ua_trgm
+CREATE INDEX IF NOT EXISTS idx_logs_part_host_ts ON logs_partitioned (host(191), timestamp DESC);
+CREATE INDEX IF NOT EXISTS idx_logs_part_status_ts ON logs_partitioned (status_code, timestamp DESC);  -- 부분 인덱스 술어 제거(최적화 목적일 뿐): WHERE status_code IS NOT NULL
+CREATE INDEX IF NOT EXISTS idx_logs_part_proxy_host_ts ON logs_partitioned (proxy_host_id, timestamp DESC);  -- 부분 인덱스 술어 제거(최적화 목적일 뿐): WHERE proxy_host_id IS NOT NULL
+CREATE INDEX IF NOT EXISTS idx_logs_part_geo_ts ON logs_partitioned (geo_country_code, timestamp DESC);  -- 부분 인덱스 술어 제거(최적화 목적일 뿐): WHERE geo_country_code IS NOT NULL AND geo_country_code != ''
+CREATE INDEX IF NOT EXISTS idx_logs_part_type_created ON logs_partitioned (log_type, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_logs_part_block_reason ON logs_partitioned (block_reason);  -- 부분 인덱스 술어 제거(최적화 목적일 뿐): WHERE block_reason != 'none'
+CREATE INDEX IF NOT EXISTS idx_logs_part_status_created ON logs_partitioned (status_code, created_at);
+CREATE INDEX IF NOT EXISTS idx_logs_part_block_reason_created ON logs_partitioned (created_at DESC, block_reason);  -- 부분 인덱스 술어 제거(최적화 목적일 뿐): WHERE block_reason != 'none' AND log_type = 'access'
+-- idx_dashboard_stats_hourly_null_host_bucket is enforced by the dashboard_stats_hourly_null_host_bucket_key generated column on dashboard_stats_hourly (WHERE proxy_host_id IS NULL)
+-- idx_global_exploit_exclusions_rule_uri_unique is enforced by generated column(s) uri_pattern_key on global_exploit_rule_exclusions
+-- idx_host_exploit_exclusions_host_rule_uri_unique is enforced by generated column(s) uri_pattern_key on host_exploit_rule_exclusions
+CREATE INDEX IF NOT EXISTS idx_banned_ips_host_banned_at ON banned_ips (proxy_host_id, banned_at DESC);
+CREATE INDEX IF NOT EXISTS idx_bot_filters_proxy_host ON bot_filters (proxy_host_id);
+CREATE INDEX IF NOT EXISTS idx_rate_limits_proxy_host ON rate_limits (proxy_host_id);
+CREATE INDEX IF NOT EXISTS idx_security_headers_proxy_host ON security_headers (proxy_host_id);
+CREATE INDEX IF NOT EXISTS idx_challenge_configs_proxy_host ON challenge_configs (proxy_host_id);
+CREATE INDEX IF NOT EXISTS idx_upstreams_proxy_host ON upstreams (proxy_host_id);
+CREATE INDEX IF NOT EXISTS idx_fail2ban_configs_proxy_host ON fail2ban_configs (proxy_host_id);
+CREATE INDEX IF NOT EXISTS idx_logs_part_block_reason_created ON logs_partitioned (created_at DESC, block_reason);  -- 부분 인덱스 술어 제거(최적화 목적일 뿐): WHERE block_reason != 'none' AND log_type = 'access'
+-- idx_global_geo_restrictions_singleton is enforced by the singleton_key generated column on global_geo_restrictions
+-- idx_global_bot_filters_singleton is enforced by the singleton_key generated column on global_bot_filters
+-- idx_global_security_headers_singleton is enforced by the singleton_key generated column on global_security_headers
+-- idx_global_cloud_providers_singleton is enforced by the singleton_key generated column on global_cloud_providers
+-- idx_global_rate_limits_singleton is enforced by the singleton_key generated column on global_rate_limits
+-- idx_global_waf_singleton is enforced by the singleton_key generated column on global_waf
+-- idx_proxy_hosts_stream_listener_unique is enforced by the proxy_hosts_stream_listener_key generated column on proxy_hosts (WHERE proxy_type = 'stream' AND enabled = true AND stream_listen_port > 0)
+-- idx_cloudflare_tunnel_singleton is enforced by the singleton_key generated column on cloudflare_tunnel
+CREATE INDEX IF NOT EXISTS idx_log_filter_presets_log_type ON log_filter_presets (log_type(191));
+
+-- --------------------------------------------------------------------------
+-- Foreign keys and deferred constraints
+-- --------------------------------------------------------------------------
+ALTER TABLE access_list_items ADD CONSTRAINT access_list_items_access_list_id_fkey FOREIGN KEY IF NOT EXISTS (access_list_id) REFERENCES access_lists(id) ON DELETE CASCADE;
+ALTER TABLE api_token_usage ADD CONSTRAINT api_token_usage_token_id_fkey FOREIGN KEY IF NOT EXISTS (token_id) REFERENCES api_tokens(id) ON DELETE CASCADE;
+ALTER TABLE api_tokens ADD CONSTRAINT api_tokens_user_id_fkey FOREIGN KEY IF NOT EXISTS (user_id) REFERENCES users(id) ON DELETE CASCADE;
+ALTER TABLE audit_logs ADD CONSTRAINT audit_logs_user_id_fkey FOREIGN KEY IF NOT EXISTS (user_id) REFERENCES users(id) ON DELETE SET NULL;
+ALTER TABLE auth_sessions ADD CONSTRAINT auth_sessions_user_id_fkey FOREIGN KEY IF NOT EXISTS (user_id) REFERENCES users(id) ON DELETE CASCADE;
+ALTER TABLE banned_ips ADD CONSTRAINT banned_ips_proxy_host_id_fkey FOREIGN KEY IF NOT EXISTS (proxy_host_id) REFERENCES proxy_hosts(id) ON DELETE CASCADE;
+ALTER TABLE bot_filters ADD CONSTRAINT bot_filters_proxy_host_id_fkey FOREIGN KEY IF NOT EXISTS (proxy_host_id) REFERENCES proxy_hosts(id) ON DELETE CASCADE;
+ALTER TABLE certificate_history ADD CONSTRAINT certificate_history_certificate_id_fkey FOREIGN KEY IF NOT EXISTS (certificate_id) REFERENCES certificates(id) ON DELETE CASCADE;
+ALTER TABLE certificates ADD CONSTRAINT certificates_dns_provider_id_fkey FOREIGN KEY IF NOT EXISTS (dns_provider_id) REFERENCES dns_providers(id) ON DELETE SET NULL;
+ALTER TABLE challenge_configs ADD CONSTRAINT challenge_configs_proxy_host_id_fkey FOREIGN KEY IF NOT EXISTS (proxy_host_id) REFERENCES proxy_hosts(id) ON DELETE CASCADE;
+ALTER TABLE challenge_logs ADD CONSTRAINT challenge_logs_proxy_host_id_fkey FOREIGN KEY IF NOT EXISTS (proxy_host_id) REFERENCES proxy_hosts(id) ON DELETE CASCADE;
+ALTER TABLE challenge_tokens ADD CONSTRAINT challenge_tokens_proxy_host_id_fkey FOREIGN KEY IF NOT EXISTS (proxy_host_id) REFERENCES proxy_hosts(id) ON DELETE CASCADE;
+ALTER TABLE dashboard_stats_daily ADD CONSTRAINT dashboard_stats_daily_proxy_host_id_fkey FOREIGN KEY IF NOT EXISTS (proxy_host_id) REFERENCES proxy_hosts(id) ON DELETE CASCADE;
+ALTER TABLE dashboard_stats_hourly ADD CONSTRAINT dashboard_stats_hourly_proxy_host_id_fkey FOREIGN KEY IF NOT EXISTS (proxy_host_id) REFERENCES proxy_hosts(id) ON DELETE CASCADE;
+ALTER TABLE ddns_records ADD CONSTRAINT fk_ddns_records_dns_provider_id FOREIGN KEY IF NOT EXISTS (dns_provider_id) REFERENCES dns_providers(id) ON DELETE CASCADE;
+ALTER TABLE ddns_records ADD CONSTRAINT ddns_records_dns_provider_id_fkey FOREIGN KEY IF NOT EXISTS (dns_provider_id) REFERENCES dns_providers(id) ON DELETE CASCADE;
+-- skipped (column added by a later upgrade, not by this file): ddns_records_proxy_host_id_fkey
+ALTER TABLE fail2ban_configs ADD CONSTRAINT fail2ban_configs_proxy_host_id_fkey FOREIGN KEY IF NOT EXISTS (proxy_host_id) REFERENCES proxy_hosts(id) ON DELETE CASCADE;
+ALTER TABLE filter_subscription_entries ADD CONSTRAINT fk_filter_subscription_entries_subscription_id FOREIGN KEY IF NOT EXISTS (subscription_id) REFERENCES filter_subscriptions(id) ON DELETE CASCADE;
+ALTER TABLE filter_subscription_entry_exclusions ADD CONSTRAINT fk_filter_subscription_entry_exclusions_subscription_id FOREIGN KEY IF NOT EXISTS (subscription_id) REFERENCES filter_subscriptions(id) ON DELETE CASCADE;
+ALTER TABLE filter_subscription_host_exclusions ADD CONSTRAINT fk_filter_subscription_host_exclusions_subscription_id FOREIGN KEY IF NOT EXISTS (subscription_id) REFERENCES filter_subscriptions(id) ON DELETE CASCADE;
+ALTER TABLE filter_subscription_host_exclusions ADD CONSTRAINT fk_filter_subscription_host_exclusions_proxy_host_id FOREIGN KEY IF NOT EXISTS (proxy_host_id) REFERENCES proxy_hosts(id) ON DELETE CASCADE;
+ALTER TABLE geo_restrictions ADD CONSTRAINT geo_restrictions_proxy_host_id_fkey FOREIGN KEY IF NOT EXISTS (proxy_host_id) REFERENCES proxy_hosts(id) ON DELETE CASCADE;
+ALTER TABLE global_exploit_rule_exclusions ADD CONSTRAINT global_exploit_rule_exclusions_rule_id_fkey FOREIGN KEY IF NOT EXISTS (rule_id) REFERENCES exploit_block_rules(id) ON DELETE CASCADE;
+ALTER TABLE host_exploit_rule_exclusions ADD CONSTRAINT host_exploit_rule_exclusions_proxy_host_id_fkey FOREIGN KEY IF NOT EXISTS (proxy_host_id) REFERENCES proxy_hosts(id) ON DELETE CASCADE;
+ALTER TABLE host_exploit_rule_exclusions ADD CONSTRAINT host_exploit_rule_exclusions_rule_id_fkey FOREIGN KEY IF NOT EXISTS (rule_id) REFERENCES exploit_block_rules(id) ON DELETE CASCADE;
+ALTER TABLE ip_ban_history ADD CONSTRAINT ip_ban_history_proxy_host_id_fkey FOREIGN KEY IF NOT EXISTS (proxy_host_id) REFERENCES proxy_hosts(id) ON DELETE SET NULL;
+ALTER TABLE ip_ban_history ADD CONSTRAINT ip_ban_history_user_id_fkey FOREIGN KEY IF NOT EXISTS (user_id) REFERENCES users(id) ON DELETE SET NULL;
+ALTER TABLE logs ADD CONSTRAINT logs_proxy_host_id_fkey FOREIGN KEY IF NOT EXISTS (proxy_host_id) REFERENCES proxy_hosts(id) ON DELETE SET NULL;
+ALTER TABLE notification_outbox ADD CONSTRAINT notification_outbox_channel_id_fkey FOREIGN KEY IF NOT EXISTS (channel_id) REFERENCES notification_channels(id) ON DELETE CASCADE;
+ALTER TABLE proxy_hosts ADD CONSTRAINT proxy_hosts_certificate_id_fkey FOREIGN KEY IF NOT EXISTS (certificate_id) REFERENCES certificates(id) ON DELETE SET NULL;
+ALTER TABLE proxy_hosts ADD CONSTRAINT proxy_hosts_ddns_provider_id_fkey FOREIGN KEY IF NOT EXISTS (ddns_provider_id) REFERENCES dns_providers(id) ON DELETE SET NULL;
+ALTER TABLE proxy_hosts ADD CONSTRAINT proxy_hosts_auth_provider_id_fkey FOREIGN KEY IF NOT EXISTS (auth_provider_id) REFERENCES auth_providers(id) ON DELETE SET NULL;
+ALTER TABLE rate_limits ADD CONSTRAINT rate_limits_proxy_host_id_fkey FOREIGN KEY IF NOT EXISTS (proxy_host_id) REFERENCES proxy_hosts(id) ON DELETE CASCADE;
+ALTER TABLE redirect_hosts ADD CONSTRAINT redirect_hosts_certificate_id_fkey FOREIGN KEY IF NOT EXISTS (certificate_id) REFERENCES certificates(id) ON DELETE SET NULL;
+ALTER TABLE role_permissions ADD CONSTRAINT role_permissions_role_id_fkey FOREIGN KEY IF NOT EXISTS (role_id) REFERENCES roles(id) ON DELETE CASCADE;
+ALTER TABLE security_headers ADD CONSTRAINT security_headers_proxy_host_id_fkey FOREIGN KEY IF NOT EXISTS (proxy_host_id) REFERENCES proxy_hosts(id) ON DELETE CASCADE;
+ALTER TABLE sso_login_states ADD CONSTRAINT sso_login_states_provider_id_fkey FOREIGN KEY IF NOT EXISTS (provider_id) REFERENCES sso_providers(id) ON DELETE CASCADE;
+ALTER TABLE sso_providers ADD CONSTRAINT sso_providers_default_role_id_fkey FOREIGN KEY IF NOT EXISTS (default_role_id) REFERENCES roles(id) ON DELETE RESTRICT;
+ALTER TABLE upstream_servers ADD CONSTRAINT upstream_servers_upstream_id_fkey FOREIGN KEY IF NOT EXISTS (upstream_id) REFERENCES upstreams(id) ON DELETE CASCADE;
+ALTER TABLE upstreams ADD CONSTRAINT upstreams_proxy_host_id_fkey FOREIGN KEY IF NOT EXISTS (proxy_host_id) REFERENCES proxy_hosts(id) ON DELETE CASCADE;
+ALTER TABLE uri_blocks ADD CONSTRAINT uri_blocks_proxy_host_id_fkey FOREIGN KEY IF NOT EXISTS (proxy_host_id) REFERENCES proxy_hosts(id) ON DELETE CASCADE;
+ALTER TABLE user_identities ADD CONSTRAINT user_identities_provider_id_fkey FOREIGN KEY IF NOT EXISTS (provider_id) REFERENCES sso_providers(id) ON DELETE CASCADE;
+ALTER TABLE user_identities ADD CONSTRAINT user_identities_user_id_fkey FOREIGN KEY IF NOT EXISTS (user_id) REFERENCES users(id) ON DELETE CASCADE;
+ALTER TABLE users ADD CONSTRAINT users_role_id_fkey FOREIGN KEY IF NOT EXISTS (role_id) REFERENCES roles(id) ON DELETE RESTRICT;
+ALTER TABLE waf_policy_history ADD CONSTRAINT waf_policy_history_proxy_host_id_fkey FOREIGN KEY IF NOT EXISTS (proxy_host_id) REFERENCES proxy_hosts(id) ON DELETE CASCADE;
+ALTER TABLE waf_rule_change_events ADD CONSTRAINT waf_rule_change_events_proxy_host_id_fkey FOREIGN KEY IF NOT EXISTS (proxy_host_id) REFERENCES proxy_hosts(id) ON DELETE CASCADE;
+ALTER TABLE waf_rule_exclusions ADD CONSTRAINT waf_rule_exclusions_proxy_host_id_fkey FOREIGN KEY IF NOT EXISTS (proxy_host_id) REFERENCES proxy_hosts(id) ON DELETE CASCADE;
+ALTER TABLE waf_rule_snapshot_details ADD CONSTRAINT waf_rule_snapshot_details_snapshot_id_fkey FOREIGN KEY IF NOT EXISTS (snapshot_id) REFERENCES waf_rule_snapshots(id) ON DELETE CASCADE;
+ALTER TABLE waf_rule_snapshots ADD CONSTRAINT waf_rule_snapshots_proxy_host_id_fkey FOREIGN KEY IF NOT EXISTS (proxy_host_id) REFERENCES proxy_hosts(id) ON DELETE CASCADE;

--- a/api/internal/database/migrations/mariadb/002_upgrades.sql
+++ b/api/internal/database/migrations/mariadb/002_upgrades.sql
@@ -1,0 +1,304 @@
+-- Nginx Proxy Guard — MariaDB/MySQL 업그레이드 문장
+--
+-- 생성된 파일입니다. 직접 수정하지 마세요.
+-- 원본   : api/internal/database/migration.go (`upgrades` 슬라이스)
+-- 재생성 : python3 scripts/pg2mariadb-schema.py
+--
+-- Replayed on every boot, like its PostgreSQL counterpart: every statement is
+-- idempotent, and the runner logs rather than aborts when one fails.
+
+-- skipped (DO $$): Detach orphan chunk inheritance entries (TimescaleDB catalog drift)
+-- skipped (ALTER TYPE): block_reason enum: cloud_provider_challenge
+-- skipped (ALTER TYPE): block_reason enum: cloud_provider_block
+-- skipped (ALTER TYPE): block_reason enum: uri_block
+-- skipped (ALTER TYPE): block_reason enum: access_denied
+-- skipped (ALTER TYPE): block_reason enum: filter_subscription
+-- proxy_hosts.cache_static_only
+ALTER TABLE proxy_hosts ADD COLUMN IF NOT EXISTS cache_static_only BOOLEAN NOT NULL DEFAULT true;
+-- proxy_hosts.cache_ttl
+ALTER TABLE proxy_hosts ADD COLUMN IF NOT EXISTS cache_ttl VARCHAR(20) NOT NULL DEFAULT '7d';
+-- geo_restrictions.allow_search_bots_cloud_providers
+ALTER TABLE geo_restrictions ADD COLUMN IF NOT EXISTS allow_search_bots_cloud_providers BOOLEAN DEFAULT false;
+-- proxy_hosts.is_favorite
+ALTER TABLE proxy_hosts ADD COLUMN IF NOT EXISTS is_favorite BOOLEAN NOT NULL DEFAULT false;
+-- v1.3.4: proxy_hosts.proxy_connect_timeout
+ALTER TABLE proxy_hosts ADD COLUMN IF NOT EXISTS proxy_connect_timeout INT DEFAULT 0;
+-- v1.3.4: proxy_hosts.proxy_send_timeout
+ALTER TABLE proxy_hosts ADD COLUMN IF NOT EXISTS proxy_send_timeout INT DEFAULT 0;
+-- v1.3.4: proxy_hosts.proxy_read_timeout
+ALTER TABLE proxy_hosts ADD COLUMN IF NOT EXISTS proxy_read_timeout INT DEFAULT 0;
+-- v1.3.4: proxy_hosts.proxy_buffering
+ALTER TABLE proxy_hosts ADD COLUMN IF NOT EXISTS proxy_buffering VARCHAR(10) DEFAULT '';
+-- v1.3.4: proxy_hosts.proxy_request_buffering
+ALTER TABLE proxy_hosts ADD COLUMN IF NOT EXISTS proxy_request_buffering VARCHAR(10) DEFAULT '';
+-- v1.3.4: proxy_hosts.client_max_body_size
+ALTER TABLE proxy_hosts ADD COLUMN IF NOT EXISTS client_max_body_size VARCHAR(20) DEFAULT '';
+-- v1.3.4: proxy_hosts.proxy_max_temp_file_size
+ALTER TABLE proxy_hosts ADD COLUMN IF NOT EXISTS proxy_max_temp_file_size VARCHAR(20) DEFAULT '';
+-- v2.18.0: proxy_hosts.proxy_type
+ALTER TABLE proxy_hosts ADD COLUMN IF NOT EXISTS proxy_type VARCHAR(20) NOT NULL DEFAULT 'http';
+-- v2.18.0: proxy_hosts.stream_listen_host
+ALTER TABLE proxy_hosts ADD COLUMN IF NOT EXISTS stream_listen_host VARCHAR(255) DEFAULT '';
+-- v2.18.0: proxy_hosts.stream_listen_port
+ALTER TABLE proxy_hosts ADD COLUMN IF NOT EXISTS stream_listen_port INT DEFAULT 0;
+-- v2.18.0: proxy_hosts.stream_protocol
+ALTER TABLE proxy_hosts ADD COLUMN IF NOT EXISTS stream_protocol VARCHAR(10) DEFAULT 'tcp';
+-- v2.18.0: proxy_hosts.stream_ssl_preread
+ALTER TABLE proxy_hosts ADD COLUMN IF NOT EXISTS stream_ssl_preread BOOLEAN NOT NULL DEFAULT false;
+-- v2.18.0: proxy_hosts.stream_accept_proxy_protocol
+ALTER TABLE proxy_hosts ADD COLUMN IF NOT EXISTS stream_accept_proxy_protocol BOOLEAN NOT NULL DEFAULT false;
+-- v2.18.0: proxy_hosts.stream_send_proxy_protocol
+ALTER TABLE proxy_hosts ADD COLUMN IF NOT EXISTS stream_send_proxy_protocol BOOLEAN NOT NULL DEFAULT false;
+-- v2.18.0: proxy_hosts.stream_proxy_connect_timeout
+ALTER TABLE proxy_hosts ADD COLUMN IF NOT EXISTS stream_proxy_connect_timeout INT DEFAULT 0;
+-- v2.18.0: proxy_hosts.stream_proxy_timeout
+ALTER TABLE proxy_hosts ADD COLUMN IF NOT EXISTS stream_proxy_timeout INT DEFAULT 0;
+-- v2.4.0: global_settings.proxy_buffering
+ALTER TABLE global_settings ADD COLUMN IF NOT EXISTS proxy_buffering VARCHAR(10) DEFAULT '';
+-- v2.4.0: global_settings.proxy_request_buffering
+ALTER TABLE global_settings ADD COLUMN IF NOT EXISTS proxy_request_buffering VARCHAR(10) DEFAULT '';
+-- v2.5.0: global_settings.ssl_ecdh_curve
+ALTER TABLE global_settings ADD COLUMN IF NOT EXISTS ssl_ecdh_curve VARCHAR(255) NOT NULL DEFAULT 'X25519MLKEM768:X25519:secp256r1:secp384r1';
+-- v2.13.2: exploit_block_rules.auto_disabled_at
+ALTER TABLE exploit_block_rules ADD COLUMN IF NOT EXISTS auto_disabled_at DATETIME(6);
+-- v2.13.2: host_exploit_rule_exclusions.uri_pattern
+ALTER TABLE host_exploit_rule_exclusions ADD COLUMN IF NOT EXISTS uri_pattern TEXT;
+-- v2.13.2: global_exploit_rule_exclusions.uri_pattern
+ALTER TABLE global_exploit_rule_exclusions ADD COLUMN IF NOT EXISTS uri_pattern TEXT;
+-- v2.13.2: drop global_exploit_rule_exclusions_rule_id_key
+ALTER TABLE global_exploit_rule_exclusions DROP INDEX IF EXISTS global_exploit_rule_exclusions_rule_id_key;
+-- v2.13.2: drop host_exploit_rule_exclusions_proxy_host_id_rule_id_key
+ALTER TABLE host_exploit_rule_exclusions DROP INDEX IF EXISTS host_exploit_rule_exclusions_proxy_host_id_rule_id_key;
+-- skipped (ALTER INDEX): v2.13.2: rename uq_global_exploit_rule_exclusions_rule_uri
+-- skipped (ALTER INDEX): v2.13.2: rename uq_host_exploit_rule_exclusions_host_rule_uri
+-- skipped (no mechanical translation): v2.13.2: idx_global_exploit_exclusions_rule_uri_unique
+-- skipped (no mechanical translation): v2.13.2: idx_host_exploit_exclusions_host_rule_uri_unique
+-- seed: exploit_block_rules system defaults
+INSERT INTO exploit_block_rules (id, category, name, pattern, pattern_type, description, severity, enabled, is_system, sort_order, auto_disabled_at) VALUES ('4243721e-8f8d-4a2b-8496-0be62d50163f', 'sql_injection', 'SQL Union Select', '(\\"|''|`)(.*)(union)(.*)(select)(\\"|''|`)' , 'query_string', 'Blocks SQL UNION SELECT injection attempts', 'critical', true, true, 1, NULL), ('a5cb921c-2c10-475b-8753-a56e2af1e5ba', 'sql_injection', 'SQL Commands', '(;|\\||`|>|<|\\^|@)', 'query_string', 'Blocks SQL command characters (semicolon, pipe, backtick, redirects) (disabled by default: matches common URL characters like @, <, >; high false-positive rate)', 'warning', false, true, 2, CURRENT_TIMESTAMP(6)), ('41d1f7bf-9179-44cb-b41a-1685ce88d965', 'sql_injection', 'SQL Keywords', '\\b(select|insert|update|delete|drop|truncate|alter|create|exec)\\b', 'query_string', 'Blocks common SQL keywords in query strings (disabled by default: matches plain English words like ''update''/''select'' in search queries; ModSecurity/CRS handles SQL injection detection more precisely)', 'warning', false, true, 3, CURRENT_TIMESTAMP(6)), ('b890779f-757c-4461-a64a-dce59fb469e3', 'xss', 'Script Tags', '<script', 'query_string', 'Blocks script tag injection', 'critical', true, true, 10, NULL), ('27ed45b1-e030-4212-bc34-edc7e13a9695', 'xss', 'Event Handlers', 'on(click|load|error|mouseover|focus|blur|change|submit)=', 'query_string', 'Blocks JavaScript event handler injection', 'critical', true, true, 11, NULL), ('aa90285b-2986-46f9-80e6-99946327cd24', 'xss', 'Special Characters', '(;|<|>|"|%0A|%0D|%22|%3C|%3E|%00)', 'query_string', 'Blocks XSS special characters (semicolon, angle brackets, encoded newlines/quotes/null) (disabled by default: matches common characters in legitimate URL parameters like quotes; CRS provides more precise XSS detection)', 'warning', false, true, 12, CURRENT_TIMESTAMP(6)), ('23b31cc1-0e43-49af-b9c9-4093fd0cbcdc', 'rfi', 'URL Parameter Injection', '[a-zA-Z0-9_]=https?://', 'query_string', 'Blocks URL values in query parameters (RFI)', 'critical', true, true, 20, NULL), ('7db3e194-8731-40c1-afaa-b7555c017a3f', 'rfi', 'Path Traversal Sequences', '[a-zA-Z0-9_]=(\\.\\./)+', 'query_string', 'Blocks path traversal in parameters', 'critical', true, true, 21, NULL), ('650c5e4a-c373-4d99-9cac-9e86b55bcb33', 'rfi', 'Directory Traversal', '\\.\\./', 'query_string', 'Blocks directory traversal patterns', 'warning', true, true, 22, NULL), ('f055a131-0596-419f-944a-cb7fa40f5c59', 'scanner', 'Nikto Scanner', 'nikto', 'user_agent', 'Blocks Nikto vulnerability scanner', 'critical', true, true, 30, NULL), ('f13159ab-0e9a-45ea-aa4b-03fde63bb3e6', 'scanner', 'SQLMap Tool', 'sqlmap', 'user_agent', 'Blocks SQLMap SQL injection tool', 'critical', true, true, 31, NULL), ('a9baaa39-ccd9-4f8a-82c0-e7d85f02cc2f', 'scanner', 'DirBuster', 'dirbuster', 'user_agent', 'Blocks DirBuster directory scanner', 'critical', true, true, 32, NULL), ('8208101f-eb91-4b86-8396-f295cd16d04b', 'scanner', 'Nmap Scanner', 'nmap', 'user_agent', 'Blocks Nmap network scanner', 'warning', true, true, 33, NULL), ('7efe59af-2d2a-405e-bbe8-951757e72ef4', 'scanner', 'Nessus Scanner', 'nessus', 'user_agent', 'Blocks Nessus vulnerability scanner', 'warning', true, true, 34, NULL), ('9a5f6bcb-ceec-47f1-9f8c-dadb815711fa', 'scanner', 'OpenVAS Scanner', 'openvas', 'user_agent', 'Blocks OpenVAS security scanner', 'warning', true, true, 35, NULL), ('ab3b4e85-08fd-49fe-b76d-3dc5cdf5a248', 'scanner', 'W3AF Scanner', 'w3af', 'user_agent', 'Blocks W3AF web scanner', 'warning', true, true, 36, NULL), ('eb60d9dd-1d53-4a42-b571-cef1d1314d4d', 'scanner', 'Acunetix Scanner', 'acunetix', 'user_agent', 'Blocks Acunetix web scanner', 'warning', true, true, 37, NULL), ('86fddcd3-30ca-43d3-bd46-34875e018395', 'scanner', 'Havij Tool', 'havij', 'user_agent', 'Blocks Havij SQL injection tool', 'critical', true, true, 38, NULL), ('bd7eeece-8f91-41a6-b06c-1ad69900512d', 'scanner', 'AppScan', 'appscan', 'user_agent', 'Blocks IBM AppScan', 'warning', true, true, 39, NULL), ('6ee9b160-9472-4584-9c83-8de7b955a4b5', 'scanner', 'WebScarab', 'webscarab', 'user_agent', 'Blocks WebScarab proxy', 'warning', true, true, 40, NULL), ('e78e2ef1-d710-409b-8a44-a03db3999b19', 'scanner', 'WebInspect', 'webinspect', 'user_agent', 'Blocks HP WebInspect', 'warning', true, true, 41, NULL), ('8ec83a35-dea8-4f51-9185-37035f0a4501', 'http_method', 'Dangerous Methods', '^(TRACE|TRACK|DEBUG|CONNECT)$', 'request_method', 'Blocks dangerous HTTP methods', 'warning', true, true, 50, NULL) ON DUPLICATE KEY UPDATE id = id;
+-- v2.4.0: idx_logs_part_block_reason_ts
+CREATE INDEX IF NOT EXISTS idx_logs_part_block_reason_ts ON logs_partitioned (block_reason, timestamp DESC);  -- 부분 인덱스 술어 제거(최적화 목적일 뿐): WHERE block_reason != 'none'
+-- v2.4.0: idx_logs_part_client_ip
+CREATE INDEX IF NOT EXISTS idx_logs_part_client_ip ON logs_partitioned (client_ip);
+-- v2.4.0: idx_logs_part_created_at
+CREATE INDEX IF NOT EXISTS idx_logs_part_created_at ON logs_partitioned (created_at DESC);
+-- v2.4.0: idx_logs_part_status_code
+CREATE INDEX IF NOT EXISTS idx_logs_part_status_code ON logs_partitioned (status_code);  -- 부분 인덱스 술어 제거(최적화 목적일 뿐): WHERE status_code IS NOT NULL
+-- v2.3.5: proxy_hosts.config_status
+ALTER TABLE proxy_hosts ADD COLUMN IF NOT EXISTS config_status VARCHAR(20) NOT NULL DEFAULT 'ok';
+-- v2.3.5: proxy_hosts.config_error
+ALTER TABLE proxy_hosts ADD COLUMN IF NOT EXISTS config_error TEXT;
+-- skipped (DO $$): v1.3.31: proxy_hosts_access_list_id_fkey
+-- v2.7.0: CREATE TABLE filter_subscriptions
+CREATE TABLE IF NOT EXISTS filter_subscriptions (
+    id VARCHAR(36) NOT NULL DEFAULT (UUID()) PRIMARY KEY,
+    name TEXT NOT NULL,
+    description TEXT,
+    url TEXT NOT NULL,
+    format VARCHAR(20) NOT NULL DEFAULT 'npg-json',
+    type VARCHAR(20) NOT NULL,
+    enabled BOOLEAN DEFAULT true,
+    refresh_type VARCHAR(20) NOT NULL DEFAULT 'interval',
+    refresh_value VARCHAR(50) NOT NULL DEFAULT '24h',
+    last_fetched_at DATETIME(6),
+    last_success_at DATETIME(6),
+    last_error TEXT,
+    entry_count INT DEFAULT 0,
+    created_at DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    UNIQUE KEY uq_filter_subscriptions_url (url(768))
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+-- v2.7.0: CREATE TABLE filter_subscription_entries
+CREATE TABLE IF NOT EXISTS filter_subscription_entries (
+    id VARCHAR(36) NOT NULL DEFAULT (UUID()) PRIMARY KEY,
+    subscription_id VARCHAR(36) NOT NULL,
+    value TEXT NOT NULL,
+    reason TEXT,
+    created_at DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    UNIQUE KEY uq_subscription_id_value (subscription_id, value(731))
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+ALTER TABLE filter_subscription_entries ADD CONSTRAINT fk_filter_subscription_entries_subscription_id FOREIGN KEY IF NOT EXISTS (subscription_id) REFERENCES filter_subscriptions(id) ON DELETE CASCADE;
+-- skipped (no mechanical translation): v2.7.0: idx_fse_subscription
+-- skipped (no mechanical translation): v2.7.0: idx_fse_value
+-- v2.7.0: CREATE TABLE filter_subscription_host_exclusions
+CREATE TABLE IF NOT EXISTS filter_subscription_host_exclusions (
+    id VARCHAR(36) NOT NULL DEFAULT (UUID()) PRIMARY KEY,
+    subscription_id VARCHAR(36) NOT NULL,
+    proxy_host_id VARCHAR(36) NOT NULL,
+    created_at DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    UNIQUE KEY uq_subscription_id_proxy_host_id (subscription_id, proxy_host_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+ALTER TABLE filter_subscription_host_exclusions ADD CONSTRAINT fk_filter_subscription_host_exclusions_subscription_id FOREIGN KEY IF NOT EXISTS (subscription_id) REFERENCES filter_subscriptions(id) ON DELETE CASCADE;
+ALTER TABLE filter_subscription_host_exclusions ADD CONSTRAINT fk_filter_subscription_host_exclusions_proxy_host_id FOREIGN KEY IF NOT EXISTS (proxy_host_id) REFERENCES proxy_hosts(id) ON DELETE CASCADE;
+-- skipped (no mechanical translation): v2.7.0: idx_fshe_proxy_host
+-- v2.8.0: CREATE TABLE filter_subscription_entry_exclusions
+CREATE TABLE IF NOT EXISTS filter_subscription_entry_exclusions (
+    id VARCHAR(36) NOT NULL DEFAULT (UUID()) PRIMARY KEY,
+    subscription_id VARCHAR(36) NOT NULL,
+    value TEXT NOT NULL,
+    created_at DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    UNIQUE KEY uq_subscription_id_value (subscription_id, value(731))
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+ALTER TABLE filter_subscription_entry_exclusions ADD CONSTRAINT fk_filter_subscription_entry_exclusions_subscription_id FOREIGN KEY IF NOT EXISTS (subscription_id) REFERENCES filter_subscriptions(id) ON DELETE CASCADE;
+-- skipped (no mechanical translation): v2.8.0: idx_fsee_subscription
+-- v2.8.0: filter_subscriptions.exclude_private_ips
+ALTER TABLE filter_subscriptions ADD COLUMN IF NOT EXISTS exclude_private_ips BOOLEAN DEFAULT false;
+-- v2.7.3: system_settings.global_trusted_ips
+ALTER TABLE system_settings ADD COLUMN IF NOT EXISTS global_trusted_ips TEXT DEFAULT ('');
+-- v2.26.0: system_settings.global_trusted_ips_bypass_waf — opt-in WAF bypass for trusted IPs (#166)
+ALTER TABLE system_settings ADD COLUMN IF NOT EXISTS global_trusted_ips_bypass_waf BOOLEAN NOT NULL DEFAULT false;
+-- v2.8.0: idx_logs_part_host_ts
+CREATE INDEX IF NOT EXISTS idx_logs_part_host_ts ON logs_partitioned (host(191), timestamp DESC);
+-- v2.8.0: idx_logs_part_status_ts
+CREATE INDEX IF NOT EXISTS idx_logs_part_status_ts ON logs_partitioned (status_code, timestamp DESC);  -- 부분 인덱스 술어 제거(최적화 목적일 뿐): WHERE status_code IS NOT NULL
+-- v2.8.0: idx_logs_part_proxy_host_ts
+CREATE INDEX IF NOT EXISTS idx_logs_part_proxy_host_ts ON logs_partitioned (proxy_host_id, timestamp DESC);  -- 부분 인덱스 술어 제거(최적화 목적일 뿐): WHERE proxy_host_id IS NOT NULL
+-- v2.8.0: idx_logs_part_geo_ts
+CREATE INDEX IF NOT EXISTS idx_logs_part_geo_ts ON logs_partitioned (geo_country_code, timestamp DESC);  -- 부분 인덱스 술어 제거(최적화 목적일 뿐): WHERE geo_country_code IS NOT NULL AND geo_country_code != ''
+-- v2.8.0: idx_logs_part_type_created
+CREATE INDEX IF NOT EXISTS idx_logs_part_type_created ON logs_partitioned (log_type, created_at DESC);
+-- Issue #96: idx_logs_part_block_reason
+CREATE INDEX IF NOT EXISTS idx_logs_part_block_reason ON logs_partitioned (block_reason);  -- 부분 인덱스 술어 제거(최적화 목적일 뿐): WHERE block_reason != 'none'
+-- Issue #96: idx_logs_part_status_created
+CREATE INDEX IF NOT EXISTS idx_logs_part_status_created ON logs_partitioned (status_code, created_at);
+-- skipped (DELETE FROM dashboard_stats_hourly a): Issue #96: dedup dashboard_stats_hourly NULL proxy_host_id
+-- skipped (partial unique index (generated column in 001_init.sql)): Issue #96: idx_dashboard_stats_hourly_null_host_bucket
+-- v2.9.0: global_settings.enable_ipv6
+ALTER TABLE global_settings ADD COLUMN IF NOT EXISTS enable_ipv6 BOOLEAN NOT NULL DEFAULT TRUE;
+-- system_settings.ui_error_page_language
+ALTER TABLE system_settings ADD COLUMN IF NOT EXISTS ui_error_page_language VARCHAR(10) DEFAULT 'auto';
+-- upstreams.scheme
+ALTER TABLE upstreams ADD COLUMN IF NOT EXISTS scheme VARCHAR(10) NOT NULL DEFAULT 'http';
+-- skipped (DO $$): logs.upstream_addr
+-- skipped (DO $$): logs.upstream_status
+-- logs_partitioned.upstream_addr
+ALTER TABLE logs_partitioned ADD COLUMN IF NOT EXISTS upstream_addr TEXT;
+-- logs_partitioned.upstream_status
+ALTER TABLE logs_partitioned ADD COLUMN IF NOT EXISTS upstream_status TEXT;
+-- exploit_block_rules.auto_disabled_at (defensive)
+ALTER TABLE exploit_block_rules ADD COLUMN IF NOT EXISTS auto_disabled_at DATETIME(6);
+-- host_exploit_rule_exclusions.uri_pattern (defensive)
+ALTER TABLE host_exploit_rule_exclusions ADD COLUMN IF NOT EXISTS uri_pattern TEXT;
+-- global_exploit_rule_exclusions.uri_pattern (defensive)
+ALTER TABLE global_exploit_rule_exclusions ADD COLUMN IF NOT EXISTS uri_pattern TEXT;
+-- skipped (DO $$): logs_unified view rebuild
+-- v2.13.7: seed ENV-001 (Dotenv File Access) rule
+INSERT INTO exploit_block_rules (id, category, name, pattern, pattern_type, description, severity, enabled, is_system, sort_order, auto_disabled_at) VALUES ( 'c1e7f001-0000-4000-8000-000000000001', 'rfi', 'Dotenv File Access', '/\\.env(\\.|$|/)', 'request_uri', 'Blocks access to .env config files (.env, .env.local, .env.production, ...)', 'critical', true, true, 23, NULL ) ON DUPLICATE KEY UPDATE id = id;
+-- v2.13.17: btree index banned_ips(proxy_host_id, banned_at DESC)
+CREATE INDEX IF NOT EXISTS idx_banned_ips_host_banned_at ON banned_ips (proxy_host_id, banned_at DESC);
+-- v2.13.17: btree index bot_filters(proxy_host_id)
+CREATE INDEX IF NOT EXISTS idx_bot_filters_proxy_host ON bot_filters (proxy_host_id);
+-- v2.13.17: btree index rate_limits(proxy_host_id)
+CREATE INDEX IF NOT EXISTS idx_rate_limits_proxy_host ON rate_limits (proxy_host_id);
+-- v2.13.17: btree index security_headers(proxy_host_id)
+CREATE INDEX IF NOT EXISTS idx_security_headers_proxy_host ON security_headers (proxy_host_id);
+-- v2.13.17: btree index challenge_configs(proxy_host_id)
+CREATE INDEX IF NOT EXISTS idx_challenge_configs_proxy_host ON challenge_configs (proxy_host_id);
+-- v2.13.17: btree index upstreams(proxy_host_id)
+CREATE INDEX IF NOT EXISTS idx_upstreams_proxy_host ON upstreams (proxy_host_id);
+-- v2.13.17: btree index fail2ban_configs(proxy_host_id)
+CREATE INDEX IF NOT EXISTS idx_fail2ban_configs_proxy_host ON fail2ban_configs (proxy_host_id);
+-- v2.13.18: idx_logs_part_block_reason_created
+CREATE INDEX IF NOT EXISTS idx_logs_part_block_reason_created ON logs_partitioned (created_at DESC, block_reason);  -- 부분 인덱스 술어 제거(최적화 목적일 뿐): WHERE block_reason != 'none' AND log_type = 'access'
+-- v2.17.0: global_settings.worker_connections DEFAULT 1024 -> 8192
+ALTER TABLE global_settings ALTER COLUMN worker_connections SET DEFAULT 8192;
+-- v2.17.0: global_settings.keepalive_timeout DEFAULT 65 -> 30
+ALTER TABLE global_settings ALTER COLUMN keepalive_timeout SET DEFAULT 30;
+-- v2.17.0: global_settings.keepalive_requests DEFAULT 100 -> 1000
+ALTER TABLE global_settings ALTER COLUMN keepalive_requests SET DEFAULT 1000;
+-- v2.17.1: system_settings.raw_log_enabled force true on every row
+UPDATE system_settings SET raw_log_enabled = true WHERE raw_log_enabled = false;
+-- v2.17.1: system_settings.raw_log_enabled DEFAULT true (mandatory since v2.17.1)
+ALTER TABLE system_settings ALTER COLUMN raw_log_enabled SET DEFAULT true;
+-- skipped (partial unique index (generated column in 001_init.sql)): v2.18.0: proxy_hosts stream listener partial unique index
+-- v2.20.0: proxy_hosts.forward_container_name (#150)
+ALTER TABLE proxy_hosts ADD COLUMN IF NOT EXISTS forward_container_name TEXT;
+-- v2.20.1: proxy_hosts.forward_container_network (#151)
+ALTER TABLE proxy_hosts ADD COLUMN IF NOT EXISTS forward_container_network TEXT;
+-- create ddns_records table (#154)
+CREATE TABLE IF NOT EXISTS ddns_records (
+    id VARCHAR(36) NOT NULL DEFAULT (UUID()) PRIMARY KEY,
+    hostname VARCHAR(253) NOT NULL,
+    dns_provider_id VARCHAR(36) NOT NULL,
+    record_type VARCHAR(8) NOT NULL DEFAULT 'A',
+    proxied BOOLEAN NOT NULL DEFAULT false,
+    ttl INT NOT NULL DEFAULT 1,
+    enabled BOOLEAN NOT NULL DEFAULT true,
+    last_ip VARCHAR(45) NOT NULL DEFAULT '',
+    last_synced_at DATETIME(6),
+    last_status VARCHAR(16) NOT NULL DEFAULT '',
+    last_error TEXT NOT NULL DEFAULT (''),
+    created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+ALTER TABLE ddns_records ADD CONSTRAINT fk_ddns_records_dns_provider_id FOREIGN KEY IF NOT EXISTS (dns_provider_id) REFERENCES dns_providers(id) ON DELETE CASCADE;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_ddns_records_hostname_provider ON ddns_records (hostname, dns_provider_id);
+-- skipped (DO $$): v2.23.0: proxy_hosts.ddns_enabled/ddns_provider_id (#157)
+-- v2.24.5: proxy_hosts.ddns_proxied default for managed DDNS (#160)
+ALTER TABLE proxy_hosts ADD COLUMN IF NOT EXISTS ddns_proxied BOOLEAN NOT NULL DEFAULT false;
+-- skipped (DO $$): v2.23.0: ddns_records.proxy_host_id (#157)
+-- v2.23.0: system_settings.ddns_check_interval_minutes (#157)
+ALTER TABLE system_settings ADD COLUMN IF NOT EXISTS ddns_check_interval_minutes INT NOT NULL DEFAULT 5;
+-- v2.27.0: auth_providers table (#179)
+CREATE TABLE IF NOT EXISTS auth_providers (
+    id VARCHAR(36) NOT NULL DEFAULT (UUID()) PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    type VARCHAR(20) NOT NULL DEFAULT 'custom',
+    provider_url TEXT NOT NULL,
+    config JSON NOT NULL DEFAULT ('{}'),
+    timeout_ms INT NOT NULL DEFAULT 5000,
+    enabled BOOLEAN NOT NULL DEFAULT true,
+    created_at DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    CONSTRAINT auth_providers_type_check CHECK (type IN ('authelia', 'authentik', 'custom'))
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+-- skipped (DO $$): v2.27.0: proxy_hosts.auth_provider_id/auth_bypass_paths (#179)
+-- v2.28.0: auth_providers docker-container target columns (#181)
+ALTER TABLE auth_providers ADD COLUMN IF NOT EXISTS container_name TEXT;
+ALTER TABLE auth_providers ADD COLUMN IF NOT EXISTS container_network TEXT;
+ALTER TABLE auth_providers ADD COLUMN IF NOT EXISTS container_port INT;
+ALTER TABLE auth_providers ADD COLUMN IF NOT EXISTS container_scheme TEXT;
+-- v2.28.0: auth_providers container-reconcile health/status (#181 follow-up)
+ALTER TABLE auth_providers ADD COLUMN IF NOT EXISTS last_resolved_ip TEXT;
+ALTER TABLE auth_providers ADD COLUMN IF NOT EXISTS last_reconcile_at DATETIME(6);
+ALTER TABLE auth_providers ADD COLUMN IF NOT EXISTS last_reconcile_status TEXT;
+ALTER TABLE auth_providers ADD COLUMN IF NOT EXISTS last_reconcile_error TEXT;
+ALTER TABLE auth_providers ADD COLUMN IF NOT EXISTS reconcile_fail_count INT NOT NULL DEFAULT 0;
+-- v2.30.0: global_settings.access_log_strip_query
+ALTER TABLE global_settings ADD COLUMN IF NOT EXISTS access_log_strip_query BOOLEAN NOT NULL DEFAULT false;
+-- skipped (no mechanical translation): v2.31.0: global_geo_restrictions singleton + geo_restrictions.disable_global (#198)
+-- skipped (no mechanical translation): v2.31.0: global_bot_filters singleton + bot_filters.disable_global (#198 slice 2)
+-- skipped (no mechanical translation): v2.31.0: global_security_headers singleton + security_headers.disable_global (#198 slice 3)
+-- skipped (no mechanical translation): v2.31.0: global_cloud_providers singleton + geo_restrictions.cloud_disable_global (#198 slice 4)
+-- skipped (no mechanical translation): v2.31.0: global_rate_limits singleton + rate_limits.disable_global (#198 slice 5)
+-- skipped (no mechanical translation): v2.31.0: global_waf singleton + proxy_hosts.waf_use_global (#198 slice 6)
+-- skipped (no mechanical translation): v2.32.0: cloudflare_tunnel singleton (Cloudflare Tunnel Phase 1 token mode)
+-- v2.33.0: log_filter_presets (saved log filter presets, #210)
+CREATE TABLE IF NOT EXISTS log_filter_presets (
+    id VARCHAR(36) NOT NULL DEFAULT (UUID()),
+    name TEXT NOT NULL,
+    log_type TEXT NOT NULL DEFAULT ('access'),
+    filter JSON NOT NULL,
+    created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    PRIMARY KEY (id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+CREATE INDEX IF NOT EXISTS idx_log_filter_presets_log_type ON log_filter_presets (log_type(191));
+-- skipped (no mechanical translation): v2.34.0: roles + role_permissions + users.role_id/must_change_password (RBAC, #222)
+-- skipped (DO $$): v2.34.0: users.role_id FK -> roles (RBAC, #222)
+-- v2.34.0: seed built-in roles and migrate existing accounts to administrator (RBAC, #222)
+INSERT INTO roles (id, name, description, is_superuser, is_builtin) VALUES ('00000000-0000-0000-0000-0000000000a1', 'builtin.administrator', 'Full access to every area', true, true), ('00000000-0000-0000-0000-0000000000a2', 'builtin.operator', 'Day-to-day operation without settings or account administration', false, true), ('00000000-0000-0000-0000-0000000000a3', 'builtin.viewer', 'Read-only across the operational areas', false, true) ON DUPLICATE KEY UPDATE id = id;
+INSERT INTO role_permissions (role_id, permission) VALUES ('00000000-0000-0000-0000-0000000000a2', 'dashboard:read'), ('00000000-0000-0000-0000-0000000000a2', 'proxy:read'), ('00000000-0000-0000-0000-0000000000a2', 'proxy:write'), ('00000000-0000-0000-0000-0000000000a2', 'redirect:read'), ('00000000-0000-0000-0000-0000000000a2', 'redirect:write'), ('00000000-0000-0000-0000-0000000000a2', 'waf:read'), ('00000000-0000-0000-0000-0000000000a2', 'waf:write'), ('00000000-0000-0000-0000-0000000000a2', 'access:read'), ('00000000-0000-0000-0000-0000000000a2', 'access:write'), ('00000000-0000-0000-0000-0000000000a2', 'authprovider:read'), ('00000000-0000-0000-0000-0000000000a2', 'authprovider:write'), ('00000000-0000-0000-0000-0000000000a2', 'certificate:read'), ('00000000-0000-0000-0000-0000000000a2', 'certificate:write'), ('00000000-0000-0000-0000-0000000000a2', 'ddns:read'), ('00000000-0000-0000-0000-0000000000a2', 'ddns:write'), ('00000000-0000-0000-0000-0000000000a2', 'logs:read'), ('00000000-0000-0000-0000-0000000000a2', 'backup:read'), ('00000000-0000-0000-0000-0000000000a3', 'dashboard:read'), ('00000000-0000-0000-0000-0000000000a3', 'proxy:read'), ('00000000-0000-0000-0000-0000000000a3', 'redirect:read'), ('00000000-0000-0000-0000-0000000000a3', 'waf:read'), ('00000000-0000-0000-0000-0000000000a3', 'access:read'), ('00000000-0000-0000-0000-0000000000a3', 'authprovider:read'), ('00000000-0000-0000-0000-0000000000a3', 'certificate:read'), ('00000000-0000-0000-0000-0000000000a3', 'ddns:read'), ('00000000-0000-0000-0000-0000000000a3', 'logs:read') ON CONFLICT (role_id, permission) DO NOTHING;
+UPDATE users SET role_id = '00000000-0000-0000-0000-0000000000a1' WHERE role_id IS NULL;
+-- v2.34.0: grant dnsprovider permissions to built-in roles (RBAC area split, #222)
+INSERT INTO role_permissions (role_id, permission) VALUES ('00000000-0000-0000-0000-0000000000a2', 'dnsprovider:read'), ('00000000-0000-0000-0000-0000000000a2', 'dnsprovider:write'), ('00000000-0000-0000-0000-0000000000a3', 'dnsprovider:read') ON CONFLICT (role_id, permission) DO NOTHING;
+-- skipped (no mechanical translation): v2.35.0: sso_providers + user_identities + sso_login_states (OIDC SSO, #227)
+-- skipped (DO $$): v2.35.0: SSO foreign keys (OIDC SSO, #227)
+-- skipped (no mechanical translation): v2.36.0: notification_channels + notification_state + notification_outbox (#221)
+-- skipped (DO $$): v2.36.0: notification_outbox FK -> notification_channels (#221)
+-- v2.36.0: per-event delivery mode and platform-native formatting (#221)
+ALTER TABLE notification_channels ADD COLUMN IF NOT EXISTS digest_events TEXT NOT NULL DEFAULT ('{}');
+ALTER TABLE notification_channels ADD COLUMN IF NOT EXISTS rich_format BOOLEAN NOT NULL DEFAULT true;
+ALTER TABLE notification_channels ADD COLUMN IF NOT EXISTS language VARCHAR(8) NOT NULL DEFAULT 'en';
+ALTER TABLE notification_channels ADD COLUMN IF NOT EXISTS dashboard_url TEXT;
+-- v2.36.0: readable subject label on notification state (#221)
+ALTER TABLE notification_state ADD COLUMN IF NOT EXISTS subject_label VARCHAR(255);

--- a/api/internal/database/migrations/mariadb/003_mariadb.sql
+++ b/api/internal/database/migrations/mariadb/003_mariadb.sql
@@ -1,0 +1,48 @@
+-- Nginx Proxy Guard — MariaDB/MySQL 보충 스키마
+--
+-- 001_init.sql, 002_upgrades.sql과 달리 손으로 작성한 파일입니다. 여기 있는 것은
+-- 전부 생성기가 PostgreSQL 원본에서 유도할 수 없는 객체들입니다. PostgreSQL
+-- 정의가 PL/pgSQL DO 블록이거나, 형태 차이가 커서 기계적 재작성이 추측이 되는
+-- 경우입니다.
+--
+-- 부팅할 때마다 재실행됩니다. 모든 문장은 멱등해야 합니다.
+
+-- ---------------------------------------------------------------------------
+-- ddns_records.proxy_host_id (#157)
+--
+-- PostgreSQL은 ADD CONSTRAINT에 IF NOT EXISTS가 없어 duplicate_object 오류를
+-- 삼키는 DO 블록으로 이 변경을 적용합니다. 여기서는 둘 다 IF NOT EXISTS를
+-- 지원하므로 평범한 문장 두 개로 끝납니다.
+-- ---------------------------------------------------------------------------
+ALTER TABLE ddns_records ADD COLUMN IF NOT EXISTS proxy_host_id VARCHAR(36);
+
+ALTER TABLE ddns_records
+    ADD CONSTRAINT ddns_records_proxy_host_id_fkey
+    FOREIGN KEY IF NOT EXISTS (proxy_host_id) REFERENCES proxy_hosts(id) ON DELETE CASCADE;
+
+-- ---------------------------------------------------------------------------
+-- logs_unified
+--
+-- PostgreSQL은 이 뷰를 동적으로 만듭니다. 파티션 테이블 마이그레이션 후에도
+-- 레거시 `logs` 테이블이 남아 있을 때만 그것과 `logs_partitioned`를 UNION 합니다.
+-- MariaDB/MySQL 설치에는 그런 이력이 없습니다. 첫 부팅부터 파티션 테이블이
+-- 존재하고 로그 수집기도 거기에만 쓰므로, 이 뷰는 단순한 투영입니다. 테이블을
+-- 직접 가리키지 않고 뷰로 두는 이유는 질의 계층을 두 백엔드에서 동일하게
+-- 유지하기 위해서입니다.
+--
+-- CREATE OR REPLACE라 멱등하고, 업그레이드 시 컬럼 목록 변경도 반영됩니다.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE VIEW logs_unified AS
+SELECT
+    id, log_type, "timestamp", host, client_ip,
+    geo_country, geo_country_code, geo_city, geo_asn, geo_org,
+    request_method, request_uri, request_protocol, status_code,
+    body_bytes_sent, request_time, upstream_response_time,
+    http_referer, http_user_agent, http_x_forwarded_for,
+    severity, error_message,
+    rule_id, rule_message, rule_severity, rule_data,
+    attack_type, action_taken,
+    block_reason, bot_category,
+    proxy_host_id, raw_log, created_at,
+    upstream_addr, upstream_status
+FROM logs_partitioned;

--- a/api/internal/handler/health_detailed.go
+++ b/api/internal/handler/health_detailed.go
@@ -9,6 +9,7 @@ import (
 
 	"nginx-proxy-guard/internal/config"
 	"nginx-proxy-guard/internal/database"
+	"nginx-proxy-guard/internal/database/dialect"
 	"nginx-proxy-guard/internal/repository"
 	"nginx-proxy-guard/internal/service"
 	"nginx-proxy-guard/pkg/cache"
@@ -20,15 +21,15 @@ import (
 // All sub-queries are bounded by a short context timeout so a stuck DB or
 // Redis cannot stall the handler indefinitely.
 type HealthDetailedHandler struct {
-	startedAt   time.Time
-	repo        *repository.HealthDetailedRepository
-	logCollect  *service.LogCollector
-	redis       *cache.RedisClient
-	proxyRepo   *repository.ProxyHostRepository
+	startedAt    time.Time
+	repo         *repository.HealthDetailedRepository
+	logCollect   *service.LogCollector
+	redis        *cache.RedisClient
+	proxyRepo    *repository.ProxyHostRepository
 	settingsRepo *repository.GlobalSettingsRepository
-	canary      *service.PipelineCanary
-	stats       *service.StatsCollector
-	db          *database.DB
+	canary       *service.PipelineCanary
+	stats        *service.StatsCollector
+	db           *database.DB
 }
 
 func NewHealthDetailedHandler(
@@ -55,13 +56,13 @@ func NewHealthDetailedHandler(
 }
 
 type detailedHealthResponse struct {
-	Version       string                      `json:"version"`
-	UptimeSeconds int64                       `json:"uptime_seconds"`
-	Database      *detailedDatabaseInfo       `json:"database"`
-	Cache         *detailedCacheInfo          `json:"cache"`
-	LogCollector  *detailedLogCollectorInfo   `json:"log_collector"`
-	Nginx         *detailedNginxInfo          `json:"nginx"`
-	NginxTuning   *detailedNginxTuningInfo    `json:"nginx_tuning,omitempty"`
+	Version       string                    `json:"version"`
+	UptimeSeconds int64                     `json:"uptime_seconds"`
+	Database      *detailedDatabaseInfo     `json:"database"`
+	Cache         *detailedCacheInfo        `json:"cache"`
+	LogCollector  *detailedLogCollectorInfo `json:"log_collector"`
+	Nginx         *detailedNginxInfo        `json:"nginx"`
+	NginxTuning   *detailedNginxTuningInfo  `json:"nginx_tuning,omitempty"`
 }
 
 // detailedNginxTuningInfo exposes the subset of global_settings that an
@@ -80,10 +81,14 @@ type detailedNginxTuningInfo struct {
 }
 
 type detailedDatabaseInfo struct {
-	Connected         bool                          `json:"connected"`
-	AccessLogRows     int64                         `json:"access_log_rows_estimate"`
-	Hypertables       []repository.HypertableStats  `json:"hypertables"`
-	HypertablesError  string                        `json:"hypertables_error,omitempty"`
+	Connected bool `json:"connected"`
+	// 이 설치가 어느 백엔드에서 도는지: "postgres", "mariadb", "mysql".
+	// 드러낼 가치가 있는 이유는 이 구조체의 나머지가 무엇을 보고할 수 있는지가
+	// 이 값에 따라 달라지기 때문이다. 하이퍼테이블 통계는 TimescaleDB 전용이다.
+	Engine           string                       `json:"engine"`
+	AccessLogRows    int64                        `json:"access_log_rows_estimate"`
+	Hypertables      []repository.HypertableStats `json:"hypertables"`
+	HypertablesError string                       `json:"hypertables_error,omitempty"`
 	// Degraded-but-serving signal: upgrade migrations are warn-and-continue
 	// (a fail-fast boot would brick existing installs), so partial-migration
 	// state surfaces here instead of flipping the liveness probe.
@@ -92,8 +97,8 @@ type detailedDatabaseInfo struct {
 }
 
 type detailedCacheInfo struct {
-	Ready          bool  `json:"ready"`
-	LogBufferSize  int64 `json:"log_buffer_size"`
+	Ready         bool  `json:"ready"`
+	LogBufferSize int64 `json:"log_buffer_size"`
 }
 
 type detailedLogCollectorInfo struct {
@@ -176,7 +181,7 @@ func (h *HealthDetailedHandler) tuningInfo(ctx context.Context) *detailedNginxTu
 }
 
 func (h *HealthDetailedHandler) dbInfo(ctx context.Context) *detailedDatabaseInfo {
-	info := &detailedDatabaseInfo{Connected: true}
+	info := &detailedDatabaseInfo{Connected: true, Engine: dialect.Active().String()}
 
 	if rows, err := h.repo.GetAccessLogRowCount(ctx); err == nil {
 		info.AccessLogRows = rows
@@ -184,11 +189,16 @@ func (h *HealthDetailedHandler) dbInfo(ctx context.Context) *detailedDatabaseInf
 		info.Connected = false
 	}
 
-	hyper, err := h.repo.GetHypertableStats(ctx)
-	if err != nil {
-		info.HypertablesError = err.Error()
-	} else {
-		info.Hypertables = hyper
+	// 하이퍼테이블은 TimescaleDB 개념이다. MySQL 계열에서 그에 해당하는 월별
+	// RANGE 파티션은 파티션 스케줄러가 관리하며, 여기서 물어봐야 혼란스러운
+	// 오류 문자열만 나온다.
+	if !dialect.ActiveIsMySQLFamily() {
+		hyper, err := h.repo.GetHypertableStats(ctx)
+		if err != nil {
+			info.HypertablesError = err.Error()
+		} else {
+			info.Hypertables = hyper
+		}
 	}
 
 	if h.db != nil {

--- a/api/internal/repository/backup_export_settings.go
+++ b/api/internal/repository/backup_export_settings.go
@@ -345,7 +345,7 @@ func (r *BackupRepository) exportRoles(ctx context.Context) ([]model.RoleExport,
 func (r *BackupRepository) exportSSOProviders(ctx context.Context) ([]model.SSOProviderExport, error) {
 	var present bool
 	if err := r.db.QueryRowContext(ctx,
-		`SELECT to_regclass('public.sso_providers') IS NOT NULL`).Scan(&present); err != nil || !present {
+		tablesExistSQL("sso_providers")).Scan(&present); err != nil || !present {
 		return nil, nil
 	}
 

--- a/api/internal/repository/backup_import_settings.go
+++ b/api/internal/repository/backup_import_settings.go
@@ -300,7 +300,7 @@ func (r *BackupRepository) importRoles(ctx context.Context, tx *sql.Tx, roles []
 func (r *BackupRepository) importSSOProviders(ctx context.Context, tx *sql.Tx, providers []model.SSOProviderExport) error {
 	var present bool
 	if err := tx.QueryRowContext(ctx,
-		`SELECT to_regclass('public.sso_providers') IS NOT NULL`).Scan(&present); err != nil || !present {
+		tablesExistSQL("sso_providers")).Scan(&present); err != nil || !present {
 		if len(providers) > 0 {
 			log.Printf("Backup import: skipping %d SSO providers — the sso_providers table is missing", len(providers))
 		}

--- a/api/internal/repository/certificate.go
+++ b/api/internal/repository/certificate.go
@@ -611,27 +611,31 @@ func (r *CertificateRepository) RecoverInterruptedStates(ctx context.Context) (r
 	// RETURNING id + per-row invalidation mirrors DeleteByErrorStatus: these
 	// raw UPDATEs change status/error_message, so a stale GetByID cache entry
 	// would otherwise serve the pre-restart status for up to 60s after recovery.
-	recovered, err = r.updateAndInvalidate(ctx, `
-		UPDATE certificates
-		SET status = 'issued',
-			error_message = 'renewal interrupted by API restart; will retry on schedule',
-			updated_at = NOW()
-		WHERE status = 'renewing' AND certificate_pem IS NOT NULL AND certificate_pem != ''
-		RETURNING id
-	`)
+	// RETURNING이 아니라 UPDATE 전에 모은다. 술어가 바로 그 갱신 대상 컬럼을
+	// 검사하므로, 나중에는 영향받은 행을 다시 조회할 방법이 없다. 이 코드는
+	// API가 서비스를 시작하기 전 부팅 시점에 돌고, 단일 인스턴스 배포에서 다른
+	// 고루틴이 인증서 상태를 건드리지 않으므로 안전하다.
+	recovered, err = r.updateAndInvalidate(ctx,
+		`SELECT id FROM certificates
+		 WHERE status = 'renewing' AND certificate_pem IS NOT NULL AND certificate_pem != ''`,
+		`UPDATE certificates
+		 SET status = 'issued',
+			 error_message = 'renewal interrupted by API restart; will retry on schedule',
+			 updated_at = NOW()
+		 WHERE id IN (%s)`)
 	if err != nil {
 		return 0, 0, fmt.Errorf("failed to recover interrupted renewals: %w", err)
 	}
 
-	failed, err = r.updateAndInvalidate(ctx, `
-		UPDATE certificates
-		SET status = 'error',
-			error_message = 'issuance interrupted by API restart; please retry',
-			updated_at = NOW()
-		WHERE status IN ('pending', 'renewing')
-			AND (certificate_pem IS NULL OR certificate_pem = '')
-		RETURNING id
-	`)
+	failed, err = r.updateAndInvalidate(ctx,
+		`SELECT id FROM certificates
+		 WHERE status IN ('pending', 'renewing')
+		   AND (certificate_pem IS NULL OR certificate_pem = '')`,
+		`UPDATE certificates
+		 SET status = 'error',
+			 error_message = 'issuance interrupted by API restart; please retry',
+			 updated_at = NOW()
+		 WHERE id IN (%s)`)
 	if err != nil {
 		return recovered, 0, fmt.Errorf("failed to fail interrupted issuances: %w", err)
 	}
@@ -639,25 +643,53 @@ func (r *CertificateRepository) RecoverInterruptedStates(ctx context.Context) (r
 	return recovered, failed, nil
 }
 
-// updateAndInvalidate runs an UPDATE ... RETURNING id query, drops each
-// affected row's per-id cache entry, and returns the number of rows changed.
-func (r *CertificateRepository) updateAndInvalidate(ctx context.Context, query string) (int64, error) {
-	rows, err := r.db.QueryContext(ctx, query)
+// updateAndInvalidate는 복구 UPDATE가 건드릴 행을 먼저 조회하고, 정확히 그 id
+// 들에만 갱신을 적용한 뒤, 각 id의 캐시 항목을 지우고 바뀐 행 수를 돌려준다.
+//
+// selectSQL이 대상 행을 특정하고, updateSQL은 %s 하나가 그 id들의 IN 목록으로
+// 채워지는 포맷 문자열이다. 행별 캐시 무효화가 중요한 이유는 이 원시 UPDATE들이
+// status와 error_message를 바꾸기 때문이다. 그대로 두면 오래된 GetByID 항목이
+// 재시작 이전 상태를 최대 60초간 서빙한다.
+func (r *CertificateRepository) updateAndInvalidate(ctx context.Context, selectSQL, updateSQL string) (int64, error) {
+	rows, err := r.db.QueryContext(ctx, selectSQL)
 	if err != nil {
 		return 0, err
 	}
-	defer rows.Close()
 
-	var affected int64
+	var ids []string
 	for rows.Next() {
 		var id string
 		if err := rows.Scan(&id); err != nil {
-			return affected, fmt.Errorf("failed to scan recovered cert id: %w", err)
+			rows.Close()
+			return 0, fmt.Errorf("failed to scan recovered cert id: %w", err)
 		}
-		r.invalidateCert(ctx, id)
-		affected++
+		ids = append(ids, id)
 	}
-	return affected, rows.Err()
+	if err := rows.Err(); err != nil {
+		rows.Close()
+		return 0, err
+	}
+	rows.Close()
+
+	if len(ids) == 0 {
+		return 0, nil
+	}
+
+	result, err := r.db.ExecContext(ctx,
+		fmt.Sprintf(updateSQL, placeholders(1, len(ids))), stringArgs(ids)...)
+	if err != nil {
+		return 0, err
+	}
+
+	for _, id := range ids {
+		r.invalidateCert(ctx, id)
+	}
+
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return int64(len(ids)), nil
+	}
+	return affected, nil
 }
 
 // Helper functions

--- a/api/internal/repository/cloud_provider.go
+++ b/api/internal/repository/cloud_provider.go
@@ -72,11 +72,11 @@ func (r *CloudProviderRepository) List(ctx context.Context) ([]model.CloudProvid
 
 // ListByRegion returns providers grouped by region
 func (r *CloudProviderRepository) ListByRegion(ctx context.Context) (*model.CloudProvidersByRegion, error) {
-	query := `
-		SELECT slug, name, region, COALESCE(description, ''), array_length(ip_ranges, 1), enabled
+	query := fmt.Sprintf(`
+		SELECT slug, name, region, COALESCE(description, ''), %s, enabled
 		FROM cloud_providers
 		WHERE enabled = true
-		ORDER BY region, name`
+		ORDER BY region, name`, arrayLength("ip_ranges"))
 
 	rows, err := r.db.QueryContext(ctx, query)
 	if err != nil {
@@ -252,12 +252,12 @@ func (r *CloudProviderRepository) GetIPRangesForProviders(ctx context.Context, s
 		return []string{}, nil
 	}
 
-	query := `
+	query := fmt.Sprintf(`
 		SELECT ip_ranges
 		FROM cloud_providers
-		WHERE slug = ANY($1) AND enabled = true`
+		WHERE slug IN (%s) AND enabled = true`, placeholders(1, len(slugs)))
 
-	rows, err := r.db.QueryContext(ctx, query, pq.Array(slugs))
+	rows, err := r.db.QueryContext(ctx, query, stringArgs(slugs)...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get IP ranges: %w", err)
 	}
@@ -486,7 +486,7 @@ func (r *CloudProviderRepository) GetProxyHostIDsWithCloudProviderBlocking(ctx c
 			SELECT proxy_host_id
 			FROM geo_restrictions
 			WHERE blocked_cloud_providers IS NOT NULL
-			  AND array_length(blocked_cloud_providers, 1) > 0`
+			  AND ` + arrayNotEmpty("blocked_cloud_providers")
 	} else {
 		// Get hosts blocking any of the specified providers
 		query = `

--- a/api/internal/repository/dashboard.go
+++ b/api/internal/repository/dashboard.go
@@ -7,6 +7,8 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"nginx-proxy-guard/internal/database/dialect"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -454,6 +456,10 @@ func (r *DashboardRepository) GetBlockBreakdown(ctx context.Context, since time.
 
 func (r *DashboardRepository) getTopCountries(ctx context.Context, since time.Time) []model.CountryStat {
 	// Aggregate from JSONB top_countries column
+	if dialect.ActiveIsMySQLFamily() {
+		return r.getTopCountriesMariaDB(ctx, since)
+	}
+
 	rows, err := r.db.QueryContext(ctx, `
 		SELECT key, SUM(value::INT) as total
 		FROM dashboard_stats_hourly, jsonb_each_text(top_countries)
@@ -472,6 +478,61 @@ func (r *DashboardRepository) getTopCountries(ctx context.Context, since time.Ti
 		var s model.CountryStat
 		rows.Scan(&s.Country, &s.Count)
 		stats = append(stats, s)
+	}
+	return stats
+}
+
+// getTopCountriesMariaDB는 시간별 JSON 맵을 Go에서 집계한다.
+//
+// PostgreSQL은 jsonb_each_text로 객체를 행으로 펼쳐 SQL에서 합산한다. MySQL
+// 계열은 JSON 객체의 키를 순회하려면 JSON_TABLE에 생성 수열을 곁들여야 하는데,
+// 여기서 행을 합산하는 것보다 느리고 읽기도 훨씬 어렵다. 행 수도 기간 내 시간
+// 수 곱하기 호스트 수로 제한되며 대시보드가 이미 그 값을 작게 유지한다.
+func (r *DashboardRepository) getTopCountriesMariaDB(ctx context.Context, since time.Time) []model.CountryStat {
+	rows, err := r.db.QueryContext(ctx, `
+		SELECT top_countries FROM dashboard_stats_hourly WHERE hour_bucket >= $1
+	`, since)
+	if err != nil {
+		return []model.CountryStat{}
+	}
+	defer rows.Close()
+
+	totals := map[string]int64{}
+	for rows.Next() {
+		var raw sql.NullString
+		if err := rows.Scan(&raw); err != nil || !raw.Valid || raw.String == "" {
+			continue
+		}
+		// 개수는 JSON 숫자로 기록되지만 과거에는 문자열로도 쓰였다. 관대하게
+		// 디코딩하고 둘 중 어느 쪽도 아니면 건너뛴다.
+		var bucket map[string]json.Number
+		if err := json.Unmarshal([]byte(raw.String), &bucket); err != nil {
+			continue
+		}
+		for country, count := range bucket {
+			n, err := count.Int64()
+			if err != nil {
+				continue
+			}
+			totals[country] += n
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return []model.CountryStat{}
+	}
+
+	stats := make([]model.CountryStat, 0, len(totals))
+	for country, count := range totals {
+		stats = append(stats, model.CountryStat{Country: country, Count: count})
+	}
+	sort.Slice(stats, func(i, j int) bool {
+		if stats[i].Count != stats[j].Count {
+			return stats[i].Count > stats[j].Count
+		}
+		return stats[i].Country < stats[j].Country
+	})
+	if len(stats) > 10 {
+		stats = stats[:10]
 	}
 	return stats
 }

--- a/api/internal/repository/ddns.go
+++ b/api/internal/repository/ddns.go
@@ -3,8 +3,8 @@ package repository
 import (
 	"context"
 	"database/sql"
-	"errors"
 	"fmt"
+	"nginx-proxy-guard/internal/database/dialect"
 	"time"
 
 	"github.com/lib/pq"
@@ -16,8 +16,7 @@ import (
 // isDDNSUniqueViolation reports whether err is a PostgreSQL unique-violation on
 // the (hostname, dns_provider_id) index (idx_ddns_records_hostname_provider).
 func isDDNSUniqueViolation(err error) bool {
-	var pqErr *pq.Error
-	return errors.As(err, &pqErr) && pqErr.Code == "23505"
+	return dialect.IsUniqueViolation(err)
 }
 
 // DDNSRepository persists DDNS records (#154).

--- a/api/internal/repository/health_detailed.go
+++ b/api/internal/repository/health_detailed.go
@@ -3,6 +3,7 @@ package repository
 import (
 	"context"
 	"database/sql"
+	"nginx-proxy-guard/internal/database/dialect"
 )
 
 // HealthDetailedRepository surfaces storage + compression telemetry used by
@@ -32,6 +33,13 @@ type HypertableStats struct {
 // catalog rows on errors so a missing timescaledb_information view (older PG
 // or a non-Timescale fallback) does not block the entire health response.
 func (r *HealthDetailedRepository) GetHypertableStats(ctx context.Context) ([]HypertableStats, error) {
+	// 하이퍼테이블은 TimescaleDB에서만 존재한다. 오류 대신 아무것도 돌려주지
+	// 않으면 "여기엔 그런 지표가 없다"는 답이 되고, 헬스 응답이 굳이 설명해야
+	// 할 실패가 되지 않는다.
+	if dialect.ActiveIsMySQLFamily() {
+		return nil, nil
+	}
+
 	const q = `
 		SELECT h.hypertable_name,
 		       h.compression_enabled,

--- a/api/internal/repository/log_cleanup.go
+++ b/api/internal/repository/log_cleanup.go
@@ -13,6 +13,20 @@ func (r *LogRepository) DeleteOld(ctx context.Context, retentionDays int) (int64
 	if retentionMonths < 1 {
 		retentionMonths = 1
 	}
+	if r.db.IsMySQLFamily() {
+		// MySQL 계열에는 PL/pgSQL 헬퍼가 없다. 파티션 단위 보존은 파티션
+		// 스케줄러가 맡으므로(scheduler/partition_mariadb.go 참고) 이 진입점은
+		// 경계에 걸친 행만 정리한다.
+		result, err := r.db.ExecContext(ctx,
+			`DELETE FROM logs_partitioned WHERE created_at < NOW() - ($1 || ' days')::INTERVAL`,
+			retentionDays)
+		if err != nil {
+			return 0, fmt.Errorf("failed to delete old logs: %w", err)
+		}
+		deleted, _ := result.RowsAffected()
+		return deleted, nil
+	}
+
 	var dropped int
 	err := r.db.QueryRowContext(ctx, `SELECT drop_old_partitions('logs_p', $1)`, retentionMonths).Scan(&dropped)
 	if err != nil {

--- a/api/internal/repository/log_insert.go
+++ b/api/internal/repository/log_insert.go
@@ -3,6 +3,7 @@ package repository
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/lib/pq"
@@ -34,54 +35,24 @@ func nullFloat64(f float64) interface{} {
 // NULLIF()/COALESCE() now happens in Go before binding — column semantics are
 // identical to createSingle.
 func (r *LogRepository) createBatchTx(ctx context.Context, logs []model.CreateLogRequest) error {
+	if r.db.IsMySQLFamily() {
+		return r.createBatchMultiRow(ctx, logs)
+	}
+
 	tx, err := r.db.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("failed to begin transaction: %w", err)
 	}
 	defer tx.Rollback()
 
-	stmt, err := tx.PrepareContext(ctx, pq.CopyIn("logs_partitioned",
-		"log_type", "timestamp", "host", "client_ip",
-		"geo_country", "geo_country_code", "geo_city", "geo_asn", "geo_org",
-		"request_method", "request_uri", "request_protocol", "status_code",
-		"body_bytes_sent", "request_time", "upstream_response_time",
-		"upstream_addr", "upstream_status",
-		"http_referer", "http_user_agent", "http_x_forwarded_for",
-		"severity", "error_message",
-		"rule_id", "rule_message", "rule_severity", "rule_data", "attack_type", "action_taken",
-		"block_reason", "bot_category", "exploit_rule",
-		"proxy_host_id", "raw_log",
-	))
+	stmt, err := tx.PrepareContext(ctx, pq.CopyIn("logs_partitioned", logColumns...))
 	if err != nil {
 		return fmt.Errorf("failed to prepare statement: %w", err)
 	}
 	defer stmt.Close()
 
 	for _, req := range logs {
-		timestamp := req.Timestamp
-		if timestamp.IsZero() {
-			timestamp = time.Now()
-		}
-
-		// COALESCE(NULLIF(block_reason, '')::block_reason, 'none')
-		blockReason := string(req.BlockReason)
-		if blockReason == "" {
-			blockReason = "none"
-		}
-
-		_, err := stmt.ExecContext(ctx,
-			string(req.LogType), timestamp, nullString(req.Host), nullString(req.ClientIP),
-			nullString(req.GeoCountry), nullString(req.GeoCountryCode), nullString(req.GeoCity), nullString(req.GeoASN), nullString(req.GeoOrg),
-			nullString(req.RequestMethod), nullString(req.RequestURI), nullString(req.RequestProtocol), nullInt64(int64(req.StatusCode)),
-			nullInt64(req.BodyBytesSent), nullFloat64(req.RequestTime), nullFloat64(req.UpstreamResponseTime),
-			nullString(req.UpstreamAddr), nullString(req.UpstreamStatus),
-			nullString(req.HTTPReferer), nullString(req.HTTPUserAgent), nullString(req.HTTPXForwardedFor),
-			nullString(string(req.Severity)), nullString(req.ErrorMessage),
-			nullInt64(req.RuleID), nullString(req.RuleMessage), nullString(req.RuleSeverity), nullString(req.RuleData), nullString(req.AttackType), nullString(req.ActionTaken),
-			blockReason, nullString(req.BotCategory), nullString(req.ExploitRule),
-			nullString(req.ProxyHostID), nullString(req.RawLog),
-		)
-		if err != nil {
+		if _, err := stmt.ExecContext(ctx, logInsertValues(req)...); err != nil {
 			return fmt.Errorf("failed to insert log: %w", err)
 		}
 	}
@@ -140,4 +111,111 @@ func (r *LogRepository) createSingle(ctx context.Context, req *model.CreateLogRe
 		req.ProxyHostID, req.RawLog,
 	)
 	return err
+}
+
+// logColumns는 COPY 경로, 다중 행 경로, logInsertValues가 공유하는 컬럼 순서다.
+// 바꾸려면 셋을 함께 바꿔야 한다.
+var logColumns = []string{
+	"log_type", "timestamp", "host", "client_ip",
+	"geo_country", "geo_country_code", "geo_city", "geo_asn", "geo_org",
+	"request_method", "request_uri", "request_protocol", "status_code",
+	"body_bytes_sent", "request_time", "upstream_response_time",
+	"upstream_addr", "upstream_status",
+	"http_referer", "http_user_agent", "http_x_forwarded_for",
+	"severity", "error_message",
+	"rule_id", "rule_message", "rule_severity", "rule_data", "attack_type", "action_taken",
+	"block_reason", "bot_category", "exploit_rule",
+	"proxy_host_id", "raw_log",
+}
+
+// logInsertValues는 요청 하나를 logColumns 순서의 바인딩 값으로 정규화한다.
+// 빈 문자열과 0을 SQL의 NULLIF()가 아니라 여기서 NULL로 바꾸므로, COPY 경로와
+// 다중 행 경로가 createSingle과 정확히 같은 값을 저장한다.
+func logInsertValues(req model.CreateLogRequest) []interface{} {
+	timestamp := req.Timestamp
+	if timestamp.IsZero() {
+		timestamp = time.Now()
+	}
+
+	// COALESCE(NULLIF(block_reason, '')::block_reason, 'none')
+	blockReason := string(req.BlockReason)
+	if blockReason == "" {
+		blockReason = "none"
+	}
+
+	return []interface{}{
+		string(req.LogType), timestamp, nullString(req.Host), nullString(req.ClientIP),
+		nullString(req.GeoCountry), nullString(req.GeoCountryCode), nullString(req.GeoCity), nullString(req.GeoASN), nullString(req.GeoOrg),
+		nullString(req.RequestMethod), nullString(req.RequestURI), nullString(req.RequestProtocol), nullInt64(int64(req.StatusCode)),
+		nullInt64(req.BodyBytesSent), nullFloat64(req.RequestTime), nullFloat64(req.UpstreamResponseTime),
+		nullString(req.UpstreamAddr), nullString(req.UpstreamStatus),
+		nullString(req.HTTPReferer), nullString(req.HTTPUserAgent), nullString(req.HTTPXForwardedFor),
+		nullString(string(req.Severity)), nullString(req.ErrorMessage),
+		nullInt64(req.RuleID), nullString(req.RuleMessage), nullString(req.RuleSeverity), nullString(req.RuleData), nullString(req.AttackType), nullString(req.ActionTaken),
+		blockReason, nullString(req.BotCategory), nullString(req.ExploitRule),
+		nullString(req.ProxyHostID), nullString(req.RawLog),
+	}
+}
+
+// maxMultiRowChunk는 INSERT 하나에 들어갈 로그 행 수의 상한이다.
+//
+// MySQL 프로토콜은 문장당 바인딩 파라미터를 최대 65535개까지 허용하고, 행마다
+// len(logColumns)개를 쓴다. 수집기의 플러시 크기인 500행은 그 안에 충분히
+// 들어가지만, 컬럼을 추가했을 때 조용히 한도를 넘는 문장이 만들어지지 않도록
+// 값을 가정하지 않고 계산한다.
+var maxMultiRowChunk = 65535 / len(logColumns)
+
+// createBatchMultiRow는 COPY 경로의 MySQL 계열 대응물이다.
+//
+// MySQL 계열에는 COPY 프로토콜이 없으므로, 왕복 한 번으로 끝내는 동등한 쓰기는
+// 다중 행 INSERT다. 의미는 COPY 경로와 정확히 같다. 트랜잭션 하나, Go에서 이미
+// 정규화된 값, 그리고 행 하나가 거부되면 배치 전체가 중단되어 CreateBatch가 더
+// 작은 배치로 물러나 문제 행을 격리할 수 있게 하는 것까지.
+func (r *LogRepository) createBatchMultiRow(ctx context.Context, logs []model.CreateLogRequest) error {
+	tx, err := r.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer tx.Rollback()
+
+	for start := 0; start < len(logs); start += maxMultiRowChunk {
+		end := start + maxMultiRowChunk
+		if end > len(logs) {
+			end = len(logs)
+		}
+		chunk := logs[start:end]
+
+		placeholderRow := "(" + strings.TrimSuffix(strings.Repeat("?, ", len(logColumns)), ", ") + ")"
+		rowsSQL := make([]string, len(chunk))
+		args := make([]interface{}, 0, len(chunk)*len(logColumns))
+		for i, req := range chunk {
+			rowsSQL[i] = placeholderRow
+			args = append(args, logInsertValues(req)...)
+		}
+
+		// 이미 대상 엔진의 SQL이므로 $N이 아니라 `?`로 쓴다. 번역기는 $N
+		// 플레이스홀더가 없는 문장은 건드리지 않는다.
+		query := fmt.Sprintf("INSERT INTO logs_partitioned (%s) VALUES %s",
+			strings.Join(quoteLogColumns(), ", "), strings.Join(rowsSQL, ", "))
+
+		if _, err := tx.ExecContext(ctx, query, args...); err != nil {
+			return fmt.Errorf("failed to insert log: %w", err)
+		}
+	}
+
+	return tx.Commit()
+}
+
+// quoteLogColumns는 로그 컬럼 중 예약어를 인용한다. 모든 커넥션에 ANSI_QUOTES가
+// 켜져 있으므로 큰따옴표가 식별자 구분자다.
+func quoteLogColumns() []string {
+	out := make([]string, len(logColumns))
+	for i, c := range logColumns {
+		if c == "timestamp" {
+			out[i] = `"timestamp"`
+			continue
+		}
+		out[i] = c
+	}
+	return out
 }

--- a/api/internal/repository/notification.go
+++ b/api/internal/repository/notification.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"nginx-proxy-guard/internal/database/dialect"
 	"time"
 
 	"github.com/lib/pq"
@@ -31,9 +32,7 @@ func NewNotificationRepository(db *database.DB) *NotificationRepository {
 func (r *NotificationRepository) TablesExist(ctx context.Context) bool {
 	var ok bool
 	err := r.db.QueryRowContext(ctx,
-		`SELECT to_regclass('public.notification_channels') IS NOT NULL
-		    AND to_regclass('public.notification_state') IS NOT NULL
-		    AND to_regclass('public.notification_outbox') IS NOT NULL`).Scan(&ok)
+		tablesExistSQL("notification_channels", "notification_state", "notification_outbox")).Scan(&ok)
 	return err == nil && ok
 }
 
@@ -114,7 +113,7 @@ func (r *NotificationRepository) GetByID(ctx context.Context, id string) (*model
 func (r *NotificationRepository) ChannelsForEvent(ctx context.Context, eventKey string) ([]model.NotificationChannel, error) {
 	rows, err := r.db.QueryContext(ctx,
 		`SELECT `+channelColumns+` FROM notification_channels
-		 WHERE enabled AND events @> ARRAY[$1]::text[] ORDER BY name`, eventKey)
+		 WHERE enabled AND `+arrayContains("events", 1)+` ORDER BY name`, eventKey)
 	if err != nil {
 		return nil, fmt.Errorf("failed to select channels for %s: %w", eventKey, err)
 	}
@@ -146,7 +145,7 @@ func (r *NotificationRepository) ChannelsForDigest(ctx context.Context, hour int
 func (r *NotificationRepository) SetChatID(ctx context.Context, channelID, chatID string) error {
 	_, err := r.db.ExecContext(ctx,
 		`UPDATE notification_channels
-		 SET config = jsonb_set(config, '{chat_id}', to_jsonb($2::text)), updated_at = now()
+		 SET config = `+jsonSetString("config", "chat_id", 2)+`, updated_at = now()
 		 WHERE id = $1`, channelID, chatID)
 	if err != nil {
 		return fmt.Errorf("failed to store migrated chat id: %w", err)
@@ -179,7 +178,7 @@ func (r *NotificationRepository) Create(ctx context.Context, req *model.CreateNo
 		req.Name, req.Type, enabled, config, pq.Array(req.Events), pq.Array(req.DigestEvents),
 		req.RichFormat, req.Language, req.DashboardURL, req.DigestEnabled, req.DigestHour, req.AllowPrivateTarget, req.Template).Scan(&id)
 	if err != nil {
-		if pqErr, ok := err.(*pq.Error); ok && pqErr.Code == "23505" {
+		if dialect.IsUniqueViolation(err) {
 			return "", fmt.Errorf("a channel with this name already exists")
 		}
 		return "", fmt.Errorf("failed to create notification channel: %w", err)
@@ -208,7 +207,7 @@ func (r *NotificationRepository) Update(ctx context.Context, id string, req *mod
 		id, req.Name, req.Type, enabled, config, pq.Array(req.Events), pq.Array(req.DigestEvents),
 		req.RichFormat, req.Language, req.DashboardURL, req.DigestEnabled, req.DigestHour, req.AllowPrivateTarget, req.Template)
 	if err != nil {
-		if pqErr, ok := err.(*pq.Error); ok && pqErr.Code == "23505" {
+		if dialect.IsUniqueViolation(err) {
 			return fmt.Errorf("a channel with this name already exists")
 		}
 		return fmt.Errorf("failed to update notification channel: %w", err)
@@ -353,7 +352,7 @@ func (r *NotificationRepository) EnqueueForDigest(ctx context.Context, channelID
 func (r *NotificationRepository) ChannelsForDigestEvent(ctx context.Context, eventKey string) ([]model.NotificationChannel, error) {
 	rows, err := r.db.QueryContext(ctx,
 		`SELECT `+channelColumns+` FROM notification_channels
-		 WHERE enabled AND digest_enabled AND digest_events @> ARRAY[$1]::text[] ORDER BY name`, eventKey)
+		 WHERE enabled AND digest_enabled AND `+arrayContains("digest_events", 1)+` ORDER BY name`, eventKey)
 	if err != nil {
 		return nil, fmt.Errorf("failed to select digest channels for %s: %w", eventKey, err)
 	}
@@ -375,7 +374,7 @@ type DigestPending struct {
 func (r *NotificationRepository) PendingDigestItems(ctx context.Context, channelID string, since time.Time) ([]DigestPending, error) {
 	rows, err := r.db.QueryContext(ctx, `
 		SELECT event_key, count(*), max(created_at),
-		       COALESCE((array_agg(payload->'fields'->>'subject' ORDER BY created_at DESC))[1], '')
+		       `+latestJSONField("payload", "subject", "created_at DESC")+`
 		FROM notification_outbox
 		WHERE channel_id = $1 AND status = $2 AND created_at >= $3
 		GROUP BY event_key
@@ -438,8 +437,8 @@ func (r *NotificationRepository) FailQueuedForDisabledChannel(ctx context.Contex
 func (r *NotificationRepository) ExpireStaleQueued(ctx context.Context, maxAge time.Duration, reason string) (int64, error) {
 	res, err := r.db.ExecContext(ctx,
 		`UPDATE notification_outbox SET status = 'failed', last_error = $2
-		 WHERE status = 'queued' AND created_at < now() - $1::interval`,
-		fmt.Sprintf("%d seconds", int(maxAge.Seconds())), reason)
+		 WHERE status = 'queued' AND created_at < now() - ($1 || ' seconds')::interval`,
+		int(maxAge.Seconds()), reason)
 	if err != nil {
 		return 0, fmt.Errorf("failed to expire stale notifications: %w", err)
 	}
@@ -508,8 +507,8 @@ func (r *NotificationRepository) MarkSent(ctx context.Context, id int64) error {
 func (r *NotificationRepository) MarkRetry(ctx context.Context, id int64, in time.Duration, reason string) error {
 	_, err := r.db.ExecContext(ctx, `
 		UPDATE notification_outbox
-		SET attempts = attempts + 1, next_attempt_at = now() + $2::interval, last_error = $3
-		WHERE id = $1`, id, fmt.Sprintf("%d seconds", int(in.Seconds())), reason)
+		SET attempts = attempts + 1, next_attempt_at = now() + ($2 || ' seconds')::interval, last_error = $3
+		WHERE id = $1`, id, int(in.Seconds()), reason)
 	return err
 }
 

--- a/api/internal/repository/proxy_host.go
+++ b/api/internal/repository/proxy_host.go
@@ -790,7 +790,7 @@ func (r *ProxyHostRepository) GetByDomain(ctx context.Context, domain string) (*
 			COALESCE(client_max_body_size, '') as client_max_body_size,
 			COALESCE(proxy_max_temp_file_size, '') as proxy_max_temp_file_size,
 			access_list_id, enabled, is_favorite, COALESCE(config_status, 'ok') as config_status, COALESCE(config_error, '') as config_error, ddns_enabled, ddns_provider_id, ddns_proxied, auth_provider_id, COALESCE(auth_bypass_paths, '{}') as auth_bypass_paths, meta, created_at, updated_at
-		FROM proxy_hosts WHERE $1 = ANY(domain_names)
+		FROM proxy_hosts WHERE ` + arrayContains("domain_names", 1) + `
 		LIMIT 1
 	`
 

--- a/api/internal/repository/proxy_host_queries.go
+++ b/api/internal/repository/proxy_host_queries.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"nginx-proxy-guard/internal/database/dialect"
 	"strings"
 
 	"github.com/lib/pq"
@@ -201,6 +202,10 @@ func (r *ProxyHostRepository) CheckDomainExists(ctx context.Context, domains []s
 		return nil, nil
 	}
 
+	if dialect.ActiveIsMySQLFamily() {
+		return r.checkDomainExistsMariaDB(ctx, domains, excludeID)
+	}
+
 	// Single query: unnest stored domain_names, intersect with input set in one pass.
 	// Was: N round-trips (one SELECT per domain). Now: one SELECT.
 	query := `
@@ -229,6 +234,63 @@ func (r *ProxyHostRepository) CheckDomainExists(ctx context.Context, domains []s
 			return nil, fmt.Errorf("failed to scan existing domain: %w", err)
 		}
 		existingDomains = append(existingDomains, d)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("failed to iterate domain check rows: %w", err)
+	}
+
+	return existingDomains, nil
+}
+
+// checkDomainExistsMariaDB는 MySQL 계열에 없는 UNNEST 없이 같은 질문에 답한다.
+//
+// 술어가 여전히 후보 도메인 중 하나 이상을 가진 호스트로 범위를 좁히므로 스캔은
+// 선택적으로 유지된다. UNNEST가 SQL에서 하던 교집합 연산만 그 몇 행에 대해 Go
+// 쪽에서 수행한다.
+func (r *ProxyHostRepository) checkDomainExistsMariaDB(ctx context.Context, domains []string, excludeID string) ([]string, error) {
+	predicates := make([]string, len(domains))
+	args := make([]interface{}, 0, len(domains)+1)
+	for i, d := range domains {
+		predicates[i] = arrayContains("domain_names", i+1)
+		args = append(args, d)
+	}
+
+	query := fmt.Sprintf(`
+		SELECT domain_names
+		FROM proxy_hosts
+		WHERE (%s)
+		  AND COALESCE(proxy_type, 'http') = 'http'
+	`, strings.Join(predicates, " OR "))
+
+	if excludeID != "" {
+		query += fmt.Sprintf(" AND id != $%d", len(domains)+1)
+		args = append(args, excludeID)
+	}
+
+	rows, err := r.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to check domain existence: %w", err)
+	}
+	defer rows.Close()
+
+	wanted := make(map[string]bool, len(domains))
+	for _, d := range domains {
+		wanted[d] = true
+	}
+
+	seen := map[string]bool{}
+	var existingDomains []string
+	for rows.Next() {
+		var stored pq.StringArray
+		if err := rows.Scan(&stored); err != nil {
+			return nil, fmt.Errorf("failed to scan existing domain: %w", err)
+		}
+		for _, d := range stored {
+			if wanted[d] && !seen[d] {
+				seen[d] = true
+				existingDomains = append(existingDomains, d)
+			}
+		}
 	}
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("failed to iterate domain check rows: %w", err)

--- a/api/internal/repository/rate_limit.go
+++ b/api/internal/repository/rate_limit.go
@@ -3,10 +3,10 @@ package repository
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"log"
 	"time"
 
-	"github.com/lib/pq"
 	"nginx-proxy-guard/internal/model"
 	"nginx-proxy-guard/pkg/cache"
 )
@@ -606,11 +606,13 @@ func (r *RateLimitRepository) GetBannedIPsByIDs(ctx context.Context, ids []strin
 	if len(ids) == 0 {
 		return nil, nil
 	}
-	query := `
+	// `= ANY($1)` 대신 IN 목록을 쓴다. 두 엔진 모두 받아주므로 이 질의에는
+	// dialect 분기가 필요 없다.
+	query := fmt.Sprintf(`
 		SELECT id, proxy_host_id, ip_address, reason, fail_count, banned_at, expires_at, is_permanent, created_at
-		FROM banned_ips WHERE id = ANY($1::uuid[])
-	`
-	rows, err := r.db.QueryContext(ctx, query, pq.Array(ids))
+		FROM banned_ips WHERE id IN (%s)
+	`, placeholders(1, len(ids)))
+	rows, err := r.db.QueryContext(ctx, query, stringArgs(ids)...)
 	if err != nil {
 		return nil, err
 	}
@@ -645,7 +647,9 @@ func (r *RateLimitRepository) UnbanIPsByIDs(ctx context.Context, ids []string) (
 	if len(ids) == 0 {
 		return 0, nil
 	}
-	result, err := r.db.ExecContext(ctx, "DELETE FROM banned_ips WHERE id = ANY($1::uuid[])", pq.Array(ids))
+	result, err := r.db.ExecContext(ctx,
+		fmt.Sprintf("DELETE FROM banned_ips WHERE id IN (%s)", placeholders(1, len(ids))),
+		stringArgs(ids)...)
 	if err != nil {
 		return 0, err
 	}
@@ -711,12 +715,12 @@ func (r *RateLimitRepository) GetActiveBannedIPSet(ctx context.Context, ips []st
 		return result, nil
 	}
 
-	query := `
+	query := fmt.Sprintf(`
 		SELECT DISTINCT ip_address FROM banned_ips
-		WHERE ip_address = ANY($1) AND (is_permanent = TRUE OR expires_at > NOW())
-	`
+		WHERE ip_address IN (%s) AND (is_permanent = TRUE OR expires_at > NOW())
+	`, placeholders(1, len(ips)))
 
-	rows, err := r.db.QueryContext(ctx, query, pq.Array(ips))
+	rows, err := r.db.QueryContext(ctx, query, stringArgs(ips)...)
 	if err != nil {
 		return nil, err
 	}

--- a/api/internal/repository/role.go
+++ b/api/internal/repository/role.go
@@ -4,8 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-
-	"github.com/lib/pq"
+	"nginx-proxy-guard/internal/database/dialect"
 
 	"nginx-proxy-guard/internal/database"
 	"nginx-proxy-guard/internal/model"
@@ -28,9 +27,7 @@ func NewRoleRepository(db *database.DB) *RoleRepository {
 // denying everything and locking the operator out of their own server. (#222)
 func (r *RoleRepository) TablesExist(ctx context.Context) bool {
 	var present bool
-	err := r.db.QueryRowContext(ctx, `
-		SELECT to_regclass('public.roles') IS NOT NULL
-		   AND to_regclass('public.role_permissions') IS NOT NULL`).Scan(&present)
+	err := r.db.QueryRowContext(ctx, tablesExistSQL("roles", "role_permissions")).Scan(&present)
 	return err == nil && present
 }
 
@@ -272,7 +269,7 @@ func insertRolePermissions(ctx context.Context, tx *sql.Tx, roleID string, perms
 // handler can map to 409 — the codebase's existing pattern (see
 // isDDNSUniqueViolation) rather than string-matching the message.
 func wrapRoleUniqueViolation(err error) error {
-	if pqErr, ok := err.(*pq.Error); ok && pqErr.Code == "23505" {
+	if dialect.IsUniqueViolation(err) {
 		return fmt.Errorf("role name already exists")
 	}
 	return fmt.Errorf("failed to write role: %w", err)

--- a/api/internal/repository/sqlcompat.go
+++ b/api/internal/repository/sqlcompat.go
@@ -1,0 +1,126 @@
+package repository
+
+import (
+	"fmt"
+	"strings"
+
+	"nginx-proxy-guard/internal/database/dialect"
+)
+
+// 두 백엔드에 대해 한 번에 쓸 수 없는 소수의 문장을 위한 질의 조각들.
+//
+// 리포지토리 SQL은 거의 전부 PostgreSQL 방언이고, 번역 드라이버를 통해 그대로
+// MySQL 계열에 도달한다. 번역되지 않는 것은 배열이나 JSON 컬럼 *안쪽*으로
+// 들어가는 경우다. 두 엔진의 저장 방식이 다르기 때문이다. PostgreSQL에는 진짜
+// text[]와 jsonb 타입과 그에 맞는 연산자가 있지만, MySQL 계열 스키마는 바로 그
+// PostgreSQL 배열 리터럴을 TEXT 컬럼에 담아 lib/pq의 배열 코덱이 양쪽에서 그대로
+// 동작하게 한다. 그 덕에 Go 쪽 왕복은 완전히 같아지고 SQL 쪽 조회만 백엔드별로
+// 갈린다. 이 파일이 치르는 대가가 그것이다.
+
+// placeholders는 IN 목록용으로 `$start, $start+1, ...`을 만든다.
+//
+// 값이 Go 슬라이스에서 오는 곳이라면 `= ANY($1)`보다 이쪽이 낫다. IN 목록은 두
+// 엔진 모두 받아주는 평범한 SQL이라 dialect 분기가 아예 필요 없다.
+func placeholders(start, n int) string {
+	parts := make([]string, n)
+	for i := range parts {
+		parts[i] = fmt.Sprintf("$%d", start+i)
+	}
+	return strings.Join(parts, ", ")
+}
+
+// stringArgs는 placeholders로 만든 질의에 넘기려고 []string을 넓힌다.
+func stringArgs(values []string) []interface{} {
+	args := make([]interface{}, len(values))
+	for i, v := range values {
+		args[i] = v
+	}
+	return args
+}
+
+// arrayContains는 배열 컬럼이 $n에 바인딩된 값을 담고 있는지 검사하는 술어를
+// 만든다. PostgreSQL의 `$n = ANY(col)` / `col @> ARRAY[$n]`에 해당한다.
+//
+// MySQL 계열에서 그 컬럼은 텍스트로 담긴 PostgreSQL 배열 리터럴이고, lib/pq는
+// 각 원소를 항상 큰따옴표로 감싼다(`{"a.example","b.example"}`). 따옴표까지
+// 포함해 `"값"`으로 매칭하면 원소 전체만 걸리므로, 다른 원소의 부분 문자열인
+// 값에 속지 않는다.
+func arrayContains(column string, n int) string {
+	if dialect.ActiveIsMySQLFamily() {
+		return fmt.Sprintf(`%s LIKE CONCAT('%%"', $%d, '"%%')`, column, n)
+	}
+	return fmt.Sprintf(`$%d = ANY(%s)`, n, column)
+}
+
+// arrayNotEmpty는 PostgreSQL의 `array_length(col, 1) > 0`을 만든다.
+func arrayNotEmpty(column string) string {
+	if dialect.ActiveIsMySQLFamily() {
+		return fmt.Sprintf(`%s IS NOT NULL AND %s <> '{}'`, column, column)
+	}
+	return fmt.Sprintf(`array_length(%s, 1) > 0`, column)
+}
+
+// arrayLength는 배열 컬럼의 원소 개수를 만든다.
+//
+// MySQL 계열 형태는 리터럴 안의 구분자를 센다. 이 함수가 쓰이는 값들(CIDR
+// 범위와 공급자 슬러그로, 어느 쪽도 쉼표를 포함할 수 없다)에는 정확하며, 쉼표를
+// 품은 원소가 있을 때만 과다 집계된다.
+func arrayLength(column string) string {
+	if dialect.ActiveIsMySQLFamily() {
+		return fmt.Sprintf(
+			`(CASE WHEN %s IS NULL OR %s = '{}' THEN 0
+			       ELSE CHAR_LENGTH(%s) - CHAR_LENGTH(REPLACE(%s, ',', '')) + 1 END)`,
+			column, column, column, column)
+	}
+	return fmt.Sprintf(`array_length(%s, 1)`, column)
+}
+
+// jsonSetString은 JSON 컬럼 안의 문자열 필드 하나를 갱신하는 식을 만든다.
+func jsonSetString(column, field string, n int) string {
+	if dialect.ActiveIsMySQLFamily() {
+		return fmt.Sprintf(`JSON_SET(%s, '$.%s', $%d)`, column, field, n)
+	}
+	return fmt.Sprintf(`jsonb_set(%s, '{%s}', to_jsonb($%d::text))`, column, field, n)
+}
+
+// latestJSONField는 "그룹에서 가장 최근 행의 JSON 필드 값"을 만든다. 알림
+// 다이제스트가 연속된 발생 건에 제목을 붙일 때 쓴다.
+//
+// PostgreSQL은 정렬된 array_agg의 첫 원소를 가져온다. MySQL 계열에는 배열
+// 타입이 없으므로 GROUP_CONCAT을 정렬해 첫 구간을 취하는 방식으로 같은 일을
+// 한다. 구분자는 유닛 세퍼레이터 제어 문자로, 알림 제목에 나타날 수 없다.
+func latestJSONField(column, field, orderBy string) string {
+	if dialect.ActiveIsMySQLFamily() {
+		return fmt.Sprintf(
+			`COALESCE(SUBSTRING_INDEX(GROUP_CONCAT(JSON_UNQUOTE(JSON_EXTRACT(%s, '$.%s')) ORDER BY %s SEPARATOR 0x1f), 0x1f, 1), '')`,
+			column, field, orderBy)
+	}
+	return fmt.Sprintf(`COALESCE((array_agg(%s->'fields'->>'%s' ORDER BY %s))[1], '')`, column, field, orderBy)
+}
+
+// tablesExistSQL은 지정한 테이블이 모두 존재하는지를 불리언 하나로 돌려주는
+// 질의를 만든다.
+//
+// SSO, RBAC, 알림 등 몇몇 기능은 그 기능이 필요로 하는 스키마보다 나중에
+// 출시됐고, 업그레이드 마이그레이션은 경고 후 계속 진행한다. 따라서 업그레이드가
+// 실패한 설치도 해당 기능만 꺼진 채로 기동할 수 있어야 한다. PostgreSQL은
+// to_regclass()로 답하지만 MySQL 계열에는 대응물이 없어 information_schema 행을
+// 세는 방식을 쓴다.
+func tablesExistSQL(tables ...string) string {
+	if dialect.ActiveIsMySQLFamily() {
+		quoted := make([]string, len(tables))
+		for i, t := range tables {
+			quoted[i] = "'" + t + "'"
+		}
+		return fmt.Sprintf(
+			`SELECT (SELECT COUNT(*) FROM information_schema.tables
+			         WHERE table_schema = DATABASE() AND table_name IN (%s)) = %d`,
+			strings.Join(quoted, ", "), len(tables))
+	}
+
+	checks := make([]string, len(tables))
+	for i, t := range tables {
+		checks[i] = fmt.Sprintf("to_regclass('public.%s') IS NOT NULL", t)
+	}
+	return "SELECT " + strings.Join(checks, "\n   AND ")
+}

--- a/api/internal/repository/sso.go
+++ b/api/internal/repository/sso.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"nginx-proxy-guard/internal/database/dialect"
 	"time"
 
 	"github.com/lib/pq"
@@ -148,7 +149,7 @@ func (r *SSORepository) Create(ctx context.Context, req *model.CreateSSOProvider
 		req.CallbackBaseURL, enabled, req.AllowJIT, pq.Array(req.AllowedEmailDomains), pq.Array(req.AllowedEmails),
 		req.GroupClaim, req.RequiredGroup, req.DefaultRoleID, mappings).Scan(&id)
 	if err != nil {
-		if pqErr, ok := err.(*pq.Error); ok && pqErr.Code == "23505" {
+		if dialect.IsUniqueViolation(err) {
 			return "", fmt.Errorf("a provider with this slug already exists")
 		}
 		return "", fmt.Errorf("failed to create sso provider: %w", err)
@@ -180,7 +181,7 @@ func (r *SSORepository) Update(ctx context.Context, id string, req *model.Update
 		req.CallbackBaseURL, enabled, req.AllowJIT, pq.Array(req.AllowedEmailDomains), pq.Array(req.AllowedEmails),
 		req.GroupClaim, req.RequiredGroup, req.DefaultRoleID, mappings)
 	if err != nil {
-		if pqErr, ok := err.(*pq.Error); ok && pqErr.Code == "23505" {
+		if dialect.IsUniqueViolation(err) {
 			return fmt.Errorf("a provider with this slug already exists")
 		}
 		return fmt.Errorf("failed to update sso provider: %w", err)
@@ -245,7 +246,7 @@ func (r *SSORepository) LinkIdentity(ctx context.Context, providerID, subject, u
 		DO UPDATE SET email = EXCLUDED.email, last_login_at = now()`,
 		providerID, subject, userID, email)
 	if err != nil {
-		if pqErr, ok := err.(*pq.Error); ok && pqErr.Code == "23505" {
+		if dialect.IsUniqueViolation(err) {
 			return fmt.Errorf("this account is already linked to a different identity on that provider")
 		}
 		return fmt.Errorf("failed to link identity: %w", err)
@@ -258,8 +259,8 @@ func (r *SSORepository) LinkIdentity(ctx context.Context, providerID, subject, u
 func (r *SSORepository) SaveLoginState(ctx context.Context, state, providerID, nonce, verifier string, ttl time.Duration) error {
 	_, err := r.db.ExecContext(ctx, `
 		INSERT INTO sso_login_states (state, provider_id, nonce, code_verifier, expires_at)
-		VALUES ($1,$2,$3,$4, now() + $5::interval)`,
-		state, providerID, nonce, verifier, fmt.Sprintf("%d seconds", int(ttl.Seconds())))
+		VALUES ($1,$2,$3,$4, now() + ($5 || ' seconds')::interval)`,
+		state, providerID, nonce, verifier, int(ttl.Seconds()))
 	if err != nil {
 		return fmt.Errorf("failed to save login state: %w", err)
 	}
@@ -298,8 +299,6 @@ func (r *SSORepository) DeleteExpiredLoginStates(ctx context.Context) (int64, er
 func (r *SSORepository) TablesExist(ctx context.Context) bool {
 	var ok bool
 	err := r.db.QueryRowContext(ctx,
-		`SELECT to_regclass('public.sso_providers') IS NOT NULL
-		    AND to_regclass('public.user_identities') IS NOT NULL
-		    AND to_regclass('public.sso_login_states') IS NOT NULL`).Scan(&ok)
+		tablesExistSQL("sso_providers", "user_identities", "sso_login_states")).Scan(&ok)
 	return err == nil && ok
 }

--- a/api/internal/repository/user.go
+++ b/api/internal/repository/user.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"nginx-proxy-guard/internal/database/dialect"
 
 	"github.com/lib/pq"
 
@@ -80,7 +81,7 @@ func (r *UserRepository) Create(ctx context.Context, username, passwordHash, rol
 		RETURNING id`,
 		username+"@localhost", username, passwordHash, legacyRole, roleID).Scan(&id)
 	if err != nil {
-		if pqErr, ok := err.(*pq.Error); ok && pqErr.Code == "23505" {
+		if dialect.IsUniqueViolation(err) {
 			return "", fmt.Errorf("username already exists")
 		}
 		return "", fmt.Errorf("failed to create user: %w", err)
@@ -109,7 +110,7 @@ func (r *UserRepository) CreateFederated(ctx context.Context, username, email, p
 		RETURNING id`,
 		email, username, passwordHash, legacyRole, roleID).Scan(&id)
 	if err != nil {
-		if pqErr, ok := err.(*pq.Error); ok && pqErr.Code == "23505" {
+		if dialect.IsUniqueViolation(err) {
 			return "", fmt.Errorf("an account with this username or email already exists")
 		}
 		return "", fmt.Errorf("failed to create federated user: %w", err)
@@ -234,12 +235,12 @@ func (r *UserRepository) GetDetail(ctx context.Context, userID string) (*model.U
 		d.TOTPVerifiedAt = &totpVerified.Time
 	}
 
-	// Identity providers this account can sign in through (#227). Guarded with
-	// to_regclass because SSO shipped later and migrations warn-and-continue: an
-	// install whose upgrade failed must still be able to open a user's detail.
+	// 이 계정이 로그인할 수 있는 아이덴티티 공급자들(#227). 테이블 존재 확인으로
+	// 감싼 이유는 SSO가 나중에 출시됐고 마이그레이션이 경고 후 계속 진행하기
+	// 때문이다. 업그레이드가 실패한 설치에서도 사용자 상세는 열려야 한다.
 	var ssoPresent bool
 	if err := r.db.QueryRowContext(ctx,
-		`SELECT to_regclass('public.user_identities') IS NOT NULL`).Scan(&ssoPresent); err == nil && ssoPresent {
+		tablesExistSQL("user_identities")).Scan(&ssoPresent); err == nil && ssoPresent {
 		idRows, err := r.db.QueryContext(ctx, `
 			SELECT p.name, p.slug, COALESCE(i.email, ''), i.last_login_at, i.created_at
 			FROM user_identities i

--- a/api/internal/scheduler/partition.go
+++ b/api/internal/scheduler/partition.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"nginx-proxy-guard/internal/database/dialect"
 	"nginx-proxy-guard/internal/repository"
 )
 
@@ -94,6 +95,9 @@ func (s *PartitionScheduler) isLogsHypertable(ctx context.Context) bool {
 // Returns false when the timescaledb_information view is unavailable so
 // installs without the extension fall through to the legacy code paths.
 func (s *PartitionScheduler) isHypertable(ctx context.Context, table string) bool {
+	if dialect.ActiveIsMySQLFamily() {
+		return false
+	}
 	var isHT bool
 	err := s.db.QueryRowContext(ctx, `
 		SELECT EXISTS(
@@ -141,6 +145,11 @@ func (s *PartitionScheduler) cleanupDashboardStats() {
 func (s *PartitionScheduler) analyzeOldPartitions() {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
 	defer cancel()
+
+	if dialect.ActiveIsMySQLFamily() {
+		s.analyzeMariaDB(ctx)
+		return
+	}
 
 	// TimescaleDB auto-analyzes its chunks; the native `logs_p%` partitions
 	// targeted below do not exist on hypertable installs.
@@ -191,6 +200,11 @@ func (s *PartitionScheduler) analyzeOldPartitions() {
 func (s *PartitionScheduler) createPartitions() {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
+
+	if dialect.ActiveIsMySQLFamily() {
+		s.createPartitionsMariaDB(ctx)
+		return
+	}
 
 	// Skip native partition operations when logs_partitioned has been migrated
 	// to a TimescaleDB hypertable. CREATE TABLE ... PARTITION OF on a hypertable
@@ -307,6 +321,11 @@ func (s *PartitionScheduler) createPartitions() {
 }
 
 func (s *PartitionScheduler) logPartitionStats(ctx context.Context) {
+	// pg_class/pg_inherits에는 여기서 보고할 만한 MySQL 계열 대응물이 없다.
+	// 파티션 관리가 이미 무엇을 추가하고 삭제했는지 로그로 남긴다.
+	if dialect.ActiveIsMySQLFamily() {
+		return
+	}
 	// Count log partitions
 	var logPartitionCount int
 	err := s.db.QueryRowContext(ctx, `
@@ -385,6 +404,16 @@ func (s *PartitionScheduler) enforceRetention() {
 		} else if deleted > 0 {
 			log.Printf("[PartitionScheduler] Cleaned up %d old system logs (retention: %d days)", deleted, settings.SystemLogRetentionDays)
 		}
+	}
+
+	if dialect.ActiveIsMySQLFamily() {
+		// 파티션 단위 보존 정책. 파티션 삭제는 메타데이터 작업인 반면 아래의
+		// 행 단위 DELETE는 모든 행을 훑고 로그로 남겨야 한다. 보존 기간 바깥에
+		// 완전히 놓인 파티션만 삭제하므로, 경계에 걸친 달은 위에서 행 단위로
+		// 정리된다.
+		s.dropOldPartitionsMariaDB(ctx, "logs_partitioned", settings.AccessLogRetentionDays)
+		s.dropOldPartitionsMariaDB(ctx, "dashboard_stats_hourly_partitioned", settings.StatsRetentionDays)
+		return
 	}
 
 	// 3. Drop old log partitions (logs_partitioned)

--- a/api/internal/scheduler/partition_mariadb.go
+++ b/api/internal/scheduler/partition_mariadb.go
@@ -1,0 +1,208 @@
+package scheduler
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log"
+	"time"
+)
+
+// MySQL 계열 파티션 관리.
+//
+// PostgreSQL 경로는 두 가지 형태를 다뤄야 한다. 청크를 알아서 관리해 주는
+// TimescaleDB 하이퍼테이블과, CREATE TABLE ... PARTITION OF로 만드는 네이티브
+// 선언적 파티션이다. MySQL 계열에는 둘 다 없다. 파티션은 테이블 정의의 일부이며
+// ALTER TABLE로 추가하고 제거한다.
+//
+// 여기 설계 전체를 좌우하는 사정이 하나 있다. 스키마 끝에는 어떤 범위에도
+// 속하지 않는 행이 거부되지 않도록 `p_max VALUES LESS THAN (MAXVALUE)`라는
+// 포괄 파티션이 있다. RANGE 파티션 목록은 순서를 지켜야 하므로 p_max 뒤에는
+// 아무것도 덧붙일 수 없다. 다음 달 파티션은 REORGANIZE PARTITION으로 그 안에서
+// 떼어내야 한다.
+
+// partitionedTables는 파티션 테이블과 그 파티션 키를 짝지어 둔 것이다.
+var partitionedTables = []struct {
+	table  string
+	column string
+}{
+	{"logs_partitioned", "created_at"},
+	{"dashboard_stats_hourly_partitioned", "hour_bucket"},
+}
+
+// maxPartitionName은 모든 파티션 테이블 끝에 있는 포괄 파티션이며, 새 달을
+// 떼어내는 대상이기도 하다.
+const maxPartitionName = "p_max"
+
+// createPartitionsMariaDB는 각 파티션 테이블에 이번 달과 앞으로 몇 달치 파티션이
+// 있는지 확인하고 없으면 만든다.
+func (s *PartitionScheduler) createPartitionsMariaDB(ctx context.Context) {
+	const monthsAhead = 3
+
+	for _, pt := range partitionedTables {
+		existing, err := s.existingPartitions(ctx, pt.table)
+		if err != nil {
+			log.Printf("[PartitionScheduler] Failed to read partitions of %s: %v", pt.table, err)
+			continue
+		}
+		if len(existing) == 0 {
+			// 파티션 테이블이 아니거나 아예 없다. 관리할 것이 없다.
+			continue
+		}
+
+		month := time.Now().UTC().Truncate(time.Hour)
+		month = time.Date(month.Year(), month.Month(), 1, 0, 0, 0, 0, time.UTC)
+
+		for i := 0; i <= monthsAhead; i++ {
+			target := month.AddDate(0, i, 0)
+			name := partitionName(target)
+			if existing[name] {
+				continue
+			}
+			if err := s.addMonthlyPartition(ctx, pt.table, name, target.AddDate(0, 1, 0)); err != nil {
+				log.Printf("[PartitionScheduler] Failed to add partition %s to %s: %v", name, pt.table, err)
+				continue
+			}
+			existing[name] = true
+			log.Printf("[PartitionScheduler] Added partition %s to %s", name, pt.table)
+		}
+	}
+}
+
+// addMonthlyPartition은 포괄 파티션에서 한 달치를 떼어낸다.
+//
+// REORGANIZE는 지금 p_max에 들어 있는 행만 다시 쓴다. 정상적인 설치라면 그런
+// 행은 없다. 파티션은 데이터가 들어오기 몇 달 전에 미리 만들어지기 때문이다.
+func (s *PartitionScheduler) addMonthlyPartition(ctx context.Context, table, name string, upperBound time.Time) error {
+	stmt := fmt.Sprintf(
+		`ALTER TABLE %s REORGANIZE PARTITION %s INTO (
+			PARTITION %s VALUES LESS THAN ('%s'),
+			PARTITION %s VALUES LESS THAN (MAXVALUE)
+		)`,
+		table, maxPartitionName, name, upperBound.Format("2006-01-02 15:04:05"), maxPartitionName)
+
+	_, err := s.db.ExecContext(ctx, stmt)
+	return err
+}
+
+// dropOldPartitionsMariaDB는 보존 기간보다 오래된 파티션을 통째로 버린다.
+//
+// 파티션 삭제는 메타데이터 작업이다. PostgreSQL 경로가 대신 쓰는 행 단위
+// DELETE는 모든 행을 훑고 로그로 남겨야 한다. 보존 기간 바깥에 완전히 놓인
+// 파티션만 삭제하므로 아직 기간 안에 있는 행은 절대 잃지 않는다. 경계에 걸친
+// 파티션은 행 단위 정리에 맡긴다.
+func (s *PartitionScheduler) dropOldPartitionsMariaDB(ctx context.Context, table string, retentionDays int) {
+	if retentionDays < 1 {
+		return
+	}
+
+	cutoff := time.Now().UTC().AddDate(0, 0, -retentionDays)
+	// 파티션은 그 상한 — 즉 그 파티션이 담지 *않는* 첫 시점 — 이 컷오프
+	// 이하일 때만 삭제할 수 있다.
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT partition_name, partition_description
+		FROM information_schema.partitions
+		WHERE table_schema = DATABASE() AND table_name = ?
+		  AND partition_name IS NOT NULL AND partition_name <> ?
+		ORDER BY partition_ordinal_position`, table, maxPartitionName)
+	if err != nil {
+		log.Printf("[PartitionScheduler] Failed to list partitions of %s: %v", table, err)
+		return
+	}
+	defer rows.Close()
+
+	type candidate struct {
+		name  string
+		upper time.Time
+	}
+	var drops []candidate
+
+	for rows.Next() {
+		var name string
+		var description sql.NullString
+		if err := rows.Scan(&name, &description); err != nil {
+			log.Printf("[PartitionScheduler] Failed to scan partition of %s: %v", table, err)
+			return
+		}
+		upper, ok := parsePartitionBound(description.String)
+		if !ok || upper.After(cutoff) {
+			continue
+		}
+		drops = append(drops, candidate{name: name, upper: upper})
+	}
+	if err := rows.Err(); err != nil {
+		log.Printf("[PartitionScheduler] Failed to iterate partitions of %s: %v", table, err)
+		return
+	}
+
+	for _, d := range drops {
+		if _, err := s.db.ExecContext(ctx,
+			fmt.Sprintf("ALTER TABLE %s DROP PARTITION %s", table, d.name)); err != nil {
+			log.Printf("[PartitionScheduler] Failed to drop partition %s of %s: %v", d.name, table, err)
+			continue
+		}
+		log.Printf("[PartitionScheduler] Dropped partition %s of %s (holds data before %s, retention %d days)",
+			d.name, table, d.upper.Format("2006-01-02"), retentionDays)
+	}
+}
+
+// analyzeMariaDB는 파티션된 로그 테이블의 옵티마이저 통계를 갱신한다.
+// PostgreSQL 경로의 ANALYZE 순회에 해당한다.
+func (s *PartitionScheduler) analyzeMariaDB(ctx context.Context) {
+	for _, pt := range partitionedTables {
+		if _, err := s.db.ExecContext(ctx, fmt.Sprintf("ANALYZE TABLE %s", pt.table)); err != nil {
+			log.Printf("[PartitionScheduler] ANALYZE TABLE %s failed: %v", pt.table, err)
+		}
+	}
+}
+
+// existingPartitions는 테이블의 파티션 이름들을 조회하기 좋은 형태로 돌려준다.
+func (s *PartitionScheduler) existingPartitions(ctx context.Context, table string) (map[string]bool, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT partition_name FROM information_schema.partitions
+		WHERE table_schema = DATABASE() AND table_name = ? AND partition_name IS NOT NULL`, table)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	out := map[string]bool{}
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return nil, err
+		}
+		out[name] = true
+	}
+	return out, rows.Err()
+}
+
+// partitionName은 001_init.sql이 정한 명명 규칙이다: p2026_03.
+func partitionName(month time.Time) string {
+	return "p" + month.Format("2006_01")
+}
+
+// parsePartitionBound는 partition_description 컬럼에서 상한을 읽는다. RANGE
+// COLUMNS 파티션에서는 '2026-01-01 00:00:00' 같은 형태다.
+func parsePartitionBound(description string) (time.Time, bool) {
+	trimmed := description
+	for _, cut := range []string{"'", `"`} {
+		trimmed = trimQuotes(trimmed, cut)
+	}
+	if trimmed == "" || trimmed == "MAXVALUE" {
+		return time.Time{}, false
+	}
+	for _, layout := range []string{"2006-01-02 15:04:05", "2006-01-02"} {
+		if t, err := time.Parse(layout, trimmed); err == nil {
+			return t.UTC(), true
+		}
+	}
+	return time.Time{}, false
+}
+
+func trimQuotes(s, quote string) string {
+	if len(s) >= 2*len(quote) && s[:len(quote)] == quote && s[len(s)-len(quote):] == quote {
+		return s[len(quote) : len(s)-len(quote)]
+	}
+	return s
+}

--- a/api/tests/integration/api_suite_test.go
+++ b/api/tests/integration/api_suite_test.go
@@ -702,12 +702,12 @@ func TestIntegrationSuite(t *testing.T) {
 
 		t.Run("Set_Geo_Restriction", func(t *testing.T) {
 			geoConfig := map[string]interface{}{
-				"enabled":            true,
-				"mode":               "whitelist",
-				"countries":          []string{"KR", "US", "JP"},
-				"challenge_mode":     false,
-				"allow_search_bots":  true,
-				"allow_private_ips":  true,
+				"enabled":           true,
+				"mode":              "whitelist",
+				"countries":         []string{"KR", "US", "JP"},
+				"challenge_mode":    false,
+				"allow_search_bots": true,
+				"allow_private_ips": true,
 			}
 			code, body := client.Post(t, "/api/v1/proxy-hosts/"+testHostID+"/geo", geoConfig)
 			if code != http.StatusOK && code != http.StatusCreated {
@@ -720,12 +720,12 @@ func TestIntegrationSuite(t *testing.T) {
 
 		t.Run("Update_Geo_Restriction", func(t *testing.T) {
 			geoConfig := map[string]interface{}{
-				"enabled":            true,
-				"mode":               "blacklist",
-				"countries":          []string{"CN", "RU"},
-				"challenge_mode":     true,
-				"allow_search_bots":  true,
-				"allow_private_ips":  true,
+				"enabled":           true,
+				"mode":              "blacklist",
+				"countries":         []string{"CN", "RU"},
+				"challenge_mode":    true,
+				"allow_search_bots": true,
+				"allow_private_ips": true,
 			}
 			code, body := client.Put(t, "/api/v1/proxy-hosts/"+testHostID+"/geo", geoConfig)
 			if code != http.StatusOK {
@@ -767,10 +767,10 @@ func TestIntegrationSuite(t *testing.T) {
 
 		t.Run("Set_Rate_Limit", func(t *testing.T) {
 			rateLimitConfig := map[string]interface{}{
-				"enabled":           true,
+				"enabled":             true,
 				"requests_per_second": 100,
-				"burst_size":        200,
-				"per_ip":            true,
+				"burst_size":          200,
+				"per_ip":              true,
 			}
 			code, body := client.Put(t, "/api/v1/proxy-hosts/"+testHostID+"/rate-limit", rateLimitConfig)
 			if code != http.StatusOK && code != http.StatusCreated {

--- a/api/tests/integration/mysqlfamily_test.go
+++ b/api/tests/integration/mysqlfamily_test.go
@@ -1,0 +1,555 @@
+package integration
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/lib/pq"
+
+	"nginx-proxy-guard/internal/database"
+	"nginx-proxy-guard/internal/database/dialect"
+	"nginx-proxy-guard/internal/model"
+	"nginx-proxy-guard/internal/repository"
+)
+
+// 이 테스트들은 실제 MySQL 계열 서버가 필요하다. NPG_MYSQL_TEST_DSN을 빈
+// 데이터베이스로 지정하면 MariaDB든 MySQL이든 떠 있는 쪽에 대해 실행된다.
+// 설정하지 않으면 건너뛰므로 기본 스위트는 외부 의존 없이 돈다. 같은 테스트가
+// 양쪽에서 모두 통과해야 하며, 두 번 돌리는 이유가 바로 그것이다.
+//
+//	docker run -d --name npg-mariadb-test -e MARIADB_ROOT_PASSWORD=root \
+//	    -e MARIADB_DATABASE=npg -p 33061:3306 mariadb:11.4
+//	NPG_MYSQL_TEST_DSN='mariadb://root:root@127.0.0.1:33061/npg' \
+//	    go test ./tests/integration/ -run MySQLFamily -v
+//
+//	docker run -d --name npg-mysql-test -e MYSQL_ROOT_PASSWORD=root \
+//	    -e MYSQL_DATABASE=npg -p 33071:3306 mysql:8.4
+//	NPG_MYSQL_TEST_DSN='mysql://root:root@127.0.0.1:33071/npg' \
+//	    go test ./tests/integration/ -run MySQLFamily -v
+func mysqlFamilyDSN(t *testing.T) string {
+	t.Helper()
+	for _, name := range []string{"NPG_MYSQL_TEST_DSN", "NPG_MARIADB_TEST_DSN"} {
+		if dsn := os.Getenv(name); dsn != "" {
+			return dsn
+		}
+	}
+	t.Skip("NPG_MYSQL_TEST_DSN is not set; skipping the MySQL-family integration tests")
+	return ""
+}
+
+func openMySQLFamily(t *testing.T) *database.DB {
+	t.Helper()
+	db, err := database.New(mysqlFamilyDSN(t))
+	if err != nil {
+		t.Fatalf("failed to connect: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	// URL 스킴은 드라이버만 골랐다. dialect는 서버 자신의 버전 문자열에서
+	// 나와야 한다. 그래야 MariaDB를 가리키는 mysql:// URL도(반대도) 올바르게
+	// 동작한다.
+	if got := db.Kind(); !got.IsMySQLFamily() {
+		t.Fatalf("dialect detected as %q, want mariadb or mysql", got)
+	}
+	t.Logf("server detected as %s", db.Kind())
+	return db
+}
+
+func TestMySQLFamilyMigrationsApplyCleanly(t *testing.T) {
+	db := openMySQLFamily(t)
+
+	if err := db.RunMigrations(); err != nil {
+		t.Fatalf("RunMigrations: %v", err)
+	}
+	if count, last := db.MigrationHealth(); count > 0 {
+		t.Fatalf("%d migration statement(s) failed; last: %s", count, last)
+	}
+
+	// 재실행은 no-op이어야 한다. 업그레이드 전체가 부팅할 때마다 재실행되므로,
+	// 멱등하지 않은 문장이 하나라도 있으면 재시작마다 깨진다.
+	if err := db.RunMigrations(); err != nil {
+		t.Fatalf("RunMigrations (second run): %v", err)
+	}
+	if count, last := db.MigrationHealth(); count > 0 {
+		t.Fatalf("re-run: %d migration statement(s) failed; last: %s", count, last)
+	}
+}
+
+func TestMySQLFamilySchemaShape(t *testing.T) {
+	db := openMySQLFamily(t)
+	if err := db.RunMigrations(); err != nil {
+		t.Fatalf("RunMigrations: %v", err)
+	}
+
+	t.Run("tables the application depends on exist", func(t *testing.T) {
+		for _, table := range []string{
+			"users", "roles", "role_permissions", "proxy_hosts", "certificates",
+			"logs_partitioned", "logs_unified", "dashboard_stats_hourly",
+			"exploit_block_rules", "notification_channels", "notification_outbox",
+			"sso_providers", "user_identities", "ddns_records", "global_settings",
+			"system_settings", "banned_ips", "access_lists", "filter_subscriptions",
+		} {
+			var n int
+			err := db.QueryRow(`
+				SELECT COUNT(*) FROM information_schema.tables
+				WHERE table_schema = DATABASE() AND table_name = ?`, table).Scan(&n)
+			if err != nil {
+				t.Fatalf("%s: %v", table, err)
+			}
+			if n == 0 {
+				t.Errorf("table %q is missing", table)
+			}
+		}
+	})
+
+	t.Run("logs are partitioned by month", func(t *testing.T) {
+		var partitions int
+		err := db.QueryRow(`
+			SELECT COUNT(*) FROM information_schema.partitions
+			WHERE table_schema = DATABASE() AND table_name = 'logs_partitioned'
+			  AND partition_name IS NOT NULL`).Scan(&partitions)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if partitions < 2 {
+			t.Errorf("logs_partitioned has %d partitions, want the monthly set", partitions)
+		}
+	})
+
+	t.Run("exploit rules are seeded", func(t *testing.T) {
+		var rules int
+		if err := db.QueryRow(`SELECT COUNT(*) FROM exploit_block_rules`).Scan(&rules); err != nil {
+			t.Fatal(err)
+		}
+		// 기본 규칙 22개에 나중 업그레이드가 채워 넣는 dotenv 규칙 하나.
+		if rules < 23 {
+			t.Errorf("exploit_block_rules has %d rows, want the full default set", rules)
+		}
+	})
+
+	t.Run("ddns_records carries the upgrade column", func(t *testing.T) {
+		var n int
+		err := db.QueryRow(`
+			SELECT COUNT(*) FROM information_schema.columns
+			WHERE table_schema = DATABASE() AND table_name = 'ddns_records'
+			  AND column_name = 'proxy_host_id'`).Scan(&n)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if n == 0 {
+			t.Error("ddns_records.proxy_host_id is missing")
+		}
+	})
+}
+
+// TestMySQLFamilyTranslatedQueries는 리포지토리가 가장 많이 쓰는 SQL 형태들을
+// 번역 드라이버를 통해 실제 서버로 보낸다. 각 문장은 리포지토리가 쓰는 그대로의
+// PostgreSQL 문장이다.
+func TestMySQLFamilyTranslatedQueries(t *testing.T) {
+	db := openMySQLFamily(t)
+	if err := db.RunMigrations(); err != nil {
+		t.Fatalf("RunMigrations: %v", err)
+	}
+	ctx := context.Background()
+
+	t.Run("insert with RETURNING", func(t *testing.T) {
+		var id string
+		err := db.QueryRowContext(ctx, `
+			INSERT INTO access_lists (name, description, satisfy_any)
+			VALUES ($1, $2, $3) RETURNING id`,
+			"translated-"+time.Now().Format("150405.000000"), "from the integration test", true,
+		).Scan(&id)
+		if err != nil {
+			t.Fatalf("INSERT ... RETURNING: %v", err)
+		}
+		if id == "" {
+			t.Fatal("RETURNING produced an empty id")
+		}
+		t.Cleanup(func() {
+			_, _ = db.ExecContext(ctx, `DELETE FROM access_lists WHERE id = $1`, id)
+		})
+
+		t.Run("reused placeholder", func(t *testing.T) {
+			var n int
+			err := db.QueryRowContext(ctx,
+				`SELECT COUNT(*) FROM access_lists WHERE id = $1 OR name = $2 OR id = $1`,
+				id, "nothing-matches-this").Scan(&n)
+			if err != nil {
+				t.Fatalf("reused placeholder: %v", err)
+			}
+			if n != 1 {
+				t.Errorf("got %d rows, want 1", n)
+			}
+		})
+
+		t.Run("ILIKE is case-insensitive", func(t *testing.T) {
+			var n int
+			err := db.QueryRowContext(ctx,
+				`SELECT COUNT(*) FROM access_lists WHERE id = $1 AND description ILIKE $2`,
+				id, "%FROM THE INTEGRATION TEST%").Scan(&n)
+			if err != nil {
+				t.Fatalf("ILIKE: %v", err)
+			}
+			if n != 1 {
+				t.Errorf("ILIKE matched %d rows, want 1", n)
+			}
+		})
+
+		t.Run("= is case-sensitive, as on PostgreSQL", func(t *testing.T) {
+			var n int
+			err := db.QueryRowContext(ctx,
+				`SELECT COUNT(*) FROM access_lists WHERE id = $1 AND description = $2`,
+				id, "FROM THE INTEGRATION TEST").Scan(&n)
+			if err != nil {
+				t.Fatalf("equality: %v", err)
+			}
+			if n != 0 {
+				t.Errorf("case-insensitive equality leaked: matched %d rows, want 0", n)
+			}
+		})
+	})
+
+	t.Run("aggregate FILTER", func(t *testing.T) {
+		var total, blocked int
+		err := db.QueryRowContext(ctx, `
+			SELECT COUNT(*), COUNT(*) FILTER (WHERE block_reason != 'none')
+			FROM logs_partitioned WHERE created_at > NOW() - INTERVAL '24 hours'`,
+		).Scan(&total, &blocked)
+		if err != nil {
+			t.Fatalf("COUNT(*) FILTER: %v", err)
+		}
+		if blocked > total {
+			t.Errorf("filtered count %d exceeds total %d", blocked, total)
+		}
+	})
+
+	t.Run("upsert", func(t *testing.T) {
+		name := "upsert-" + time.Now().Format("150405.000000")
+		insert := `
+			INSERT INTO access_lists (id, name, description)
+			VALUES ($1, $2, $3)
+			ON CONFLICT (id) DO UPDATE SET description = EXCLUDED.description`
+		id := "11111111-2222-3333-4444-" + time.Now().Format("150405000000")
+
+		if _, err := db.ExecContext(ctx, insert, id, name, "first"); err != nil {
+			t.Fatalf("upsert insert: %v", err)
+		}
+		t.Cleanup(func() {
+			_, _ = db.ExecContext(ctx, `DELETE FROM access_lists WHERE id = $1`, id)
+		})
+		if _, err := db.ExecContext(ctx, insert, id, name, "second"); err != nil {
+			t.Fatalf("upsert update: %v", err)
+		}
+
+		var description string
+		if err := db.QueryRowContext(ctx,
+			`SELECT description FROM access_lists WHERE id = $1`, id).Scan(&description); err != nil {
+			t.Fatal(err)
+		}
+		if description != "second" {
+			t.Errorf("description = %q, want %q", description, "second")
+		}
+	})
+
+	t.Run("unique violations are classified", func(t *testing.T) {
+		name := "dup-" + time.Now().Format("150405.000000")
+		if _, err := db.ExecContext(ctx,
+			`INSERT INTO roles (name, description) VALUES ($1, $2)`, name, "first"); err != nil {
+			t.Skipf("roles insert unavailable: %v", err)
+		}
+		t.Cleanup(func() {
+			_, _ = db.ExecContext(ctx, `DELETE FROM roles WHERE name = $1`, name)
+		})
+
+		_, err := db.ExecContext(ctx,
+			`INSERT INTO roles (name, description) VALUES ($1, $2)`, name, "second")
+		if err == nil {
+			t.Fatal("expected a unique violation on the second insert")
+		}
+		if !dialect.IsUniqueViolation(err) {
+			t.Errorf("IsUniqueViolation(%v) = false, want true", err)
+		}
+	})
+
+	t.Run("timestamps round-trip in UTC", func(t *testing.T) {
+		// DATETIME에는 시간대가 없다. 드라이버가 UTC로 고정돼 있으므로 여기서
+		// 쓴 Go 시각은 같은 시점으로 돌아와야 한다.
+		want := time.Date(2026, 3, 14, 15, 9, 26, 535000000, time.UTC)
+		var got time.Time
+		if err := db.QueryRowContext(ctx, `SELECT CAST($1 AS DATETIME(6))`, want).Scan(&got); err != nil {
+			t.Fatalf("timestamp round-trip: %v", err)
+		}
+		if !got.UTC().Equal(want) {
+			t.Errorf("got %s, want %s", got.UTC(), want)
+		}
+	})
+
+	t.Run("transactions are translated too", func(t *testing.T) {
+		tx, err := db.BeginTx(ctx, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer tx.Rollback()
+
+		var n int
+		if err := tx.QueryRowContext(ctx,
+			`SELECT COUNT(*) FROM proxy_hosts WHERE enabled = $1`, true).Scan(&n); err != nil {
+			t.Fatalf("query inside a transaction: %v", err)
+		}
+		if err := tx.Commit(); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("prepared statements are translated too", func(t *testing.T) {
+		stmt, err := db.PrepareContext(ctx,
+			`SELECT COUNT(*) FROM exploit_block_rules WHERE category = $1 AND enabled = $2`)
+		if err != nil {
+			t.Fatalf("prepare: %v", err)
+		}
+		defer stmt.Close()
+
+		var n int
+		if err := stmt.QueryRowContext(ctx, "scanner", true).Scan(&n); err != nil {
+			t.Fatalf("execute prepared: %v", err)
+		}
+		if n == 0 {
+			t.Error("expected at least one enabled scanner rule")
+		}
+	})
+
+	t.Run("null handling matches", func(t *testing.T) {
+		var got sql.NullString
+		if err := db.QueryRowContext(ctx,
+			`SELECT NULLIF($1, '')`, "").Scan(&got); err != nil {
+			t.Fatalf("NULLIF: %v", err)
+		}
+		if got.Valid {
+			t.Errorf("NULLIF('', '') returned %q, want NULL", got.String)
+		}
+	})
+}
+
+// TestMySQLFamilyReturningIsEmulated는 서버가 직접 표현할 수 없는 문장 형태를
+// 다룬다. MySQL에서는 모든 RETURNING 형태가, MariaDB에서도 UPDATE와 업서트
+// 형태가 여기 해당한다. 번역기가 이들을 쓰기와 재조회로 나누고, 드라이버가 그
+// 둘을 한 트랜잭션 안에서 실행한다.
+func TestMySQLFamilyReturningIsEmulated(t *testing.T) {
+	db := openMySQLFamily(t)
+	if err := db.RunMigrations(); err != nil {
+		t.Fatalf("RunMigrations: %v", err)
+	}
+	ctx := context.Background()
+
+	t.Run("UPDATE ... RETURNING", func(t *testing.T) {
+		var id string
+		err := db.QueryRowContext(ctx,
+			`INSERT INTO access_lists (name, description) VALUES ($1, $2) RETURNING id`,
+			"upd-"+time.Now().Format("150405.000000"), "before").Scan(&id)
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { db.ExecContext(ctx, `DELETE FROM access_lists WHERE id = $1`, id) })
+
+		var gotID, gotName, gotDescription string
+		err = db.QueryRowContext(ctx, `
+			UPDATE access_lists SET description = $1, updated_at = now()
+			WHERE id = $2
+			RETURNING id, name, description`, "after", id).Scan(&gotID, &gotName, &gotDescription)
+		if err != nil {
+			t.Fatalf("UPDATE ... RETURNING: %v", err)
+		}
+		if gotID != id {
+			t.Errorf("returned id = %q, want %q", gotID, id)
+		}
+		if gotDescription != "after" {
+			t.Errorf("returned description = %q, want the post-update value %q", gotDescription, "after")
+		}
+	})
+
+	t.Run("UPDATE ... RETURNING matching no rows", func(t *testing.T) {
+		// 쓰기 쪽이 아무 행도 건드리지 않으므로, 재조회는 PostgreSQL의
+		// RETURNING과 똑같이 sql.ErrNoRows를 내야 한다.
+		var id string
+		err := db.QueryRowContext(ctx,
+			`UPDATE access_lists SET description = $1 WHERE id = $2 RETURNING id`,
+			"unreachable", "00000000-0000-0000-0000-000000000000").Scan(&id)
+		if !errors.Is(err, sql.ErrNoRows) {
+			t.Fatalf("got %v, want sql.ErrNoRows", err)
+		}
+	})
+
+	t.Run("upsert ... RETURNING", func(t *testing.T) {
+		hostID := createProxyHost(t, db, "returning-upsert")
+
+		upsert := `
+			INSERT INTO rate_limits (proxy_host_id, enabled, requests_per_second, burst_size)
+			VALUES ($1, $2, $3, $4)
+			ON CONFLICT (proxy_host_id) DO UPDATE
+			   SET enabled = EXCLUDED.enabled, burst_size = EXCLUDED.burst_size
+			RETURNING id, proxy_host_id, enabled, burst_size`
+
+		var id, gotHost string
+		var enabled bool
+		var burst int
+		if err := db.QueryRowContext(ctx, upsert, hostID, true, 10, 20).
+			Scan(&id, &gotHost, &enabled, &burst); err != nil {
+			t.Fatalf("insert path: %v", err)
+		}
+		if gotHost != hostID || !enabled || burst != 20 {
+			t.Fatalf("insert path returned (%s, %v, %d)", gotHost, enabled, burst)
+		}
+
+		var secondID string
+		if err := db.QueryRowContext(ctx, upsert, hostID, false, 10, 99).
+			Scan(&secondID, &gotHost, &enabled, &burst); err != nil {
+			t.Fatalf("update path: %v", err)
+		}
+		if secondID != id {
+			t.Errorf("upsert created a second row: %q then %q", id, secondID)
+		}
+		if enabled || burst != 99 {
+			t.Errorf("update path returned stale values (%v, %d)", enabled, burst)
+		}
+	})
+}
+
+// TestMySQLFamilyArrayColumns는 TEXT 안에 담긴 text[] 표현을 확인한다. Go에서는
+// lib/pq의 배열 코덱이 그대로 왕복하고, SQL에서는 dialect 분기 술어가 그 안의
+// 값을 찾아낸다.
+func TestMySQLFamilyArrayColumns(t *testing.T) {
+	db := openMySQLFamily(t)
+	if err := db.RunMigrations(); err != nil {
+		t.Fatalf("RunMigrations: %v", err)
+	}
+	ctx := context.Background()
+
+	suffix := time.Now().Format("150405.000000")
+	domains := []string{"alpha-" + suffix + ".example", "beta-" + suffix + ".example"}
+
+	var id string
+	err := db.QueryRowContext(ctx, `
+		INSERT INTO proxy_hosts (domain_names, forward_scheme, forward_host, forward_port, enabled)
+		VALUES ($1, 'http', '127.0.0.1', 8080, true) RETURNING id`,
+		pq.Array(domains)).Scan(&id)
+	if err != nil {
+		t.Fatalf("insert with an array column: %v", err)
+	}
+	t.Cleanup(func() { db.ExecContext(ctx, `DELETE FROM proxy_hosts WHERE id = $1`, id) })
+
+	t.Run("round-trips through lib/pq", func(t *testing.T) {
+		var got pq.StringArray
+		if err := db.QueryRowContext(ctx,
+			`SELECT domain_names FROM proxy_hosts WHERE id = $1`, id).Scan(&got); err != nil {
+			t.Fatal(err)
+		}
+		if len(got) != len(domains) || got[0] != domains[0] || got[1] != domains[1] {
+			t.Errorf("got %v, want %v", got, domains)
+		}
+	})
+
+	t.Run("membership predicate finds whole elements only", func(t *testing.T) {
+		var found string
+		err := db.QueryRowContext(ctx,
+			`SELECT id FROM proxy_hosts WHERE domain_names LIKE CONCAT('%"', $1, '"%')`,
+			domains[1]).Scan(&found)
+		if err != nil {
+			t.Fatalf("membership lookup: %v", err)
+		}
+		if found != id {
+			t.Errorf("found %q, want %q", found, id)
+		}
+
+		// 저장된 원소의 앞부분만 일치하는 값은 매칭되면 안 된다.
+		var any string
+		err = db.QueryRowContext(ctx,
+			`SELECT id FROM proxy_hosts WHERE domain_names LIKE CONCAT('%"', $1, '"%')`,
+			"alpha-"+suffix).Scan(&any)
+		if !errors.Is(err, sql.ErrNoRows) {
+			t.Errorf("a partial element matched: %v", err)
+		}
+	})
+}
+
+// TestMySQLFamilyLogIngestion은 로그 수집기가 쓰는 배치 쓰기 경로를 실행한다.
+func TestMySQLFamilyLogIngestion(t *testing.T) {
+	db := openMySQLFamily(t)
+	if err := db.RunMigrations(); err != nil {
+		t.Fatalf("RunMigrations: %v", err)
+	}
+	ctx := context.Background()
+
+	repo := repository.NewLogRepository(db)
+	host := "ingest-" + time.Now().Format("150405.000000") + ".example"
+
+	batch := make([]model.CreateLogRequest, 0, 25)
+	for i := 0; i < 25; i++ {
+		batch = append(batch, model.CreateLogRequest{
+			LogType:       model.LogTypeAccess,
+			Timestamp:     time.Now().UTC(),
+			Host:          host,
+			ClientIP:      "203.0.113.7",
+			RequestMethod: "GET",
+			RequestURI:    "/batch",
+			StatusCode:    200,
+			BodyBytesSent: int64(1024 + i),
+			RequestTime:   0.125,
+		})
+	}
+	if err := repo.CreateBatch(ctx, batch); err != nil {
+		t.Fatalf("CreateBatch: %v", err)
+	}
+	t.Cleanup(func() { db.ExecContext(ctx, `DELETE FROM logs_partitioned WHERE host = $1`, host) })
+
+	var stored int
+	if err := db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM logs_partitioned WHERE host = $1`, host).Scan(&stored); err != nil {
+		t.Fatal(err)
+	}
+	if stored != len(batch) {
+		t.Errorf("stored %d rows, want %d", stored, len(batch))
+	}
+
+	t.Run("empty strings become NULL, as on PostgreSQL", func(t *testing.T) {
+		var nullReferers int
+		if err := db.QueryRowContext(ctx,
+			`SELECT COUNT(*) FROM logs_partitioned WHERE host = $1 AND http_referer IS NULL`,
+			host).Scan(&nullReferers); err != nil {
+			t.Fatal(err)
+		}
+		if nullReferers != len(batch) {
+			t.Errorf("%d rows have a NULL referer, want %d", nullReferers, len(batch))
+		}
+	})
+
+	t.Run("readable through logs_unified", func(t *testing.T) {
+		var viaView int
+		if err := db.QueryRowContext(ctx,
+			`SELECT COUNT(*) FROM logs_unified WHERE host = $1`, host).Scan(&viaView); err != nil {
+			t.Fatalf("logs_unified: %v", err)
+		}
+		if viaView != len(batch) {
+			t.Errorf("logs_unified shows %d rows, want %d", viaView, len(batch))
+		}
+	})
+}
+
+// createProxyHost는 최소한의 활성 호스트를 삽입하고 그 id를 돌려준다.
+func createProxyHost(t *testing.T, db *database.DB, label string) string {
+	t.Helper()
+	var id string
+	err := db.QueryRow(`
+		INSERT INTO proxy_hosts (domain_names, forward_scheme, forward_host, forward_port, enabled)
+		VALUES ($1, 'http', '127.0.0.1', 8080, true) RETURNING id`,
+		pq.Array([]string{label + "-" + time.Now().Format("150405.000000") + ".example"}),
+	).Scan(&id)
+	if err != nil {
+		t.Fatalf("failed to create a proxy host: %v", err)
+	}
+	t.Cleanup(func() { db.Exec(`DELETE FROM proxy_hosts WHERE id = $1`, id) })
+	return id
+}

--- a/api/tests/integration/postgres_dialect_test.go
+++ b/api/tests/integration/postgres_dialect_test.go
@@ -1,0 +1,143 @@
+package integration
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/lib/pq"
+
+	"nginx-proxy-guard/internal/database"
+	"nginx-proxy-guard/internal/database/dialect"
+	"nginx-proxy-guard/internal/model"
+	"nginx-proxy-guard/internal/repository"
+)
+
+// MySQL 계열 지원을 추가하면서 공유 리포지토리 코드를 손봐야 했다. `= ANY($1)`,
+// 파라미터화된 interval 캐스트, UPDATE ... RETURNING을 쓰던 질의들을 두 엔진이
+// 모두 받아주는 형태로 바꿨다. 이 파일은 바로 그 경로들을 PostgreSQL에서 다시
+// 실행한다. MySQL 계열을 위한 변경이 거의 모든 설치가 실제로 돌리는 백엔드를
+// 조용히 망가뜨리지 못하게 하기 위해서다.
+//
+// NPG_POSTGRES_TEST_DSN을 빈 데이터베이스로 지정하면 실행되고, 설정하지 않으면
+// 건너뛴다.
+//
+//	docker run -d --name npg-pg-test -e POSTGRES_PASSWORD=postgres \
+//	    -e POSTGRES_DB=npg -p 55432:5432 timescale/timescaledb:latest-pg17 \
+//	    -c shared_preload_libraries=timescaledb
+//	NPG_POSTGRES_TEST_DSN='postgres://postgres:postgres@127.0.0.1:55432/npg?sslmode=disable' \
+//	    go test ./tests/integration/ -run PostgresSharedPaths -v
+func TestPostgresSharedPaths(t *testing.T) {
+	dsn := os.Getenv("NPG_POSTGRES_TEST_DSN")
+	if dsn == "" {
+		t.Skip("NPG_POSTGRES_TEST_DSN is not set; skipping the PostgreSQL regression tests")
+	}
+
+	db, err := database.New(dsn)
+	if err != nil {
+		t.Fatalf("failed to connect to PostgreSQL: %v", err)
+	}
+	defer db.Close()
+
+	if got := db.Kind(); got != dialect.Postgres {
+		t.Fatalf("dialect detected as %q, want %q", got, dialect.Postgres)
+	}
+	if err := db.RunMigrations(); err != nil {
+		t.Fatalf("RunMigrations: %v", err)
+	}
+	// 업그레이드 실패는 설계상 경고 후 계속 진행이며, 일부는 사용 중인
+	// TimescaleDB 빌드에 따라 달라진다. 그래서 여기서는 치명적 실패가 아니라
+	// 보고만 한다.
+	if n, last := db.MigrationHealth(); n > 0 {
+		t.Logf("note: %d upgrade statement(s) failed on this server: %s", n, last)
+	}
+
+	ctx := context.Background()
+
+	t.Run("IN list in place of = ANY", func(t *testing.T) {
+		rl := repository.NewRateLimitRepository(db.DB)
+		if _, err := rl.GetActiveBannedIPSet(ctx, []string{"192.0.2.1", "192.0.2.2"}); err != nil {
+			t.Errorf("GetActiveBannedIPSet: %v", err)
+		}
+		if _, err := rl.GetBannedIPsByIDs(ctx, []string{"00000000-0000-0000-0000-000000000000"}); err != nil {
+			t.Errorf("GetBannedIPsByIDs: %v", err)
+		}
+	})
+
+	t.Run("parameterised interval retention", func(t *testing.T) {
+		if _, err := db.ExecContext(ctx,
+			`DELETE FROM audit_logs WHERE created_at < NOW() - ($1 || ' days')::INTERVAL`, 3650); err != nil {
+			t.Errorf("interval retention: %v", err)
+		}
+	})
+
+	t.Run("array membership predicate", func(t *testing.T) {
+		var n int
+		if err := db.QueryRowContext(ctx,
+			`SELECT COUNT(*) FROM proxy_hosts WHERE $1 = ANY(domain_names)`,
+			"absent.example").Scan(&n); err != nil {
+			t.Errorf("array membership: %v", err)
+		}
+	})
+
+	t.Run("certificate recovery selects before it updates", func(t *testing.T) {
+		if _, _, err := repository.NewCertificateRepository(db).RecoverInterruptedStates(ctx); err != nil {
+			t.Errorf("RecoverInterruptedStates: %v", err)
+		}
+	})
+
+	t.Run("domain existence check", func(t *testing.T) {
+		if _, err := repository.NewProxyHostRepository(db).
+			CheckDomainExists(ctx, []string{"a.example", "b.example"}, ""); err != nil {
+			t.Errorf("CheckDomainExists: %v", err)
+		}
+	})
+
+	t.Run("COPY batch log insert", func(t *testing.T) {
+		host := "pgpaths-" + time.Now().Format("150405.000000") + ".example"
+		logs := make([]model.CreateLogRequest, 0, 5)
+		for i := 0; i < 5; i++ {
+			logs = append(logs, model.CreateLogRequest{
+				LogType: model.LogTypeAccess, Timestamp: time.Now().UTC(),
+				Host: host, ClientIP: "203.0.113.9", RequestMethod: "GET",
+				RequestURI: "/x", StatusCode: 200,
+			})
+		}
+		if err := repository.NewLogRepository(db).CreateBatch(ctx, logs); err != nil {
+			t.Fatalf("CreateBatch: %v", err)
+		}
+		t.Cleanup(func() { db.ExecContext(ctx, `DELETE FROM logs_partitioned WHERE host = $1`, host) })
+
+		var stored int
+		if err := db.QueryRowContext(ctx,
+			`SELECT COUNT(*) FROM logs_partitioned WHERE host = $1`, host).Scan(&stored); err != nil {
+			t.Fatal(err)
+		}
+		if stored != len(logs) {
+			t.Errorf("stored %d rows, want %d", stored, len(logs))
+		}
+	})
+
+	t.Run("array columns round-trip", func(t *testing.T) {
+		domains := []string{"pgarray-" + time.Now().Format("150405.000000") + ".example"}
+		var id string
+		err := db.QueryRowContext(ctx, `
+			INSERT INTO proxy_hosts (domain_names, forward_scheme, forward_host, forward_port, enabled)
+			VALUES ($1, 'http', '127.0.0.1', 8080, true) RETURNING id`,
+			pq.Array(domains)).Scan(&id)
+		if err != nil {
+			t.Fatalf("insert: %v", err)
+		}
+		t.Cleanup(func() { db.ExecContext(ctx, `DELETE FROM proxy_hosts WHERE id = $1`, id) })
+
+		var got pq.StringArray
+		if err := db.QueryRowContext(ctx,
+			`SELECT domain_names FROM proxy_hosts WHERE id = $1`, id).Scan(&got); err != nil {
+			t.Fatal(err)
+		}
+		if len(got) != 1 || got[0] != domains[0] {
+			t.Errorf("got %v, want %v", got, domains)
+		}
+	})
+}

--- a/api/tests/integration/utils/setup.go
+++ b/api/tests/integration/utils/setup.go
@@ -9,7 +9,7 @@ import (
 func WaitForAPI(t *testing.T, baseURL string) {
 	client := NewAPIClient(baseURL)
 	maxRetries := 30
-	
+
 	for i := 0; i < maxRetries; i++ {
 		// Try to hit health endpoint
 		// Note: Using a simple req directly to avoid Auth checks if any
@@ -22,9 +22,9 @@ func WaitForAPI(t *testing.T, baseURL string) {
 		if resp != nil {
 			resp.Body.Close()
 		}
-		
+
 		time.Sleep(1 * time.Second)
 	}
-	
+
 	t.Fatalf("API did not become ready at %s after %d seconds", baseURL, maxRetries)
 }

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -98,7 +98,7 @@ services:
     environment:
       TZ: ${TZ:-UTC}
       PORT: "8080"
-      DATABASE_URL: postgres://${DB_USER:-postgres}:${DB_PASSWORD:-your-secure-password-here}@npg-db:5432/${DB_NAME:-nginx_guard}?sslmode=disable
+      DATABASE_URL: ${DATABASE_URL:-postgres://${DB_USER:-postgres}:${DB_PASSWORD:-your-secure-password-here}@npg-db:5432/${DB_NAME:-nginx_guard}?sslmode=disable}
       REDIS_URL: redis://npg-valkey:6379/0
       JWT_SECRET: ${JWT_SECRET:-change-this-in-production-use-openssl-rand-hex-32}
       ENVIRONMENT: ${ENVIRONMENT:-production}

--- a/docker-compose.mariadb.yml
+++ b/docker-compose.mariadb.yml
@@ -1,0 +1,71 @@
+# Nginx Proxy Guard — TimescaleDB/PostgreSQL 대신 MariaDB로 구동한다.
+#
+#   docker compose -f docker-compose.yml -f docker-compose.mariadb.yml up -d
+#
+# 매번 두 파일을 지정하기 번거로우면 셸 별칭을 만들거나 .env에 COMPOSE_FILE을
+# 설정해 두면 이후 명령이 자동으로 인식한다.
+#
+#   COMPOSE_FILE=docker-compose.yml:docker-compose.mariadb.yml
+#
+# 이 오버레이는 서비스 이름을 `db` 그대로 유지한다. 덕분에 스택의 나머지 —
+# depends_on, 헬스체크, api의 DB 대기 루프 — 는 손댈 필요가 없다.
+# MySQL용은 docker-compose.mysql.yml을 보면 된다. 두 엔진은 스키마 한 벌과 코드
+# 경로 하나를 공유한다.
+#
+# 백엔드 선택은 설치할 때 한 번 하는 결정이다. 두 엔진 사이의 마이그레이션
+# 경로는 없다. 스키마는 같은 원본에서 생성되지만 데이터는 이식되지 않으므로,
+# 바꾸려면 빈 데이터베이스에서 새로 시작하거나 Nginx Proxy Guard 백업을
+# 복원해야 한다. 백업은 pg_dump가 아니라 API가 직접 내보내고 가져오므로 엔진과
+# 무관하게 호환된다.
+#
+# MariaDB에서 달라지는 점:
+#   * 로그 테이블이 TimescaleDB 하이퍼테이블이 아니라 MariaDB 네이티브 월별
+#     RANGE 파티션을 쓴다. 보존 정책은 여전히 파티션을 통째로 삭제한다.
+#   * 압축은 TimescaleDB 청크 압축이 아니라 InnoDB 페이지 압축이다. 실제 형태의
+#     액세스 로그로 측정했을 때 약 5배.
+#   * 로그 텍스트 검색에는 트라이그램 인덱스가 없어 선택한 기간 범위 안을
+#     스캔한다. 기간 필터를 켜 두는 것이 속도를 유지하는 방법이다.
+# 프록시 호스트, 인증서, WAF, 알림, SSO 등 나머지는 동일하게 동작한다.
+
+services:
+  db:
+    image: mariadb:11.4
+    # 베이스 파일의 postgres 커맨드라인을 대체한다.
+    command: >
+      --character-set-server=utf8mb4
+      --collation-server=utf8mb4_bin
+      --innodb-buffer-pool-size=512M
+      --innodb-flush-log-at-trx-commit=2
+      --max-connections=200
+      --default-time-zone=+00:00
+    environment:
+      # 베이스 파일의 POSTGRES_* 변수는 병합된 설정에 남지만 이 이미지가 그냥
+      # 무시한다.
+      MARIADB_ROOT_PASSWORD: ${DB_ROOT_PASSWORD:-${DB_PASSWORD:-postgres}}
+      MARIADB_USER: ${DB_USER:-npg}
+      MARIADB_PASSWORD: ${DB_PASSWORD:-postgres}
+      MARIADB_DATABASE: ${DB_NAME:-nginx_proxy_guard}
+      # utf8mb4_bin은 PostgreSQL처럼 `=`가 대소문자를 구분하게 한다. 대소문자
+      # 무시 매칭은 질의가 원래 요구한 자리(ILIKE)에서만 API의 SQL 번역 계층이
+      # 되살린다.
+      MARIADB_AUTO_UPGRADE: "1"
+    volumes:
+      # Compose는 볼륨 목록을 대상 경로 기준으로 병합하므로 베이스 파일의
+      # postgres_data 마운트가 이것과 함께 남는다. 빈 채로 있고 비용도 없다.
+      # 없애려면 `!reset` 태그가 필요한데, 구버전 Compose가 아예 거부한다.
+      - mariadb_data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
+
+  api:
+    environment:
+      # 스킴이 백엔드를 고른다. internal/database/dialect 참고.
+      DATABASE_URL: mariadb://${DB_USER:-npg}:${DB_PASSWORD:-postgres}@db:3306/${DB_NAME:-nginx_proxy_guard}
+
+volumes:
+  mariadb_data:
+    name: npg_mariadb_data

--- a/docker-compose.mysql.yml
+++ b/docker-compose.mysql.yml
@@ -1,0 +1,66 @@
+# Nginx Proxy Guard — TimescaleDB/PostgreSQL 대신 MySQL로 구동한다.
+#
+#   docker compose -f docker-compose.yml -f docker-compose.mysql.yml up -d
+#
+# 매번 두 파일을 지정하기 번거로우면 셸 별칭을 만들거나 .env에 COMPOSE_FILE을
+# 설정해 두면 이후 명령이 자동으로 인식한다.
+#
+#   COMPOSE_FILE=docker-compose.yml:docker-compose.mysql.yml
+#
+# MariaDB용은 docker-compose.mariadb.yml을 보면 된다. 두 엔진은 스키마 한 벌과
+# 코드 경로 하나를 공유한다. API는 접속할 때 어느 쪽인지 서버에 직접 묻고
+# (MariaDB는 VERSION()에 자기 이름을 넣는다) 둘이 어긋나는 소수의 문장만
+# 조정한다. MySQL에만 필요한 처리는 다음과 같다.
+#
+#   * RETURNING 절이 아예 없다. 새 행을 돌려주는 INSERT는 한 트랜잭션 안에서
+#     삽입과 재조회로 나뉘어 실행되며, 조회할 키가 있어야 하므로 기본 키는 API가
+#     만든다. 행을 돌려주는 DELETE는 먼저 읽는다.
+#   * CREATE INDEX, ADD COLUMN, ADD FOREIGN KEY에 IF NOT EXISTS를 쓸 수 없다.
+#     그래서 마이그레이션 파일에서 그 절을 빼고 내보내고, 재실행 시 나오는
+#     "이미 존재함" 오류를 성공으로 읽는다.
+#   * 압축이 MariaDB의 PAGE_COMPRESSED 속성이 아니라 COMPRESSION='zlib'이다.
+#
+# 백엔드 선택은 설치할 때 한 번 하는 결정이다. 두 엔진 사이의 마이그레이션
+# 경로는 없다. 바꾸려면 빈 데이터베이스에서 새로 시작하거나 Nginx Proxy Guard
+# 백업을 복원해야 한다. 백업은 덤프 도구가 아니라 API가 직접 내보내고
+# 가져오므로 엔진과 무관하게 호환된다.
+
+services:
+  db:
+    image: mysql:8.4
+    # 베이스 파일의 postgres 커맨드라인을 대체한다.
+    command: >
+      --character-set-server=utf8mb4
+      --collation-server=utf8mb4_bin
+      --innodb-buffer-pool-size=512M
+      --innodb-flush-log-at-trx-commit=2
+      --max-connections=200
+      --default-time-zone=+00:00
+    environment:
+      # 베이스 파일의 POSTGRES_* 변수는 병합된 설정에 남지만 이 이미지가 그냥
+      # 무시한다.
+      MYSQL_ROOT_PASSWORD: ${DB_ROOT_PASSWORD:-${DB_PASSWORD:-postgres}}
+      MYSQL_USER: ${DB_USER:-npg}
+      MYSQL_PASSWORD: ${DB_PASSWORD:-postgres}
+      MYSQL_DATABASE: ${DB_NAME:-nginx_proxy_guard}
+    volumes:
+      # Compose는 볼륨 목록을 대상 경로 기준으로 병합하므로 베이스 파일의
+      # postgres_data 마운트가 이것과 함께 남는다. 빈 채로 있고 비용도 없다.
+      # 없애려면 `!reset` 태그가 필요한데, 구버전 Compose가 아예 거부한다.
+      - mysql_data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "127.0.0.1", "-u", "root", "-p${DB_ROOT_PASSWORD:-${DB_PASSWORD:-postgres}}"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 40s
+
+  api:
+    environment:
+      # 어느 스킴이든 같은 드라이버로 이어지고, 엔진은 서버에 물어서 정한다.
+      # internal/database/dialect 참고.
+      DATABASE_URL: mysql://${DB_USER:-npg}:${DB_PASSWORD:-postgres}@db:3306/${DB_NAME:-nginx_proxy_guard}
+
+volumes:
+  mysql_data:
+    name: npg_mysql_data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -92,7 +92,7 @@ services:
     environment:
       TZ: ${TZ:-UTC}
       PORT: "8080"
-      DATABASE_URL: postgres://${DB_USER:-postgres}:${DB_PASSWORD:-postgres}@db:5432/${DB_NAME:-nginx_proxy_guard}?sslmode=disable
+      DATABASE_URL: ${DATABASE_URL:-postgres://${DB_USER:-postgres}:${DB_PASSWORD:-postgres}@db:5432/${DB_NAME:-nginx_proxy_guard}?sslmode=disable}
       REDIS_URL: redis://valkey:6379/0
       JWT_SECRET: ${JWT_SECRET:-change-this-in-production-use-openssl-rand-hex-32}
       ENVIRONMENT: ${ENVIRONMENT:-production}

--- a/env.example
+++ b/env.example
@@ -24,6 +24,46 @@ DB_USER=postgres
 DB_NAME=nginx_proxy_guard
 
 # ===========================================
+# Database Engine
+# ===========================================
+
+# Nginx Proxy Guard runs on TimescaleDB/PostgreSQL (the default), MariaDB, or
+# MySQL. The backend is chosen by the DATABASE_URL scheme; nothing else in the
+# configuration changes.
+#
+# Pick one at install time. There is no in-place migration between the two —
+# switching means starting from an empty database, or restoring a Nginx Proxy
+# Guard backup, which is engine-independent because the API exports and imports
+# it itself.
+#
+# PostgreSQL (default — leave DATABASE_URL unset and the compose file builds it
+# from DB_USER / DB_PASSWORD / DB_NAME):
+# DATABASE_URL=postgres://postgres:change-me-in-production@db:5432/nginx_proxy_guard?sslmode=disable
+#
+# MariaDB — also start the stack with the overlay that swaps the db service:
+#   docker compose -f docker-compose.yml -f docker-compose.mariadb.yml up -d
+# or set COMPOSE_FILE below so every compose command picks it up.
+# DB_USER=npg
+# DB_ROOT_PASSWORD=change-me-too
+# DATABASE_URL=mariadb://npg:change-me-in-production@db:3306/nginx_proxy_guard
+# COMPOSE_FILE=docker-compose.yml:docker-compose.mariadb.yml
+#
+# MySQL — the same, with the MySQL overlay:
+# DB_USER=npg
+# DB_ROOT_PASSWORD=change-me-too
+# DATABASE_URL=mysql://npg:change-me-in-production@db:3306/nginx_proxy_guard
+# COMPOSE_FILE=docker-compose.yml:docker-compose.mysql.yml
+#
+# The scheme only selects the driver — which of MariaDB and MySQL is listening
+# is settled by asking the server — so a mismatched scheme is harmless.
+#
+# On both, the log tables use native monthly partitions instead of TimescaleDB
+# hypertables, and InnoDB page compression instead of chunk compression (~5x
+# measured). The one real gap is log text search: neither has a trigram index,
+# so they scan within the time range the query selects. Every other feature
+# behaves identically.
+
+# ===========================================
 # Docker Compatibility (Synology DSM, etc.)
 # ===========================================
 

--- a/scripts/pg2mariadb-schema.py
+++ b/scripts/pg2mariadb-schema.py
@@ -1,0 +1,1401 @@
+#!/usr/bin/env python3
+"""정본인 PostgreSQL 스키마에서 MariaDB 초기 스키마를 생성한다.
+
+스키마를 설계하고 계속 발전시키는 곳은 PostgreSQL 쪽이므로, MariaDB 버전은 손으로
+유지하지 않고 생성한다. migrations/001_init.sql을 고쳤다면 이 스크립트를 다시
+돌리고 결과를 커밋한다. 모든 예외 처리가 이 파일 안에 있으므로 출력은 재현
+가능하고, 어느 줄을 손으로 고쳤는지 아무도 기억할 필요가 없다.
+
+    python3 scripts/pg2mariadb-schema.py
+
+읽기: api/internal/database/migrations/001_init.sql
+쓰기: api/internal/database/migrations/mariadb/001_init.sql
+
+출력은 MariaDB를 겨냥한다. MySQL도 같은 파일을 실행한다. MySQL이 거부하는 소수의
+구문 — 대부분의 DDL에 붙는 IF NOT EXISTS, MariaDB의 페이지 압축 속성 — 은
+번역기가 실행 도중 재작성한다(internal/database/dialect 참고).
+
+두 스키마가 의도적으로 다른 지점:
+
+  * TimescaleDB 하이퍼테이블과 PostgreSQL 선언적 파티셔닝은 같은 키를 쓰는
+    RANGE COLUMNS 파티셔닝이 된다. 모든 유니크 키가 파티션 컬럼을 포함해야
+    하므로, 해당 테이블의 기본 키에 그 컬럼이 추가된다.
+  * enum 타입은 컬럼 수준 ENUM으로 인라인된다. 독립적으로 CREATE할 enum 타입이
+    없기 때문이다.
+  * text[] 컬럼은 PostgreSQL 배열 리터럴을 담은 TEXT가 된다. 덕분에 lib/pq의
+    배열 Scanner/Valuer가 두 백엔드에서 그대로 동작한다.
+  * 부분 인덱스는 WHERE 술어를 잃는다(보장이 아니라 최적화이므로). 단 UNIQUE인
+    경우에는 그 술어가 *바로* 보장이므로, 생성 컬럼과 평범한 유니크 인덱스로
+    바꾼다.
+
+    그 컬럼들은 STORED가 아니라 VIRTUAL이다. 아무도 그 값을 조회하지 않고 —
+    유니크 인덱스를 담기 위해서만 존재한다 — 실체화하면 공간만 낭비된다. 게다가
+    MySQL은 STORED 생성 컬럼이 참조하는 컬럼에 ON DELETE CASCADE 외래 키를
+    허용하지 않는데, 여기 해당하는 컬럼이 여럿이다.
+  * GIN/트라이그램 인덱스는 버린다. InnoDB에 대응물이 없다.
+  * updated_at 트리거는 ON UPDATE CURRENT_TIMESTAMP(6)이 된다.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+SOURCE = ROOT / "api/internal/database/migrations/001_init.sql"
+TARGET = ROOT / "api/internal/database/migrations/mariadb/001_init.sql"
+
+# InnoDB DYNAMIC 행 포맷의 인덱스 키 상한은 3072바이트다.
+MAX_KEY_BYTES = 3072
+BYTES_PER_CHAR = 4  # utf8mb4
+# 비유니크 인덱스에서 TEXT 컬럼에 쓸 접두사 길이. 선택도를 확보할 만큼 길면서
+# 키 예산 안에 넉넉히 들어갈 만큼 짧다.
+TEXT_INDEX_PREFIX = 191
+
+# InnoDB 페이지 압축을 적용할 테이블과 사용할 zlib 레벨.
+#
+# TimescaleDB 청크 압축에 대한 MySQL 계열의 답이다. 로그 행은 반복이 극심하다.
+# 같은 유저 에이전트, 같은 호스트, 같은 URI 형태가 계속 나온다. 실제 형태의 액세스
+# 로그 20만 행으로 측정했을 때 테이블이 165MB에서 36MB로 줄었다. 4.6배다.
+#
+# 기본값 6이 아니라 레벨 1을 쓴다. 같은 데이터에서 두 레벨의 디스크 크기는 같은데
+# 레벨 6은 쓰기에 2.7배가 걸린다. 로그 수집이 이 애플리케이션에서 가장 쓰기가 많은
+# 작업이므로, 여기서는 싼 쪽이 명백히 낫다.
+#
+# 페이지 압축에는 sparse 파일에 hole punch가 가능한 파일시스템이 필요하다. ext4,
+# xfs, btrfs 모두 가능하다. 지원하지 않는 환경에서는 InnoDB가 페이지를 압축하되
+# 전체 크기로 기록하므로, 오류가 아니라 약간의 CPU 낭비로 끝난다.
+#
+# 대용량 테이블만 올린다. 압축은 버퍼 풀에서 빗나가는 페이지 읽기마다 CPU를
+# 쓰는데, 끊임없이 읽히고 크기는 킬로바이트 단위인 작은 설정 테이블에까지 치를
+# 값은 아니다.
+COMPRESSED_TABLES = {
+    "logs_partitioned",
+    "logs",
+    "system_logs",
+    "audit_logs",
+}
+PAGE_COMPRESSION_LEVEL = 1
+
+
+# ---------------------------------------------------------------------------
+# 문장 분리
+# ---------------------------------------------------------------------------
+
+def split_statements(sql: str) -> list[str]:
+    """최상위 세미콜론 기준으로 나눈다. 따옴표와 $$ 본문은 존중한다."""
+    out, buf = [], []
+    i, n = 0, len(sql)
+    while i < n:
+        c = sql[i]
+        if c == "'":
+            j = i + 1
+            while j < n:
+                if sql[j] == "\\":
+                    j += 2
+                    continue
+                if sql[j] == "'":
+                    if j + 1 < n and sql[j + 1] == "'":
+                        j += 2
+                        continue
+                    j += 1
+                    break
+                j += 1
+            buf.append(sql[i:j])
+            i = j
+        elif c == '"':
+            j = sql.find('"', i + 1)
+            j = n if j < 0 else j + 1
+            buf.append(sql[i:j])
+            i = j
+        elif c == "-" and sql.startswith("--", i):
+            j = sql.find("\n", i)
+            j = n if j < 0 else j
+            buf.append(sql[i:j])
+            i = j
+        elif c == "$":
+            m = re.match(r"\$[A-Za-z_0-9]*\$", sql[i:])
+            if m:
+                tag = m.group(0)
+                j = sql.find(tag, i + len(tag))
+                j = n if j < 0 else j + len(tag)
+                buf.append(sql[i:j])
+                i = j
+            else:
+                buf.append(c)
+                i += 1
+        elif c == ";":
+            out.append("".join(buf).strip())
+            buf = []
+            i += 1
+        else:
+            buf.append(c)
+            i += 1
+    if "".join(buf).strip():
+        out.append("".join(buf).strip())
+    return [s for s in out if s]
+
+
+def strip_line_comments(sql: str) -> tuple[str, str]:
+    """(선행 주석 블록, 코드)를 돌려준다. 코드에서는 -- 주석을 모두 제거한다.
+
+    원본의 문장 앞에는 이유를 설명하는 여러 줄이 붙어 있는 경우가 많다. 그 설명은
+    생성 파일로 옮길 가치가 있지만, 패턴이 문장 시작에 고정된 파서들에게까지
+    도달해서는 안 된다.
+    """
+    lead: list[str] = []
+    code: list[str] = []
+    seen_code = False
+    i, n = 0, len(sql)
+    while i < n:
+        c = sql[i]
+        if c == "'":
+            j = i + 1
+            while j < n:
+                if sql[j] == "'":
+                    if j + 1 < n and sql[j + 1] == "'":
+                        j += 2
+                        continue
+                    j += 1
+                    break
+                j += 1
+            code.append(sql[i:j])
+            seen_code = True
+            i = j
+        elif c == '"':
+            j = sql.find('"', i + 1)
+            j = n if j < 0 else j + 1
+            code.append(sql[i:j])
+            seen_code = True
+            i = j
+        elif sql.startswith("--", i):
+            j = sql.find("\n", i)
+            j = n if j < 0 else j
+            if not seen_code:
+                lead.append(sql[i:j])
+            i = j
+        else:
+            if not c.isspace():
+                seen_code = True
+            code.append(c)
+            i += 1
+    return "\n".join(lead), " ".join("".join(code).split())
+
+
+def split_top_level_commas(body: str) -> list[str]:
+    """CREATE TABLE 본문을 컬럼과 제약 조건 절로 나눈다."""
+    parts, buf, depth = [], [], 0
+    i, n = 0, len(body)
+    while i < n:
+        c = body[i]
+        if c == "'":
+            j = i + 1
+            while j < n:
+                if body[j] == "'":
+                    if j + 1 < n and body[j + 1] == "'":
+                        j += 2
+                        continue
+                    j += 1
+                    break
+                j += 1
+            buf.append(body[i:j])
+            i = j
+            continue
+        if c in "([":
+            depth += 1
+        elif c in ")]":
+            depth -= 1
+        elif c == "," and depth == 0:
+            parts.append("".join(buf).strip())
+            buf = []
+            i += 1
+            continue
+        buf.append(c)
+        i += 1
+    if "".join(buf).strip():
+        parts.append("".join(buf).strip())
+    return parts
+
+
+# ---------------------------------------------------------------------------
+# 타입과 기본값 대응
+# ---------------------------------------------------------------------------
+
+SCALAR_TYPES = [
+    (r"^timestamp\s+with(out)?\s+time\s+zone$", "DATETIME(6)"),
+    (r"^timestamptz$", "DATETIME(6)"),
+    (r"^timestamp$", "DATETIME(6)"),
+    (r"^date$", "DATE"),
+    (r"^time\s+with(out)?\s+time\s+zone$", "TIME"),
+    (r"^time$", "TIME"),
+    (r"^uuid$", "VARCHAR(36)"),
+    (r"^boolean$", "BOOLEAN"),
+    (r"^smallint$", "SMALLINT"),
+    (r"^integer$", "INT"),
+    (r"^int$", "INT"),
+    (r"^bigint$", "BIGINT"),
+    (r"^serial$", "INT AUTO_INCREMENT"),
+    (r"^bigserial$", "BIGINT AUTO_INCREMENT"),
+    (r"^double\s+precision$", "DOUBLE"),
+    (r"^real$", "FLOAT"),
+    (r"^numeric\((\d+),\s*(\d+)\)$", r"DECIMAL(\1,\2)"),
+    (r"^numeric\((\d+)\)$", r"DECIMAL(\1)"),
+    (r"^numeric$", "DECIMAL(20,6)"),
+    (r"^character\s+varying\((\d+)\)$", r"VARCHAR(\1)"),
+    (r"^character\s+varying$", "TEXT"),
+    (r"^varchar\((\d+)\)$", r"VARCHAR(\1)"),
+    (r"^character\((\d+)\)$", r"CHAR(\1)"),
+    (r"^jsonb$", "JSON"),
+    (r"^json$", "JSON"),
+    # No native inet: the longest textual IPv6 with a zone still fits in 45.
+    (r"^inet$", "VARCHAR(45)"),
+    (r"^cidr$", "VARCHAR(49)"),
+    (r"^macaddr$", "VARCHAR(17)"),
+    (r"^bytea$", "LONGBLOB"),
+    (r"^text$", "TEXT"),
+]
+
+
+def map_type(pg_type: str, enums: dict[str, list[str]]) -> str:
+    t = " ".join(pg_type.strip().split())
+    bare = t[len("public."):] if t.lower().startswith("public.") else t
+
+    # 배열은 PostgreSQL 리터럴 형태를 유지한다. lib/pq의 배열 코덱이 그대로
+    # 왕복하게 하기 위해서다. 바뀌는 것은 저장 타입뿐이다.
+    if bare.endswith("[]"):
+        return "TEXT"
+
+    if bare.lower() in enums:
+        values = ", ".join("'%s'" % v for v in enums[bare.lower()])
+        return "ENUM(%s)" % values
+
+    for pattern, replacement in SCALAR_TYPES:
+        m = re.match(pattern, t, re.IGNORECASE)
+        if m:
+            return re.sub(pattern, replacement, t, flags=re.IGNORECASE).upper() \
+                if "\\" in replacement else replacement
+
+    raise SystemExit("unmapped PostgreSQL type: %r" % pg_type)
+
+
+def map_default(expr: str, enums: dict[str, list[str]]) -> str | None:
+    """DEFAULT 식을 번역한다. None을 돌려주면 그 기본값을 버린다."""
+    e = expr.strip()
+
+    # Postgres 캐스트를 제거한다: 'x'::character varying, '{}'::text[], ...
+    e = re.sub(r"::\s*public\.[A-Za-z_0-9]+(\[\])?", "", e)
+    e = re.sub(r"::\s*(character\s+varying|double\s+precision|timestamp\s+with(out)?\s+time\s+zone)"
+               r"(\(\d+\))?(\[\])?", "", e, flags=re.IGNORECASE)
+    e = re.sub(r"::\s*[A-Za-z_0-9]+(\(\d+(,\s*\d+)?\))?(\[\])?", "", e)
+    e = e.strip()
+
+    low = e.lower()
+    if low in ("now()", "current_timestamp", "current_timestamp()"):
+        return "CURRENT_TIMESTAMP(6)"
+    if low in ("gen_random_uuid()", "uuid_generate_v4()", "public.uuid_generate_v4()"):
+        # 괄호를 씌우는 이유: MySQL은 함수 기본값을 식 형태로만 받아준다.
+        # MariaDB는 둘 다 받으므로 한 형태로 양쪽을 커버한다.
+        return "(UUID())"
+    if low == "null":
+        return "NULL"
+
+    # ARRAY['a','b'] 리터럴은 lib/pq가 만들었을 PostgreSQL 배열 리터럴
+    # 텍스트가 된다.
+    m = re.match(r"^ARRAY\[(.*)\]$", e, re.IGNORECASE | re.DOTALL)
+    if m:
+        items = [x.strip() for x in split_top_level_commas(m.group(1))] if m.group(1).strip() else []
+        rendered = ",".join('"%s"' % x.strip("'").replace("''", "'").replace('"', '\\"') for x in items)
+        return "'{%s}'" % rendered
+
+    if e.startswith("'") or re.match(r"^-?[0-9.]+$", e) or low in ("true", "false"):
+        # JSON 컬럼은 식 형태가 아니면 맨 리터럴을 기본값으로 둘 수 없다.
+        # 괄호가 식 기본값으로 만들어 준다.
+        return e
+
+    if re.match(r"^[A-Za-z_0-9]+\(\)$", e):
+        return None  # 알 수 없는 함수 기본값: 추측하지 말고 버린다
+    return e
+
+
+def needs_expression_default(mysql_type: str) -> bool:
+    """TEXT/BLOB/JSON 기본값은 식 형태로 써야 한다."""
+    head = mysql_type.split("(")[0].upper()
+    return head in {"TEXT", "TINYTEXT", "MEDIUMTEXT", "LONGTEXT", "JSON", "BLOB", "LONGBLOB"}
+
+
+# ---------------------------------------------------------------------------
+# 원본 파싱
+# ---------------------------------------------------------------------------
+
+def parse_enums(statements: list[str]) -> dict[str, list[str]]:
+    enums: dict[str, list[str]] = {}
+    for stmt in statements:
+        for m in re.finditer(
+            r"CREATE\s+TYPE\s+(?:public\.)?([A-Za-z_0-9]+)\s+AS\s+ENUM\s*\((.*?)\)",
+            stmt, re.IGNORECASE | re.DOTALL,
+        ):
+            name = m.group(1).lower()
+            values = re.findall(r"'([^']*)'", m.group(2))
+            enums[name] = values
+    return enums
+
+
+PARTITION_CHILD = re.compile(r"^(logs_p(?:\d{4}_\d{2}|_default)|stats_hourly_p(?:\d{4}_\d{2}|_default))$")
+
+
+def parse_partition_ranges(statements: list[str]) -> dict[str, list[tuple[str, str]]]:
+    """ATTACH 문장들에서 파티션 부모 테이블의 경계값을 복원한다."""
+    ranges: dict[str, list[tuple[str, str]]] = {}
+    for stmt in statements:
+        m = re.search(
+            r"ALTER\s+TABLE\s+ONLY\s+(?:public\.)?([A-Za-z_0-9]+)\s+ATTACH\s+PARTITION\s+"
+            r"(?:public\.)?([A-Za-z_0-9]+)\s+FOR\s+VALUES\s+FROM\s*\('([^']+)'\)\s*TO\s*\('([^']+)'\)",
+            stmt, re.IGNORECASE,
+        )
+        if m:
+            parent, child, _from, to = m.groups()
+            ranges.setdefault(parent, []).append((child, to))
+    for parent in ranges:
+        ranges[parent].sort(key=lambda cv: cv[1])
+    return ranges
+
+
+class Table:
+    def __init__(self, name: str):
+        self.name = name
+        self.columns: list[tuple[str, str, str]] = []  # (name, mysql type, tail)
+        self.column_types: dict[str, str] = {}
+        self.constraints: list[str] = []
+        self.partition_by: str | None = None
+        self.generated: list[str] = []
+        self.extra_keys: list[str] = []
+        self.doc: str = ""
+        # Foreign keys are always emitted after every table exists. MariaDB
+        # rejects a table whose FK target has not been created yet, and the
+        # tables are written in alphabetical order.
+        self.foreign_keys: list[tuple[str, str]] = []
+
+    def add_generated(self, name: str, definition: str) -> None:
+        if any(g.split()[0] == name for g in self.generated):
+            return
+        self.generated.append(definition)
+
+    def add_key(self, name: str, definition: str) -> None:
+        if any(re.search(r"KEY %s \(" % re.escape(name), k) for k in self.extra_keys):
+            return
+        self.extra_keys.append(definition)
+
+
+def parse_tables(prepared: list[tuple[str, str]], enums: dict[str, list[str]]) -> dict[str, Table]:
+    tables: dict[str, Table] = {}
+    for lead, stmt in prepared:
+        # 선택 그룹 하나가 아니라 두 번 시도한다. 탐욕적인 본문 캡처는
+        # `) PARTITION BY RANGE (created_at)`까지 삼켜 버리고 테이블을
+        # 비파티션으로 보고하므로, 꼬리를 고정한 파티션 형태를 먼저 시도해야
+        # 한다.
+        m = re.match(
+            r"CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?(?:public\.)?([A-Za-z_0-9]+)\s*\((.*)\)\s*"
+            r"PARTITION\s+BY\s+RANGE\s*\(([A-Za-z_0-9\"]+)\)\s*$",
+            stmt, re.IGNORECASE | re.DOTALL,
+        )
+        if m:
+            name, body, part_col = m.groups()
+        else:
+            m = re.match(
+                r"CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?(?:public\.)?([A-Za-z_0-9]+)\s*\((.*)\)\s*$",
+                stmt, re.IGNORECASE | re.DOTALL,
+            )
+            if not m:
+                continue
+            name, body = m.groups()
+            part_col = None
+        if PARTITION_CHILD.match(name):
+            continue  # 부모 테이블의 PARTITION 절이 된다
+
+        table = Table(name)
+        table.doc = lead
+        table.partition_by = part_col.strip('"') if part_col else None
+
+        for clause in split_top_level_commas(body):
+            if re.match(r"^(CONSTRAINT|PRIMARY\s+KEY|UNIQUE|CHECK|FOREIGN\s+KEY|EXCLUDE)\b",
+                        clause, re.IGNORECASE):
+                translated = translate_table_constraint(clause, enums)
+                if not translated:
+                    continue
+                fk = re.match(r"^(?:CONSTRAINT (\S+) )?(FOREIGN KEY .*)$", translated)
+                if fk:
+                    table.foreign_keys.append(
+                        (fk.group(1) or "fk_%s_%d" % (table.name, len(table.foreign_keys)),
+                         fk.group(2)))
+                else:
+                    table.constraints.append(translated)
+                continue
+
+            col = parse_column(clause, enums)
+            if col:
+                cname, ctype, ctail, cref = col
+                # TEXT 컬럼에 인라인으로 붙은 UNIQUE는 접두사 길이를 가질 수
+                # 없다. MySQL은 그것을 요구하고 MariaDB는 키를 조용히 USING
+                # HASH로 바꿔 넘긴다. 접두사 단계가 길이를 명시적으로 정할 수
+                # 있도록 테이블 수준 키로 승격한다.
+                if "UNIQUE" in ctail and ctype.split("(")[0].upper() in (
+                        "TEXT", "LONGTEXT", "MEDIUMTEXT", "TINYTEXT", "JSON"):
+                    ctail = re.sub(r"\s*\bUNIQUE\b", "", ctail).strip()
+                    table.extra_keys.append(
+                        "UNIQUE KEY uq_%s_%s (%s)" % (table.name, cname, cname))
+                table.columns.append((cname, ctype, ctail))
+                table.column_types[cname] = ctype
+                if cref:
+                    table.foreign_keys.append(
+                        ("fk_%s_%s" % (table.name, cname),
+                         "FOREIGN KEY (%s) REFERENCES %s" % (cname, cref)))
+
+        tables[name] = table
+    return tables
+
+
+
+# Keywords that end a DEFAULT expression. Matching these with a regex over the
+# raw text is not safe: a default like 'Please complete the security check to
+# continue.' contains the word CHECK inside a string literal, and an earlier
+# version of this script truncated the value there.
+TAIL_KEYWORDS = ("NOT", "NULL", "PRIMARY", "UNIQUE", "REFERENCES", "CHECK",
+                 "CONSTRAINT", "COLLATE", "GENERATED")
+
+
+def tokenize_tail(tail: str) -> list[tuple[str, int, int]]:
+    """Tokenize a column's trailing modifiers, keeping literals atomic."""
+    toks: list[tuple[str, int, int]] = []
+    i, n = 0, len(tail)
+    while i < n:
+        c = tail[i]
+        if c.isspace():
+            i += 1
+        elif c == "'":
+            j = i + 1
+            while j < n:
+                if tail[j] == "'":
+                    if j + 1 < n and tail[j + 1] == "'":
+                        j += 2
+                        continue
+                    j += 1
+                    break
+                j += 1
+            toks.append(("str", i, j))
+            i = j
+        elif c.isalnum() or c == "_":
+            j = i
+            while j < n and (tail[j].isalnum() or tail[j] == "_" or tail[j] == "."):
+                j += 1
+            toks.append(("word", i, j))
+            i = j
+        else:
+            toks.append(("punct", i, i + 1))
+            i += 1
+    return toks
+
+
+def parse_column_modifiers(tail: str) -> dict[str, str]:
+    """Split a column tail into its modifiers, keyed by canonical name."""
+    toks = tokenize_tail(tail)
+    out: dict[str, str] = {}
+
+    def word_at(k: int) -> str:
+        kind, a, b = toks[k]
+        return tail[a:b].upper() if kind == "word" else ""
+
+    i = 0
+    while i < len(toks):
+        w = word_at(i)
+        if w == "NOT" and i + 1 < len(toks) and word_at(i + 1) == "NULL":
+            out["NOT NULL"] = ""
+            i += 2
+        elif w == "PRIMARY" and i + 1 < len(toks) and word_at(i + 1) == "KEY":
+            out["PRIMARY KEY"] = ""
+            i += 2
+        elif w == "UNIQUE":
+            out["UNIQUE"] = ""
+            i += 1
+        elif w == "DEFAULT":
+            j, depth = i + 1, 0
+            while j < len(toks):
+                kind, a, b = toks[j]
+                frag = tail[a:b]
+                if kind == "punct" and frag in "([":
+                    depth += 1
+                elif kind == "punct" and frag in ")]":
+                    depth -= 1
+                elif depth == 0 and j > i + 1 and word_at(j) in TAIL_KEYWORDS:
+                    break
+                j += 1
+            out["DEFAULT"] = tail[toks[i + 1][1]:toks[j - 1][2]].strip()
+            i = j
+        elif w == "REFERENCES":
+            j = i + 1
+            while j < len(toks):
+                if word_at(j) in ("CHECK", "CONSTRAINT", "DEFAULT"):
+                    break
+                j += 1
+            out["REFERENCES"] = tail[toks[i + 1][1]:toks[j - 1][2]].strip()
+            i = j
+        else:
+            i += 1
+    return out
+
+
+
+COLUMN_RE = re.compile(r'^("?[A-Za-z_0-9]+"?)\s+(.*)$', re.DOTALL)
+
+
+def parse_column(clause: str, enums: dict[str, list[str]]) -> tuple[str, str, str, str | None] | None:
+    m = COLUMN_RE.match(clause.strip())
+    if not m:
+        return None
+    name = m.group(1).strip('"')
+    rest = " ".join(m.group(2).split())
+
+    type_match = re.match(
+        r"^((?:public\.)?[A-Za-z_0-9]+(?:\s+(?:varying|precision|with(?:out)?\s+time\s+zone))*"
+        r"(?:\(\d+(?:,\s*\d+)?\))?(?:\[\])*)",
+        rest, re.IGNORECASE,
+    )
+    if not type_match:
+        return None
+    pg_type = type_match.group(1)
+    tail = rest[len(pg_type):].strip()
+    mysql_type = map_type(pg_type, enums)
+
+    modifiers = parse_column_modifiers(tail)
+
+    pieces: list[str] = []
+    if "DEFAULT" in modifiers:
+        default = map_default(modifiers["DEFAULT"], enums)
+        if default is not None:
+            already_expression = default.startswith("(")
+            if not already_expression and needs_expression_default(mysql_type) \
+                    and not default.upper().startswith("CURRENT_TIMESTAMP"):
+                default = "(%s)" % default
+            pieces.append("DEFAULT %s" % default)
+    if "NOT NULL" in modifiers:
+        pieces.insert(0, "NOT NULL")
+    if "PRIMARY KEY" in modifiers:
+        pieces.append("PRIMARY KEY")
+    if "UNIQUE" in modifiers:
+        pieces.append("UNIQUE")
+    reference = None
+    if "REFERENCES" in modifiers:
+        reference = re.sub(r"^(?:public\.)?", "", modifiers["REFERENCES"].strip())
+
+    # NOT NULL must precede DEFAULT for readability but MariaDB accepts either;
+    # keep the canonical order.
+    ordered = []
+    for want in ("NOT NULL",):
+        if want in pieces:
+            ordered.append(want)
+            pieces.remove(want)
+    ordered.extend(pieces)
+
+    return name, mysql_type, " ".join(ordered), reference
+
+
+def translate_table_constraint(clause: str, enums: dict[str, list[str]]) -> str | None:
+    c = " ".join(clause.split())
+
+    m = re.match(r"^CONSTRAINT\s+([A-Za-z_0-9]+)\s+(.*)$", c, re.IGNORECASE)
+    name, rest = (m.group(1), m.group(2)) if m else (None, c)
+
+    if re.match(r"^PRIMARY\s+KEY", rest, re.IGNORECASE):
+        cols = re.search(r"\((.*)\)", rest).group(1)
+        return "PRIMARY KEY (%s)" % normalise_columns(cols)
+
+    if re.match(r"^UNIQUE", rest, re.IGNORECASE):
+        cols = normalise_columns(re.search(r"\((.*)\)", rest).group(1))
+        # PostgreSQL is happy with an anonymous UNIQUE(...); naming it keeps the
+        # key addressable, both for a later ALTER and for the prefix pass below.
+        if not name:
+            name = "uq_%s" % "_".join(c.strip('"') for c in cols.split(", "))
+        return "UNIQUE KEY %s (%s)" % (name, cols)
+
+    if re.match(r"^CHECK", rest, re.IGNORECASE):
+        translated = translate_check(rest)
+        if translated is None:
+            return None
+        return "CONSTRAINT %s %s" % (name, translated) if name else translated
+
+    if re.match(r"^FOREIGN\s+KEY", rest, re.IGNORECASE):
+        fk = re.sub(r"REFERENCES\s+public\.", "REFERENCES ", rest, flags=re.IGNORECASE)
+        return "CONSTRAINT %s %s" % (name, fk) if name else fk
+
+    return None
+
+
+def translate_check(expr: str) -> str | None:
+    """`CHECK ((col)::text = ANY ((ARRAY[...])::text[]))`를 `CHECK (col IN (...))`으로 바꾼다."""
+    m = re.search(r"\(?\(([A-Za-z_0-9]+)\)?(?:::text)?\s*=\s*ANY\s*\(\s*\(?\s*ARRAY\[(.*?)\]",
+                  expr, re.IGNORECASE | re.DOTALL)
+    if m:
+        col = m.group(1)
+        values = []
+        for item in split_top_level_commas(m.group(2)):
+            item = re.sub(r"::\s*[A-Za-z_0-9\[\]\s]+$", "", item.strip()).strip()
+            if item:
+                values.append(item)
+        if not values:
+            return None
+        return "CHECK (%s IN (%s))" % (col, ", ".join(values))
+
+    body = re.sub(r"::\s*[A-Za-z_0-9\[\]\s]+", "", expr)
+    if "ANY" in body.upper() or "~" in body:
+        return None  # 지원하지 않는 술어 형태. 잘못 번역하느니 버린다
+    return " ".join(body.split())
+
+
+def normalise_columns(cols: str) -> str:
+    return ", ".join(c.strip().strip('"') for c in cols.split(","))
+
+
+# ---------------------------------------------------------------------------
+# 인덱스 번역
+# ---------------------------------------------------------------------------
+
+INDEX_RE = re.compile(
+    r"^CREATE\s+(UNIQUE\s+)?INDEX\s+(?:CONCURRENTLY\s+)?(?:IF\s+NOT\s+EXISTS\s+)?([A-Za-z_0-9]+)\s+"
+    r"ON\s+(?:ONLY\s+)?(?:public\.)?([A-Za-z_0-9]+)\s+"
+    r"(?:USING\s+([A-Za-z_0-9]+)\s+)?\((.*?)\)\s*(?:WHERE\s+(.*))?$",
+    re.IGNORECASE | re.DOTALL,
+)
+
+
+def type_key_bytes(mysql_type: str) -> int:
+    head = mysql_type.split("(")[0].upper()
+    m = re.search(r"\((\d+)", mysql_type)
+    size = int(m.group(1)) if m else 0
+    if head == "VARCHAR":
+        return size * BYTES_PER_CHAR + 2
+    if head == "CHAR":
+        return size * BYTES_PER_CHAR
+    if head in ("TEXT", "LONGTEXT", "MEDIUMTEXT", "TINYTEXT", "JSON"):
+        return TEXT_INDEX_PREFIX * BYTES_PER_CHAR + 2
+    if head in ("BIGINT", "DOUBLE", "DATETIME"):
+        return 8
+    if head in ("INT", "FLOAT", "DATE"):
+        return 4
+    if head in ("SMALLINT", "ENUM"):
+        return 2
+    return 1
+
+
+def index_column_spec(table: Table, col: str, unique: bool, budget: int) -> tuple[str, int]:
+    """인덱스 컬럼 하나를 렌더링한다. 타입이 필요로 하면 접두사 길이를 붙인다."""
+    name = col.strip().strip('"')
+    direction = ""
+    dm = re.match(r"^(.*?)\s+(ASC|DESC)$", name, re.IGNORECASE)
+    if dm:
+        name, direction = dm.group(1).strip().strip('"'), " " + dm.group(2).upper()
+
+    mysql_type = table.column_types.get(name, "TEXT")
+    head = mysql_type.split("(")[0].upper()
+
+    if head in ("TEXT", "LONGTEXT", "MEDIUMTEXT", "TINYTEXT"):
+        # 접두사에 건 유니크 인덱스는 그 접두사에 대해서만 유일성을 강제한다.
+        # 그래서 해당 컬럼에는 키 예산에서 들어가는 만큼을 최대한 준다.
+        prefix = min(budget // BYTES_PER_CHAR, 768) if unique else TEXT_INDEX_PREFIX
+        prefix = max(prefix, 1)
+        return "%s(%d)%s" % (name, prefix, direction), prefix * BYTES_PER_CHAR + 2
+
+    return "%s%s" % (name, direction), type_key_bytes(mysql_type)
+
+
+def translate_index(stmt: str, tables: dict[str, Table]) -> str | None:
+    m = INDEX_RE.match(" ".join(stmt.split()))
+    if not m:
+        return None
+    unique, name, table_name, method, cols, where = m.groups()
+    unique = bool(unique)
+
+    if table_name not in tables:
+        return None  # index on a partition child, or a table this file drops
+    table = tables[table_name]
+
+    if method and method.lower() in ("gin", "gist", "brin", "spgist"):
+        return "-- skipped (%s 인덱스는 대응물이 없어 건너뜀): %s" % (method.lower(), name)
+
+    col_list = split_top_level_commas(cols)
+
+    # 식 인덱스. 이 스키마가 쓰는 두 형태는 모두 제약을 표현하기 위해 존재하므로,
+    # 둘 다 생성 컬럼으로 재현한다.
+    if any("(" in c or c.strip().lower() == "true" for c in col_list):
+        return translate_expression_index(unique, name, table, col_list)
+
+    if where and unique:
+        return translate_partial_unique_index(name, table, col_list, where)
+
+    budget = MAX_KEY_BYTES
+    fixed = sum(type_key_bytes(table.column_types.get(c.strip().strip('"').split()[0], "TEXT"))
+                for c in col_list
+                if table.column_types.get(c.strip().strip('"').split()[0], "TEXT").split("(")[0].upper()
+                not in ("TEXT", "LONGTEXT", "MEDIUMTEXT", "TINYTEXT"))
+    text_count = max(1, len(col_list) - sum(
+        1 for c in col_list
+        if table.column_types.get(c.strip().strip('"').split()[0], "TEXT").split("(")[0].upper()
+        not in ("TEXT", "LONGTEXT", "MEDIUMTEXT", "TINYTEXT")))
+    per_text = max(64 * BYTES_PER_CHAR, (MAX_KEY_BYTES - fixed) // text_count)
+
+    specs = []
+    for c in col_list:
+        spec, used = index_column_spec(table, c, unique, per_text)
+        specs.append(spec)
+        budget -= used
+
+    note = ""
+    if where:
+        note = "  -- 부분 인덱스 술어 제거(최적화 목적일 뿐): WHERE %s" % " ".join(where.split())
+
+    return "CREATE %sINDEX IF NOT EXISTS %s ON %s (%s);%s" % (
+        "UNIQUE " if unique else "", name, table.name, ", ".join(specs), note)
+
+
+def translate_expression_index(unique: bool, name: str, table: Table, col_list: list[str]) -> str:
+    exprs = [c.strip() for c in col_list]
+
+    # `USING btree ((true))`는 싱글턴 트릭이다. 테이블당 행 하나.
+    if len(exprs) == 1 and exprs[0].strip("()").lower() == "true":
+        table.add_generated("singleton_key", "singleton_key TINYINT AS (1) VIRTUAL")
+        table.add_key(name, "UNIQUE KEY %s (singleton_key)" % name)
+        return "-- %s is enforced by the singleton_key generated column on %s" % (name, table.name)
+
+    # `(rule_id, COALESCE(uri_pattern, ''))` — NULL이 유일성을 무력화하면 안 된다.
+    # `(lower(name))` — 대소문자 무시 유일성. utf8mb4_bin 콜레이션만으로는 얻을 수
+    # 없다.
+    specs, gen_cols = [], []
+    for expr in exprs:
+        lm = re.match(r"^lower\(\s*\(?([A-Za-z_0-9]+)\)?(?:::text)?\s*\)$", expr, re.IGNORECASE)
+        if lm:
+            src = lm.group(1)
+            gen_name = "%s_lower" % src
+            src_type = table.column_types.get(src, "VARCHAR(255)")
+            gen_type = "VARCHAR(512)" if src_type.split("(")[0].upper() in (
+                "TEXT", "LONGTEXT", "MEDIUMTEXT", "TINYTEXT") else src_type
+            table.add_generated(gen_name, "%s %s AS (LOWER(%s)) VIRTUAL" % (gen_name, gen_type, src))
+            gen_cols.append(gen_name)
+            specs.append(gen_name)
+            continue
+
+        cm = re.match(r"^COALESCE\(\s*([A-Za-z_0-9]+)\s*,\s*''(?:::text)?\s*\)$", expr, re.IGNORECASE)
+        if cm:
+            src = cm.group(1)
+            gen_name = "%s_key" % src
+            src_type = table.column_types.get(src, "TEXT")
+            gen_type = "VARCHAR(512)" if src_type.split("(")[0].upper() in (
+                "TEXT", "LONGTEXT", "MEDIUMTEXT", "TINYTEXT") else src_type
+            table.add_generated(gen_name, "%s %s AS (COALESCE(%s, '')) VIRTUAL" % (gen_name, gen_type, src))
+            gen_cols.append(gen_name)
+            specs.append(gen_name)
+        else:
+            col = expr.strip("()").strip()
+            spec, _ = index_column_spec(table, col, unique, 512 * BYTES_PER_CHAR)
+            specs.append(spec)
+
+    if gen_cols:
+        table.add_key(name, "UNIQUE KEY %s (%s)" % (name, ", ".join(specs)))
+        return "-- %s is enforced by generated column(s) %s on %s" % (
+            name, ", ".join(gen_cols), table.name)
+
+    return "-- skipped (unsupported expression index): %s" % name
+
+
+def translate_partial_unique_index(name: str, table: Table, col_list: list[str], where: str) -> str:
+    """실제 보장이 WHERE 절에 담겨 있는 UNIQUE 인덱스.
+
+    부분 인덱스는 없지만, 술어 바깥에서 NULL로 평가되는 생성 컬럼이 그 의미를
+    정확히 재현한다. 유니크 인덱스는 NULL을 무시하므로 제외된 행은 그냥 참여하지
+    않는다.
+    """
+    cols = [c.strip().strip('"') for c in col_list]
+    predicate = " ".join(where.split()).strip("()")
+    predicate = re.sub(r"::\s*(?:public\.)?[A-Za-z_0-9]+(\[\])?", "", predicate)
+    predicate = predicate.replace(" <> ", " != ")
+
+    gen_name = "%s_key" % name.replace("idx_", "").replace("_unique", "")[:48]
+    parts = []
+    for c in cols:
+        t = table.column_types.get(c, "TEXT").split("(")[0].upper()
+        parts.append("COALESCE(CAST(%s AS CHAR), '')" % c if t not in ("VARCHAR", "CHAR") else "COALESCE(%s, '')" % c)
+    concat = "CONCAT_WS('\\n', %s)" % ", ".join(parts)
+
+    table.add_generated(gen_name, "%s VARCHAR(768) AS (CASE WHEN %s THEN %s END) VIRTUAL" % (
+        gen_name, predicate, concat))
+    table.add_key(name, "UNIQUE KEY %s (%s)" % (name, gen_name))
+    return "-- %s is enforced by the %s generated column on %s (WHERE %s)" % (
+        name, gen_name, table.name, predicate)
+
+
+# ---------------------------------------------------------------------------
+# 렌더링
+# ---------------------------------------------------------------------------
+
+MONTH_END = re.compile(r"^(\d{4})-(\d{2})-(\d{2})")
+
+
+def render_partitions(parent: str, ranges: list[tuple[str, str]]) -> str:
+    lines = []
+    for child, upper in ranges:
+        pname = child.replace("logs_", "").replace("stats_hourly_", "")
+        if not pname.startswith("p"):
+            pname = "p" + pname
+        boundary = upper.split("+")[0].strip()
+        lines.append("    PARTITION %s VALUES LESS THAN ('%s')" % (pname, boundary))
+    lines.append("    PARTITION p_max VALUES LESS THAN (MAXVALUE)")
+    return ",\n".join(lines)
+
+
+def render_table(table: Table, ranges: dict[str, list[tuple[str, str]]],
+                 auto_update: set[str]) -> str:
+    lines = []
+    for name, mysql_type, tail in table.columns:
+        piece = "    %s %s" % (quote_ident(name), mysql_type)
+        if tail:
+            piece += " " + tail
+        # PostgreSQL의 updated_at 트리거는 여기서 컬럼 속성이 된다.
+        if name == "updated_at" and table.name in auto_update:
+            piece += " ON UPDATE CURRENT_TIMESTAMP(6)"
+        lines.append(piece)
+
+    lines.extend("    %s" % g for g in table.generated)
+    lines.extend("    %s" % c for c in table.constraints if c)
+    lines.extend("    %s" % k for k in table.extra_keys)
+
+    body = ",\n".join(lines)
+    options = "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin"
+    if table.name in COMPRESSED_TABLES:
+        options += " PAGE_COMPRESSED=1 PAGE_COMPRESSION_LEVEL=%d" % PAGE_COMPRESSION_LEVEL
+    out = "CREATE TABLE IF NOT EXISTS %s (\n%s\n) %s" % (table.name, body, options)
+    if table.doc:
+        out = table.doc + "\n" + out
+
+    if table.partition_by and table.name in ranges:
+        out += "\nPARTITION BY RANGE COLUMNS(%s) (\n%s\n)" % (
+            table.partition_by, render_partitions(table.name, ranges[table.name]))
+    return out + ";"
+
+
+# MariaDB reserved words that occur, or plausibly could occur, as column names
+# in this schema. ANSI_QUOTES is enabled on every connection, so double quotes
+# are identifier quotes on both backends and the same DDL parses either way.
+RESERVED = {
+    "key", "keys", "timestamp", "rows", "row", "groups", "group", "rank", "over",
+    "window", "recursive", "system", "lead", "lag", "order", "range", "read",
+    "usage", "condition", "interval", "match", "option", "status", "call",
+    "signal", "resource", "references", "leave", "release", "purge", "current_role",
+}
+
+
+def quote_ident(name: str) -> str:
+    return '"%s"' % name if name.lower() in RESERVED else name
+
+
+def fix_partitioned_keys(table: Table) -> None:
+    """모든 유니크 키는 파티션 컬럼을 포함해야 한다."""
+    if not table.partition_by:
+        return
+    part = table.partition_by
+
+    def add_part(cols: str) -> str:
+        names = [c.strip() for c in cols.split(",")]
+        if part not in names:
+            names.append(part)
+        return ", ".join(names)
+
+    new_constraints = []
+    for c in table.constraints:
+        m = re.match(r"^PRIMARY KEY \((.*)\)$", c)
+        if m:
+            new_constraints.append("PRIMARY KEY (%s)" % add_part(m.group(1)))
+            continue
+        m = re.match(r"^UNIQUE KEY (\S*) \((.*)\)$", c)
+        if m:
+            new_constraints.append("UNIQUE KEY %s (%s)" % (m.group(1), add_part(m.group(2))))
+            continue
+        # 파티션 테이블은 외래 키에 아예 참여할 수 없다.
+        if "FOREIGN KEY" in c.upper():
+            continue
+        new_constraints.append(c)
+    table.constraints = new_constraints
+
+    # 컬럼 수준 PRIMARY KEY/UNIQUE는 두 번째 컬럼을 포함할 수 없다. 승격한다.
+    promoted = []
+    for i, (name, mysql_type, tail) in enumerate(table.columns):
+        if re.search(r"\bPRIMARY KEY\b", tail):
+            tail = re.sub(r"\s*\bPRIMARY KEY\b", "", tail).strip()
+            promoted.append("PRIMARY KEY (%s, %s)" % (name, part))
+        if re.search(r"\bUNIQUE\b", tail):
+            tail = re.sub(r"\s*\bUNIQUE\b", "", tail).strip()
+            promoted.append("UNIQUE KEY uq_%s_%s (%s, %s)" % (table.name, name, name, part))
+        table.columns[i] = (name, mysql_type, tail)
+    table.constraints.extend(promoted)
+
+
+def apply_alter(stmt: str, tables: dict[str, Table]) -> None:
+    """지연된 ALTER TABLE 제약을 테이블 정의 안으로 접어 넣는다.
+
+    PostgreSQL 스키마는 pg_dump가 내보내는 방식대로 대부분의 기본 키와 유니크 키를
+    사후에 선언한다. ALTER TABLE ADD CONSTRAINT 자체는 받아주지만 키에 대해서는
+    IF NOT EXISTS를 붙일 수 없는데, 이 파일은 멱등해야 하므로 제약을 CREATE TABLE
+    안으로 옮긴다. 외래 키는 대상이 생기기 전에 실행되면 안 되므로 지연된 채로
+    둔다.
+    """
+    s_ = " ".join(stmt.split())
+    m = re.match(
+        r"^ALTER\s+TABLE\s+(?:ONLY\s+)?(?:public\.)?([A-Za-z_0-9]+)\s+ADD\s+CONSTRAINT\s+"
+        r"([A-Za-z_0-9]+)\s+(.*)$", s_, re.IGNORECASE)
+    if not m:
+        return
+    table_name, cname, body = m.groups()
+    table = tables.get(table_name)
+    if table is None:
+        return
+
+    if re.match(r"^PRIMARY\s+KEY", body, re.IGNORECASE):
+        cols = normalise_columns(re.search(r"\((.*?)\)", body).group(1))
+        if not any(c.startswith("PRIMARY KEY") for c in table.constraints) and not has_inline_pk(table):
+            table.constraints.insert(0, "PRIMARY KEY (%s)" % cols)
+        return
+
+    if re.match(r"^UNIQUE", body, re.IGNORECASE):
+        cols = normalise_columns(re.search(r"\((.*?)\)", body).group(1))
+        table.add_key(cname, "UNIQUE KEY %s (%s)" % (cname, cols))
+        return
+
+    if re.match(r"^FOREIGN\s+KEY", body, re.IGNORECASE):
+        body = re.sub(r"REFERENCES\s+public\.", "REFERENCES ", body, flags=re.IGNORECASE)
+        if not any(n == cname for n, _ in table.foreign_keys):
+            table.foreign_keys.append((cname, body))
+        return
+
+    if re.match(r"^CHECK", body, re.IGNORECASE):
+        translated = translate_check(body)
+        if translated:
+            table.constraints.append("CONSTRAINT %s %s" % (cname, translated))
+
+
+def has_inline_pk(table: Table) -> bool:
+    return any("PRIMARY KEY" in tail for _, _, tail in table.columns)
+
+
+KEY_CLAUSE_RE = re.compile(r"^(PRIMARY KEY|UNIQUE KEY(?: \S+)?|CONSTRAINT \S+ UNIQUE) \((.*)\)$")
+
+
+def apply_key_prefixes(table: Table) -> None:
+    """모든 키 절을 유효한 형태로 만든다.
+
+    PostgreSQL 원본은 신경 쓸 필요가 없는 두 가지가 있다. InnoDB는 접두사 길이
+    없는 TEXT 컬럼을 키에 넣는 것을 거부하고, 예약어를 이름으로 쓴 컬럼은 인용해야
+    한다. 인라인·지연·인덱스 유래 키 절을 모두 모은 뒤 여기서 둘 다 적용한다.
+    """
+    generated_names = {g.split()[0] for g in table.generated}
+
+    def fix(clause: str) -> str:
+        m = KEY_CLAUSE_RE.match(clause)
+        if not m:
+            return clause
+        head, cols = m.groups()
+        entries = [c.strip() for c in cols.split(",")]
+
+        def is_text(col: str) -> bool:
+            return table.column_types.get(col.strip('"'), "").split("(")[0].upper() in (
+                "TEXT", "LONGTEXT", "MEDIUMTEXT", "TINYTEXT", "JSON")
+
+        # A prefix on a UNIQUE key narrows the guarantee to those first
+        # characters, so give text columns as much of the 3072-byte budget as
+        # is left after the fixed-width members. MariaDB would otherwise
+        # silently switch the whole key to USING HASH and MySQL would reject it
+        # outright — neither is what the PostgreSQL constraint says.
+        unique = "UNIQUE" in head.upper()
+        fixed = sum(type_key_bytes(table.column_types.get(c.strip('"'), "INT"))
+                    for c in entries if "(" not in c and not is_text(c))
+        text_members = max(1, sum(1 for c in entries if "(" not in c and is_text(c)))
+        budget = max(64, (MAX_KEY_BYTES - fixed) // text_members // BYTES_PER_CHAR)
+        prefix = min(budget, 768) if unique else TEXT_INDEX_PREFIX
+
+        rendered = []
+        for col in entries:
+            if "(" in col or col in generated_names:
+                rendered.append(col)  # 이미 접두사가 붙었거나 생성 컬럼이다
+                continue
+            base = col.strip('"')
+            if is_text(col):
+                rendered.append("%s(%d)" % (quote_ident(base), prefix))
+            else:
+                rendered.append(quote_ident(base))
+        return "%s (%s)" % (head, ", ".join(rendered))
+
+    table.constraints = [fix(c) for c in table.constraints]
+    table.extra_keys = [fix(k) for k in table.extra_keys]
+
+
+def ensure_primary_key(table: Table) -> None:
+    """InnoDB에 명시적인 클러스터 키를 준다.
+
+    싱글턴 설정 테이블들(global_waf, cloudflare_tunnel, ...)은 PostgreSQL에서
+    기본 키가 없다. 상수 식 `(true)`에 건 유니크 인덱스가 행 하나로 묶어 준다.
+    그래도 `id` 컬럼은 실질적으로 유일하므로, 그것을 기본 키로 지정하면 InnoDB가
+    보이지 않는 rowid가 아니라 의미 있는 것을 기준으로 클러스터링한다.
+    """
+    if has_inline_pk(table) or any(c.startswith("PRIMARY KEY") for c in table.constraints):
+        return
+    if any(name == "id" for name, _, _ in table.columns):
+        table.constraints.insert(0, "PRIMARY KEY (id)")
+
+
+def render_foreign_keys(tables: dict[str, Table]) -> list[str]:
+    """모든 테이블이 생긴 뒤에 외래 키를 내보낸다.
+
+    파티션 테이블은 어느 방향으로도 외래 키를 가질 수 없으므로, 조용히 버리지 않고
+    건너뛰었다고 표시한다.
+    """
+    partitioned = {name for name, t in tables.items() if t.partition_by}
+    out: list[str] = []
+    for name in sorted(tables):
+        table = tables[name]
+        for cname, body in table.foreign_keys:
+            # 원본 파일에는 컬럼이 migration.go의 업그레이드 단계에서야 추가되는
+            # 외래 키가 몇 개 있다. 그것들은 신규 설치의 기본 스키마가 아니라
+            # 업그레이드 경로에 속한다.
+            cols = re.search(r"FOREIGN KEY \(([^)]*)\)", body, re.IGNORECASE)
+            if cols and any(c.strip().strip('"') not in table.column_types
+                            for c in cols.group(1).split(",")):
+                out.append("-- skipped (column added by a later upgrade, not by this file): %s"
+                           % cname)
+                continue
+
+            target = re.search(r"REFERENCES\s+([A-Za-z_0-9]+)", body, re.IGNORECASE)
+            if name in partitioned or (target and target.group(1) in partitioned):
+                out.append("-- skipped (%s is partitioned; MariaDB forbids foreign keys there): %s"
+                           % (name if name in partitioned else target.group(1), cname))
+                continue
+            body = re.sub(r"^FOREIGN\s+KEY", "FOREIGN KEY IF NOT EXISTS", body, count=1,
+                          flags=re.IGNORECASE)
+            out.append("ALTER TABLE %s ADD CONSTRAINT %s %s;" % (name, cname, body))
+    return out
+
+
+def main() -> int:
+    sql = SOURCE.read_text()
+    prepared = [strip_line_comments(s) for s in split_statements(sql)]
+    codes = [code for _, code in prepared]
+
+    enums = parse_enums(codes)
+    ranges = parse_partition_ranges(codes)
+    tables = parse_tables(prepared, enums)
+
+    auto_update = {
+        m.group(1)
+        for stmt in codes
+        for m in [re.search(r"CREATE\s+TRIGGER\s+\S+\s+BEFORE\s+UPDATE\s+ON\s+(?:public\.)?([A-Za-z_0-9]+)",
+                            stmt, re.IGNORECASE)]
+        if m
+    }
+
+    # 지연된 제약을 먼저 처리한다. 거의 모든 테이블의 기본 키가 이 경로로 오고,
+    # 아래 인덱스 단계가 그 존재를 알아야 한다.
+    for stmt in codes:
+        apply_alter(stmt, tables)
+
+    # 렌더링보다 인덱스를 먼저 번역한다. 식 인덱스와 부분 유니크 규칙이 테이블
+    # 정의에 생성 컬럼을 추가하기 때문이다.
+    index_lines: list[str] = []
+    for stmt in codes:
+        if re.match(r"^CREATE\s+(UNIQUE\s+)?INDEX", stmt.strip(), re.IGNORECASE):
+            out = translate_index(stmt, tables)
+            if out:
+                index_lines.append(out)
+
+    for table in tables.values():
+        ensure_primary_key(table)
+        fix_partitioned_keys(table)
+        apply_key_prefixes(table)
+
+    alter_lines = render_foreign_keys(tables)
+
+    parts: list[str] = [HEADER]
+
+    parts.append("-- " + "-" * 74 + "\n-- Tables\n-- " + "-" * 74)
+    for name in sorted(tables):
+        parts.append(render_table(tables[name], ranges, auto_update))
+
+    parts.append("\n-- " + "-" * 74 + "\n-- Indexes\n-- " + "-" * 74)
+    parts.extend(index_lines)
+
+    parts.append("\n-- " + "-" * 74 + "\n-- Foreign keys and deferred constraints\n-- " + "-" * 74)
+    parts.extend(alter_lines)
+
+    TARGET.parent.mkdir(parents=True, exist_ok=True)
+    TARGET.write_text("\n".join(parts) + "\n")
+
+    UPGRADES_TARGET.write_text("\n".join(build_upgrades(enums, tables)) + "\n")
+
+    print("wrote %s" % TARGET.relative_to(ROOT))
+    print("  tables : %d" % len(tables))
+    print("  indexes: %d (%d skipped)" % (
+        len([l for l in index_lines if l.startswith("CREATE")]),
+        len([l for l in index_lines if l.startswith("--")])))
+    print("  alters : %d" % len([l for l in alter_lines if l.startswith("ALTER")]))
+    print("  enums  : %s" % ", ".join(sorted(enums)))
+    return 0
+
+
+HEADER = """-- Nginx Proxy Guard — MariaDB/MySQL 초기 스키마
+--
+-- 생성된 파일입니다. 직접 수정하지 마세요.
+-- 원본   : api/internal/database/migrations/001_init.sql (PostgreSQL)
+-- 재생성 : python3 scripts/pg2mariadb-schema.py
+--
+-- 멱등합니다. 모든 객체를 IF NOT EXISTS로 생성합니다.
+"""
+
+
+
+# ---------------------------------------------------------------------------
+# 업그레이드 문장 (migration.go)
+#
+# 신규 설치에는 001_init.sql만으로 부족하다. migration.go의 업그레이드 목록이
+# 컬럼과 테이블, 그리고 결정적으로 PostgreSQL 초기 파일에는 전혀 없는 exploit
+# 차단 규칙 시드 행을 추가하기 때문이다. 그 항목들을 여기서 두 번째 파일로
+# 번역하고, 러너가 부팅할 때마다 재실행한다. PostgreSQL 경로가 자기 목록을
+# 재실행하는 것과 똑같다.
+# ---------------------------------------------------------------------------
+
+UPGRADES_SOURCE = ROOT / "api/internal/database/migration.go"
+UPGRADES_TARGET = ROOT / "api/internal/database/migrations/mariadb/002_upgrades.sql"
+
+DESC_RE = re.compile(r'desc:\s*"((?:[^"\\]|\\.)*)"\s*,\s*sql:\s*', re.S)
+
+
+def read_go_string(src: str, pos: int) -> tuple[str, int]:
+    """Go 문자열 식을 읽는다. `+` 연결도 따라간다.
+
+    업그레이드 문장 중 몇 개는 백틱을 끼워 넣기 위해 원시 문자열을 중간에 끊는다.
+    원시 문자열 안에는 백틱을 넣을 수 없기 때문이다. 백틱으로 둘러싸인 첫 구간만
+    읽으면 그런 문장이 리터럴 도중에 잘리고, 실제로 exploit 규칙 시드가 조용히
+    누락됐었다.
+    """
+    parts: list[str] = []
+    n = len(src)
+    while pos < n:
+        while pos < n and src[pos] in " \t\n\r":
+            pos += 1
+        if pos >= n:
+            break
+        if src[pos] == "`":
+            end = src.index("`", pos + 1)
+            parts.append(src[pos + 1:end])
+            pos = end + 1
+        elif src[pos] == '"':
+            j = pos + 1
+            buf = []
+            while j < n and src[j] != '"':
+                if src[j] == "\\":
+                    esc = src[j + 1]
+                    buf.append({"n": "\n", "t": "\t", "r": "\r"}.get(esc, esc))
+                    j += 2
+                    continue
+                buf.append(src[j])
+                j += 1
+            parts.append("".join(buf))
+            pos = j + 1
+        else:
+            break
+        # 명시적인 연결이 있을 때만 이어서 읽는다.
+        save = pos
+        while pos < n and src[pos] in " \t\n\r":
+            pos += 1
+        if pos < n and src[pos] == "+":
+            pos += 1
+            continue
+        pos = save
+        break
+    return "".join(parts), pos
+
+
+def parse_upgrade_entries(src: str) -> list[tuple[str, str]]:
+    entries: list[tuple[str, str]] = []
+    for m in DESC_RE.finditer(src):
+        body, _ = read_go_string(src, m.end())
+        if body:
+            entries.append((m.group(1), body))
+    return entries
+
+# PostgreSQL이나 TimescaleDB만을 위해 존재하는 구문들. 이것들을 건너뛰는 것은
+# 누락이 아니라 올바른 처리다. 대상 스키마에는 그런 개념 자체가 없거나, 같은
+# 보장을 다른 방식으로 표현한다(부분 유니크 인덱스에 대해서는 001_init.sql의
+# 생성 컬럼 참고).
+POSTGRES_ONLY_MARKERS = (
+    "DO $$", "ALTER TYPE", "timescaledb", "pg_inherits", "pg_extension",
+    "pg_constraint", "pg_class", "information_schema", "ALTER INDEX",
+    "USING gin", "logs_unified", "regclass",
+    # DELETE ... USING은 PostgreSQL의 다중 테이블 삭제다. 유일한 쓰임새는 유니크
+    # 인덱스보다 먼저 생긴 중복 행을 한 번 정리하는 것인데, 이쪽에서는 그 인덱스가
+    # 첫 부팅부터 (생성 컬럼으로) 존재하므로 정리 대상 중복이 생길 수 없다.
+    "DELETE FROM dashboard_stats_hourly a",
+)
+
+
+def is_postgres_only(sql: str) -> tuple[bool, str]:
+    for marker in POSTGRES_ONLY_MARKERS:
+        if marker.lower() in sql.lower():
+            return True, marker
+    # 술어가 붙은 UNIQUE 인덱스는 힌트가 아니라 제약이다. 001_init.sql이 생성
+    # 컬럼으로 대신 재현한다.
+    if re.search(r"CREATE\s+UNIQUE\s+INDEX", sql, re.I) and re.search(r"\bWHERE\b", sql, re.I):
+        return True, "partial unique index (generated column in 001_init.sql)"
+    return False, ""
+
+
+def convert_column_definition(text: str, enums: dict[str, list[str]]) -> str:
+    col = parse_column(text.strip(), enums)
+    if not col:
+        raise ValueError("cannot parse column definition: %r" % text)
+    name, mysql_type, tail, _ = col
+    return " ".join(x for x in (quote_ident(name), mysql_type, tail) if x)
+
+
+def convert_upgrade(sql: str, enums: dict[str, list[str]],
+                    tables: dict[str, Table]) -> list[str] | None:
+    """업그레이드 문장 하나를 번역한다. 불가능하면 None을 돌려준다."""
+    out: list[str] = []
+    for stmt in split_statements(sql):
+        _, code = strip_line_comments(stmt)
+        if not code:
+            continue
+
+        m = re.match(r"^ALTER\s+TABLE\s+(?:public\.)?([A-Za-z_0-9]+)\s+ADD\s+COLUMN\s+"
+                     r"(?:IF\s+NOT\s+EXISTS\s+)?(.*)$", code, re.I | re.S)
+        if m:
+            table, definition = m.group(1), m.group(2)
+            out.append("ALTER TABLE %s ADD COLUMN IF NOT EXISTS %s;" % (
+                table, convert_column_definition(definition, enums)))
+            continue
+
+        m = re.match(r"^ALTER\s+TABLE\s+(?:public\.)?([A-Za-z_0-9]+)\s+ALTER\s+COLUMN\s+"
+                     r"([A-Za-z_0-9]+)\s+SET\s+DEFAULT\s+(.*)$", code, re.I | re.S)
+        if m:
+            default = map_default(m.group(3), enums)
+            if default is None:
+                return None
+            out.append("ALTER TABLE %s ALTER COLUMN %s SET DEFAULT %s;" % (
+                m.group(1), quote_ident(m.group(2)), default))
+            continue
+
+        m = re.match(r"^ALTER\s+TABLE\s+(?:public\.)?([A-Za-z_0-9]+)\s+"
+                     r"DROP\s+CONSTRAINT\s+IF\s+EXISTS\s+([A-Za-z_0-9]+)$", code, re.I)
+        if m:
+            # 유니크 제약에 대해서는 DROP INDEX로 적는다. 두 형태를 모두
+            # 시도하고, 실패는 러너가 감내한다.
+            out.append("ALTER TABLE %s DROP INDEX IF EXISTS %s;" % (m.group(1), m.group(2)))
+            continue
+
+        if re.match(r"^CREATE\s+TABLE", code, re.I):
+            rendered = convert_upgrade_table(code, enums, tables)
+            if rendered is None:
+                return None
+            out.append(rendered)
+            continue
+
+        if re.match(r"^CREATE\s+(UNIQUE\s+)?INDEX", code, re.I):
+            rendered = translate_index(code, tables)
+            if rendered is None or rendered.startswith("--"):
+                return None
+            out.append(rendered)
+            continue
+
+        if re.match(r"^(INSERT|UPDATE|DELETE)\b", code, re.I):
+            out.append(convert_dml(code) + ";")
+            continue
+
+        return None
+    return out
+
+
+def convert_upgrade_table(code: str, enums: dict[str, list[str]],
+                          tables: dict[str, Table]) -> str | None:
+    """업그레이드 목록에 나오는 CREATE TABLE을 렌더링한다."""
+    parsed = parse_tables([("", code)], enums)
+    if not parsed:
+        return None
+    table = next(iter(parsed.values()))
+    ensure_primary_key(table)
+    apply_key_prefixes(table)
+    # 이후 업그레이드 인덱스가 컬럼 타입을 해석할 수 있도록 등록해 둔다.
+    tables.setdefault(table.name, table)
+
+    rendered = render_table(table, {}, set())
+    for cname, body in table.foreign_keys:
+        body = re.sub(r"^FOREIGN\s+KEY", "FOREIGN KEY IF NOT EXISTS", body, count=1, flags=re.I)
+        rendered += "\nALTER TABLE %s ADD CONSTRAINT %s %s;" % (table.name, cname, body)
+    return rendered
+
+
+def convert_dml(code: str) -> str:
+    """시드 INSERT나 데이터 보정용 UPDATE/DELETE를 번역한다."""
+    out = re.sub(r"\bpublic\.", "", code)
+
+    # ON CONFLICT (id) DO NOTHING -> 아무 일도 하지 않는 자기 대입. 중복 키만
+    # 삼키고 나머지는 삼키지 않는다. 이유는 Go 번역기 쪽 설명 참고.
+    m = re.search(r"\s+ON\s+CONFLICT\s*\(\s*([A-Za-z_0-9]+)\s*\)\s*DO\s+NOTHING\s*$", out, re.I)
+    if m:
+        col = m.group(1)
+        out = out[:m.start()] + " ON DUPLICATE KEY UPDATE %s = %s" % (col, col)
+
+    out = re.sub(r"\bE'", "'", out)
+    out = re.sub(r"::\s*(?:public\.)?[A-Za-z_0-9]+(\[\])?", "", out)
+    out = re.sub(r"\bnow\(\)", "CURRENT_TIMESTAMP(6)", out, flags=re.I)
+    out = re.sub(r"\bgen_random_uuid\(\)", "UUID()", out, flags=re.I)
+    out = re.sub(r"INTERVAL\s+'(\d+)\s+([a-z]+?)s?'",
+                 lambda mm: "INTERVAL %s %s" % (mm.group(1), mm.group(2).upper()), out, flags=re.I)
+    return out.strip().rstrip(";")
+
+
+def build_upgrades(enums: dict[str, list[str]], tables: dict[str, Table]) -> list[str]:
+    src = UPGRADES_SOURCE.read_text()
+    entries = parse_upgrade_entries(src)
+    if not entries:
+        raise SystemExit("no upgrade entries parsed from migration.go — has its shape changed?")
+
+    lines = [UPGRADES_HEADER]
+    applied = skipped = 0
+    for desc, sql in entries:
+        postgres_only, marker = is_postgres_only(sql)
+        if postgres_only:
+            lines.append("-- skipped (%s): %s" % (marker, desc))
+            skipped += 1
+            continue
+        try:
+            rendered = convert_upgrade(sql, enums, tables)
+        except (ValueError, SystemExit):
+            rendered = None
+        if rendered is None:
+            lines.append("-- skipped (no mechanical translation): %s" % desc)
+            skipped += 1
+            continue
+        lines.append("-- %s" % desc)
+        lines.extend(rendered)
+        applied += 1
+
+    print("  upgrades: %d translated, %d skipped" % (applied, skipped))
+    return lines
+
+
+UPGRADES_HEADER = """-- Nginx Proxy Guard — MariaDB/MySQL 업그레이드 문장
+--
+-- 생성된 파일입니다. 직접 수정하지 마세요.
+-- 원본   : api/internal/database/migration.go (`upgrades` 슬라이스)
+-- 재생성 : python3 scripts/pg2mariadb-schema.py
+--
+-- Replayed on every boot, like its PostgreSQL counterpart: every statement is
+-- idempotent, and the runner logs rather than aborts when one fails.
+"""
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
데이터베이스 백엔드를 DATABASE_URL 스킴으로 고른다. PostgreSQL이 여전히 기본값이며 동작은 그대로다. mysql:// 와 mariadb:// 가 새 경로를 선택한다. MySQL 계열 두 서버 중 실제로 어느 쪽이 떠 있는지는 서버에 직접 물어서 정하므로
(MariaDB는 VERSION()에 자기 이름을 넣는다) 스킴을 반대로 적어도 문제가 없다.

  docker compose -f docker-compose.yml -f docker-compose.mariadb.yml up -d
  docker compose -f docker-compose.yml -f docker-compose.mysql.yml up -d

접근 방식

리포지토리 코드 2만 줄은 PostgreSQL을 모국어로 쓴다. $N 플레이스홀더,
ON CONFLICT, RETURNING, text[], jsonb, COUNT(*) FILTER 같은 것들이다. 63개 파일을 갈라내는 대신 한 층 아래에서 번역한다. 각 문장을 서버로 보내는 길에
재작성하는 database/sql 드라이버다. 리포지토리는 Postgres 방언 질의문 한 벌을 그대로 유지하고, 준비된 문장·트랜잭션·단발성 질의가 모두 같은 경로로 처리된다.

충실한 대응물이 없는 구문은 최선을 다한 재작성 대신 오류를 낸다. 잘못된 번역은
몇 달 뒤 대시보드 숫자가 망가진 형태로 드러난다. 프로젝트가 실제로 쓰는 그런
구문(배열·JSON 연산자, COPY, 카탈로그 함수)은 호출부에서 dialect로 분기한다. TestEveryQueryTranslates가 internal/ 아래 모든 SQL 리터럴을 훑으며 번역되지 않는 질의가 새로 들어오면 실패하므로, 이 구조는 방치돼도 썩지 않는다.

RETURNING

MariaDB에는 UPDATE ... RETURNING이 없고 MySQL에는 RETURNING이 아예 없다. 해당 문장은 쓰기와 같은 행을 읽는 SELECT로 나뉘어 한 트랜잭션 안에서 실행되고 결과는
버퍼링된다. UPDATE는 자기 술어로 재조회하되, 그 술어가 SET 대상 컬럼을 검사하면 거부한다. 업서트는 충돌 대상을 키로 쓴다. MySQL의 평범한 INSERT는 조회할 키가 있어야 하므로 UUID를 드라이버가 만들어 명시적으로 삽입한다. DELETE는 먼저 읽는다.

스키마

migrations/mariadb/ 는 scripts/pg2mariadb-schema.py 가 PostgreSQL 스키마에서 생성한다. 001_init.sql을 고쳤다면 다시 돌려야 한다. 두 엔진이 같은 파일을
실행하며, MySQL이 거부하는 소수의 구문만 실행 도중 재작성한다. 하이퍼테이블은
네이티브 월별 RANGE 파티션이 되고, 부분 유니크 인덱스는 술어를 그대로 재현하는
생성 컬럼이 되며, enum은 인라인되고, text[]는 PostgreSQL 배열 리터럴로 남아 lib/pq의 코덱이 양쪽에서 그대로 동작한다.

로그 저장

대용량 테이블에 InnoDB 페이지 압축을 적용했다. 실제 형태의 액세스 로그 20만 행
기준 logs_partitioned가 논리 317MB 대비 디스크 60MB를 쓴다. 압축 레벨은 기본값 6이 아니라 1이다. 로그 데이터에서는 두 레벨의 결과 크기가 같은데 레벨 6은 쓰기에
2.7배가 걸리고, 로그 수집이 여기서 가장 쓰기가 많은 경로이기 때문이다.

로그 텍스트 검색은 유일하게 메우지 못한 격차다. PostgreSQL은 pg_trgm으로 임의의 %부분문자열% 매칭을 인덱스로 처리하지만, MySQL 계열에는 트라이그램 인덱스가 없고
단어 단위 FULLTEXT로는 부분 토큰 질의를 아예 처리할 수 없다. 검색창의 동작을
조용히 바꾸는 대신 스캔하되, 질의가 선택한 기간 범위로 월별 파티션이 프루닝된다.

공유 코드

리포지토리 질의 몇 개를 두 엔진이 모두 받아주는 형태로 바꿨다. `= ANY($1)`은 IN 목록이 됐고, 파라미터화된 interval 캐스트는 단위를 SQL로 끌어올렸으며, 인증서
복구 UPDATE는 RETURNING에 기대는 대신 대상 id를 먼저 모은다.
tests/integration/postgres_dialect_test.go 가 바로 그 경로들을 PostgreSQL에서 다시 검증한다.

잠재 위험 하나도 함께 고쳤다. libpq의 sslmode 파라미터를 남긴 채 스킴만 바꾼 URL은 "Unknown system variable"로 접속에 실패했다. MySQL 드라이버가 알 수 없는 파라미터를 SET으로 재생하기 때문이다. 이제 변환하거나 제거한다.