### PR TITLE
fix(sso): preserve trailing slash in OIDC issuer

### DIFF
--- a/api/internal/service/sso.go
+++ b/api/internal/service/sso.go
@@ -414,7 +414,7 @@ func (s *SSOService) discover(ctx context.Context, issuer string) (*oidc.Provide
 	}
 	s.mu.Unlock()
 
-	provider, err := oidc.NewProvider(ctx, strings.TrimRight(issuer, "/"))
+	provider, err := oidc.NewProvider(ctx, issuer)
 	if err != nil {
 		log.Printf("SSO: discovery failed for %s: %v", issuer, err)
 		return nil, ErrSSODiscovery

--- a/api/internal/service/sso_userinfo_test.go
+++ b/api/internal/service/sso_userinfo_test.go
@@ -146,3 +146,34 @@ func TestAFailingUserInfoLookupChangesNothing(t *testing.T) {
 		t.Errorf("a failed lookup damaged the token's own claims: %+v", claims)
 	}
 }
+
+func TestDiscoverPreservesTrailingSlashInIssuer(t *testing.T) {
+	mux := http.NewServeMux()
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	//trailing slash가 있는 issuer
+	issuer := srv.URL + "/application/o/test/"
+
+	mux.HandleFunc("/application/o/test/.well-known/openid-configuration",
+		func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"issuer":                 issuer,
+				"authorization_endpoint": srv.URL + "/auth",
+				"token_endpoint":         srv.URL + "/token",
+				"jwks_uri":               srv.URL + "/keys",
+			})
+		},
+	)
+
+	s := NewSSOService(nil, nil, nil, nil, nil)
+
+	provider, err := s.discover(context.Background(), issuer)
+	if err != nil {
+		t.Fatalf("discovery failed for issuer with trailing slash: %v", err)
+	}
+	if provider == nil {
+		t.Fatal("discovery returned nil provider")
+	}
+}


### PR DESCRIPTION
## 개요

OIDC Provider 생성 시 사용자가 설정한 Issuer URL을 그대로 전달하도록 수정했습니다.

## 문제

Authentik의 애플리케이션별 OIDC Issuer URL은 다음과 같이 trailing slash(`/`)를 포함합니다.

```text
https://auth.example.com/application/o/example/
````

기존 NginxProxyGuard에서는 `oidc.NewProvider` 호출 전에 trailing slash를 제거하고 있었습니다.

```go
oidc.NewProvider(ctx, strings.TrimRight(issuer, "/"))
```

`go-oidc`는 사용자가 전달한 Issuer URL과 Discovery 문서에서 반환된 `issuer` 값을 정확히 비교합니다.

따라서 사용자가 다음과 같이 설정해도:

```text
https://auth.example.com/application/o/example/
```

내부적으로는 다음과 같이 변경되어:

```text
https://auth.example.com/application/o/example
```

Discovery 문서에서 반환된 값과 불일치가 발생했고 OIDC Discovery가 실패했습니다.

## 수정 내용

Issuer URL을 변경하지 않고 그대로 `oidc.NewProvider`에 전달하도록 수정했습니다.

```go
oidc.NewProvider(ctx, issuer)
```

## 테스트

trailing slash가 포함된 OIDC Issuer에 대한 회귀 테스트를 추가했습니다.

기존 구현에서는 Issuer mismatch로 테스트가 실패하는 것을 확인했고, 수정 후 동일 테스트가 정상 통과하는 것을 확인했습니다.

```text
=== RUN   TestDiscoverPreservesTrailingSlashInIssuer
--- PASS: TestDiscoverPreservesTrailingSlashInIssuer
PASS
```

추가한 회귀 테스트 및 `internal/service`를 포함한 일반 Go 패키지 테스트가 정상 통과하는 것을 확인했습니다.