### PR TITLE
fix(ui): generate TOTP QR codes locally

### DIFF
--- a/ui/nginx.conf
+++ b/ui/nginx.conf
@@ -24,7 +24,7 @@ server {
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-XSS-Protection "1; mode=block" always;
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdn.jsdelivr.net; font-src 'self' data: https://fonts.gstatic.com https://cdn.jsdelivr.net; img-src 'self' data: https://api.qrserver.com; connect-src 'self' https://cdn.jsdelivr.net; frame-ancestors 'none'; base-uri 'self'; object-src 'none'" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdn.jsdelivr.net; font-src 'self' data: https://fonts.gstatic.com https://cdn.jsdelivr.net; img-src 'self' data:; connect-src 'self' https://cdn.jsdelivr.net; frame-ancestors 'none'; base-uri 'self'; object-src 'none'" always;
 
     # Gzip compression
     gzip on;
@@ -45,7 +45,7 @@ server {
         add_header X-Content-Type-Options "nosniff" always;
         add_header X-XSS-Protection "1; mode=block" always;
         add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdn.jsdelivr.net; font-src 'self' data: https://fonts.gstatic.com https://cdn.jsdelivr.net; img-src 'self' data: https://api.qrserver.com; connect-src 'self' https://cdn.jsdelivr.net; frame-ancestors 'none'; base-uri 'self'; object-src 'none'" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdn.jsdelivr.net; font-src 'self' data: https://fonts.gstatic.com https://cdn.jsdelivr.net; img-src 'self' data:; connect-src 'self' https://cdn.jsdelivr.net; frame-ancestors 'none'; base-uri 'self'; object-src 'none'" always;
 
         # Cache control
         add_header Cache-Control "no-cache, no-store, must-revalidate" always;

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -14,6 +14,7 @@
         "i18next": "^26.3.6",
         "i18next-browser-languagedetector": "^8.2.1",
         "prop-types": "^15.8.1",
+        "qrcode.react": "^4.2.0",
         "react": "^19.2.8",
         "react-datepicker": "^9.1.0",
         "react-dom": "^19.2.8",
@@ -3213,6 +3214,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/qrcode.react": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/qrcode.react/-/qrcode.react-4.2.0.tgz",
+      "integrity": "sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/react": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -16,6 +16,7 @@
     "i18next": "^26.3.6",
     "i18next-browser-languagedetector": "^8.2.1",
     "prop-types": "^15.8.1",
+    "qrcode.react": "^4.2.0",
     "react": "^19.2.8",
     "react-datepicker": "^9.1.0",
     "react-dom": "^19.2.8",

--- a/ui/src/components/account/TwoFactorTab.tsx
+++ b/ui/src/components/account/TwoFactorTab.tsx
@@ -1,4 +1,5 @@
 import { Trans, useTranslation } from 'react-i18next';
+import { QRCodeSVG } from 'qrcode.react';
 import type { AccountInfo, Setup2FAResponse, Disable2FARequest } from '../../api/auth';
 
 interface TwoFactorTabProps {
@@ -59,11 +60,15 @@ export function TwoFactorTab({
                 <p className="text-gray-500 dark:text-gray-400 mb-4">
                   {t('account.twoFactor.scanQR')}
                 </p>
-                <div className="inline-block bg-white p-4 rounded">
-                  <img
-                    src={`https://api.qrserver.com/v1/create-qr-code/?size=200x200&data=${encodeURIComponent(setup2FAData.qr_code_url)}`}
-                    alt="2FA QR Code"
-                    className="w-48 h-48"
+                <div
+                  className="inline-block bg-white p-4 rounded"
+                  role="img"
+                  aria-label="2FA QR Code"
+                >
+                  <QRCodeSVG
+                    value={setup2FAData.qr_code_url}
+                    size={192}
+                    level="M"
                   />
                 </div>
               </div>


### PR DESCRIPTION
## 변경 내용

- `qrcode.react`를 사용해 브라우저 내부에서 TOTP 등록 QR 코드를 생성합니다.
- TOTP 비밀키가 포함된 `api.qrserver.com` 요청을 제거합니다.
- UI Content Security Policy에서 `api.qrserver.com` 허용을 제거합니다.

## 이 수정이 필요한 이유

TOTP 등록용 QR 코드는 단순한 이미지가 아닙니다. QR 안에는 다음과 같이 계정의 장기 TOTP 비밀키가 포함된 전체 `otpauth://` 등록 URI가 들어 있습니다.

```text
otpauth://totp/...?...&secret=<TOTP_SECRET>
```

기존 UI는 이 URI를 외부 QR 생성 서비스의 쿼리 파라미터에 넣어 요청했습니다.

```text
https://api.qrserver.com/v1/create-qr-code/?data=<otpauth URI>
```

따라서 사용자가 2FA를 활성화하는 순간 TOTP 비밀키가 NginxProxyGuard 설치 환경 밖의 제3자에게 전달될 수 있었습니다. URL 쿼리 파라미터는 외부 서비스와 CDN, 접근 로그, 모니터링 시스템 등에 기록되거나 보관될 가능성이 있으며, 해당 시스템이 추후 침해되는 경우에도 노출될 수 있습니다.

TOTP 비밀키는 사용자가 2FA를 비활성화하거나 다시 등록하기 전까지 계속 유효합니다. 이 값을 확보한 사람은 동일한 일회용 인증 코드를 독립적으로 생성할 수 있으며, 사용자 비밀번호까지 유출된 상황에서는 2FA가 제공해야 하는 추가 보호를 우회할 수 있습니다.

QR 코드를 브라우저 내부에서 생성하면 이러한 불필요한 외부 신뢰 경계를 제거할 수 있습니다. `qrcode.react`가 등록 URI를 사용자 브라우저에서 바로 인라인 SVG로 변환하므로 TOTP 비밀키를 QR 제공업체나 다른 외부 서버에 전송할 필요가 없습니다. CSP에서도 외부 QR 도메인을 제거하여 동일한 외부 요청이 실수로 다시 도입되는 것을 방지합니다.

## 보안 효과

이 변경 이후에는 다음이 보장됩니다.

- TOTP 등록 URI가 사용자 브라우저 내부에만 유지됩니다.
- 외부 QR 생성 서비스로 요청하지 않습니다.
- QR 코드는 브라우저에서 생성한 인라인 SVG로 동일하게 스캔할 수 있습니다.
- `img-src`에서 `api.qrserver.com`을 허용할 필요가 없습니다.

기존 UI를 통해 이미 2FA를 등록한 사용자는 수정 버전을 배포한 뒤 2FA를 비활성화하고 다시 등록하는 것을 권장합니다. 이렇게 하면 기존 TOTP 비밀키와 백업 코드가 모두 새 값으로 교체됩니다.

## 검증

- `npm run build` ✅
- `npx eslint src/components/account/TwoFactorTab.tsx` ✅
- `npm audit --omit=dev` ✅ — 프로덕션 의존성 취약점 0건
- 소스 및 프로덕션 빌드 결과에 `api.qrserver.com`과 `create-qr-code` 참조가 남아 있지 않음을 확인했습니다.

저장소 전체 `npm run lint`에는 `RawLogFiles.tsx`와 `MethodBadge.tsx`의 기존 오류 3건이 남아 있습니다. 이번에 수정한 컴포넌트에서는 새로운 lint 오류가 발생하지 않습니다.