### PR TITLE
fix(api): validate redirect hosts before rendering

### DIFF
--- a/api/internal/handler/redirect_host.go
+++ b/api/internal/handler/redirect_host.go
@@ -49,11 +49,8 @@ func (h *RedirectHostHandler) Create(c echo.Context) error {
 		return c.JSON(http.StatusBadRequest, map[string]string{"error": "Invalid request body"})
 	}
 
-	if len(req.DomainNames) == 0 {
-		return c.JSON(http.StatusBadRequest, map[string]string{"error": "At least one domain name is required"})
-	}
-	if req.ForwardDomainName == "" {
-		return c.JSON(http.StatusBadRequest, map[string]string{"error": "Forward domain name is required"})
+	if err := req.Validate(); err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": err.Error()})
 	}
 
 	host, err := h.repo.Create(c.Request().Context(), &req)
@@ -92,6 +89,10 @@ func (h *RedirectHostHandler) Update(c echo.Context) error {
 	var req model.UpdateRedirectHostRequest
 	if err := json.NewDecoder(c.Request().Body).Decode(&req); err != nil {
 		return c.JSON(http.StatusBadRequest, map[string]string{"error": "Invalid request body"})
+	}
+
+	if err := req.Validate(); err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": err.Error()})
 	}
 
 	host, err := h.repo.Update(c.Request().Context(), id, &req)

--- a/api/internal/model/proxy_host.go
+++ b/api/internal/model/proxy_host.go
@@ -100,6 +100,11 @@ func ValidateHostnameOrIP(host string) bool {
 	return ValidateDomainName(host)
 }
 
+// ValidatePort checks whether a TCP/UDP port is in the usable numeric range.
+func ValidatePort(port int) bool {
+	return port >= 1 && port <= 65535
+}
+
 // Dangerous nginx directives that should not be allowed in advanced config
 // ANYWHERE — code execution, config escape, security disable, traffic/log
 // redirection at any nesting depth. These are blocked regardless of context.

--- a/api/internal/model/redirect_host.go
+++ b/api/internal/model/redirect_host.go
@@ -2,7 +2,12 @@ package model
 
 import (
 	"encoding/json"
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
 	"time"
+	"unicode"
 )
 
 // RedirectHost represents a redirect-only virtual host
@@ -27,7 +32,7 @@ type RedirectHost struct {
 // CreateRedirectHostRequest is the request to create a redirect host
 type CreateRedirectHostRequest struct {
 	DomainNames       []string        `json:"domain_names" validate:"required,min=1"`
-	ForwardScheme     string          `json:"forward_scheme,omitempty"`      // default: auto
+	ForwardScheme     string          `json:"forward_scheme,omitempty"` // default: auto
 	ForwardDomainName string          `json:"forward_domain_name" validate:"required"`
 	ForwardPath       string          `json:"forward_path,omitempty"`
 	PreservePath      *bool           `json:"preserve_path,omitempty"`
@@ -54,6 +59,180 @@ type UpdateRedirectHostRequest struct {
 	Enabled           *bool           `json:"enabled,omitempty"`
 	BlockExploits     *bool           `json:"block_exploits,omitempty"`
 	Meta              json.RawMessage `json:"meta,omitempty"`
+}
+
+// ValidateRedirectHost rejects values that could break out of the generated
+// nginx server_name or return directives. nginx -t only validates syntax, so a
+// syntactically valid injected directive must be rejected before rendering.
+func ValidateRedirectHost(host *RedirectHost) error {
+	if host == nil {
+		return fmt.Errorf("redirect host is required")
+	}
+	if err := validateRedirectDomains(host.DomainNames); err != nil {
+		return err
+	}
+	if err := validateRedirectScheme(host.ForwardScheme); err != nil {
+		return err
+	}
+	if err := validateRedirectTarget(host.ForwardDomainName); err != nil {
+		return err
+	}
+	if err := validateRedirectPath(host.ForwardPath); err != nil {
+		return err
+	}
+	if !validRedirectCode(host.RedirectCode) {
+		return fmt.Errorf("redirect_code must be one of 301, 302, 307 or 308")
+	}
+	return nil
+}
+
+// Validate applies defaults and validates a complete create request.
+func (r *CreateRedirectHostRequest) Validate() error {
+	scheme := r.ForwardScheme
+	if scheme == "" {
+		scheme = "auto"
+	}
+	code := r.RedirectCode
+	if code == 0 {
+		code = 301
+	}
+	return ValidateRedirectHost(&RedirectHost{
+		DomainNames:       r.DomainNames,
+		ForwardScheme:     scheme,
+		ForwardDomainName: r.ForwardDomainName,
+		ForwardPath:       r.ForwardPath,
+		RedirectCode:      code,
+	})
+}
+
+// Validate checks only fields present in a partial update. The repository also
+// validates the merged RedirectHost before writing it, which protects non-HTTP
+// callers and combinations with existing values.
+func (r *UpdateRedirectHostRequest) Validate() error {
+	if len(r.DomainNames) > 0 {
+		if err := validateRedirectDomains(r.DomainNames); err != nil {
+			return err
+		}
+	}
+	if r.ForwardScheme != nil {
+		if err := validateRedirectScheme(*r.ForwardScheme); err != nil {
+			return err
+		}
+	}
+	if r.ForwardDomainName != nil {
+		if err := validateRedirectTarget(*r.ForwardDomainName); err != nil {
+			return err
+		}
+	}
+	if r.ForwardPath != nil {
+		if err := validateRedirectPath(*r.ForwardPath); err != nil {
+			return err
+		}
+	}
+	if r.RedirectCode != nil && !validRedirectCode(*r.RedirectCode) {
+		return fmt.Errorf("redirect_code must be one of 301, 302, 307 or 308")
+	}
+	return nil
+}
+
+func validateRedirectDomains(domains []string) error {
+	if len(domains) == 0 {
+		return fmt.Errorf("at least one domain name is required")
+	}
+	for _, domain := range domains {
+		if domain != strings.TrimSpace(domain) || !ValidateDomainName(domain) {
+			return fmt.Errorf("invalid domain name %q", domain)
+		}
+	}
+	return nil
+}
+
+func validateRedirectScheme(scheme string) error {
+	switch scheme {
+	case "auto", "http", "https":
+		return nil
+	default:
+		return fmt.Errorf("forward_scheme must be one of auto, http or https")
+	}
+}
+
+func validateRedirectTarget(target string) error {
+	if target != strings.TrimSpace(target) || strings.Contains(target, "*") {
+		return fmt.Errorf("forward_domain_name must be a valid hostname or IP address")
+	}
+
+	host, port, ok := splitRedirectTarget(target)
+	if !ok {
+		return fmt.Errorf("forward_domain_name must be a valid hostname or IP address with an optional port")
+	}
+	// A trailing dot is the canonical absolute-FQDN form. Validate the DNS name
+	// without that root label while preserving the user's value for rendering.
+	hostForValidation := strings.TrimSuffix(host, ".")
+	if !ValidateHostnameOrIP(hostForValidation) {
+		return fmt.Errorf("forward_domain_name must contain a valid hostname or IP address")
+	}
+	if port != "" {
+		if strings.IndexFunc(port, func(r rune) bool { return r < '0' || r > '9' }) >= 0 {
+			return fmt.Errorf("forward_domain_name port must contain only decimal digits")
+		}
+		portNumber, err := strconv.Atoi(port)
+		if err != nil || !ValidatePort(portNumber) {
+			return fmt.Errorf("forward_domain_name port must be between 1 and 65535")
+		}
+	}
+	return nil
+}
+
+// splitRedirectTarget accepts URL-authority host forms without accepting a
+// scheme, credentials or path. IPv6 must be bracketed so the rendered redirect
+// remains a valid URL; hostnames and IPv4 addresses may carry an optional port.
+func splitRedirectTarget(target string) (host, port string, ok bool) {
+	if strings.HasPrefix(target, "[") {
+		end := strings.IndexByte(target, ']')
+		if end <= 1 {
+			return "", "", false
+		}
+		host = target[1:end]
+		rest := target[end+1:]
+		switch {
+		case rest == "":
+			return host, "", net.ParseIP(host) != nil
+		case strings.HasPrefix(rest, ":") && len(rest) > 1 && !strings.Contains(rest[1:], ":"):
+			return host, rest[1:], net.ParseIP(host) != nil
+		default:
+			return "", "", false
+		}
+	}
+
+	switch strings.Count(target, ":") {
+	case 0:
+		return target, "", true
+	case 1:
+		host, port, err := net.SplitHostPort(target)
+		return host, port, err == nil && host != "" && port != ""
+	default:
+		// A bare IPv6 literal is not a valid URL authority. Require brackets.
+		return "", "", false
+	}
+}
+
+func validateRedirectPath(path string) error {
+	if path == "" {
+		return nil
+	}
+	if !strings.HasPrefix(path, "/") {
+		return fmt.Errorf("forward_path must start with /")
+	}
+	if strings.ContainsAny(path, "\r\n;{}\\\"'$") || strings.IndexFunc(path, func(r rune) bool {
+		return unicode.IsSpace(r) || unicode.IsControl(r)
+	}) >= 0 {
+		return fmt.Errorf("forward_path contains characters that are unsafe in nginx configuration")
+	}
+	return nil
+}
+
+func validRedirectCode(code int) bool {
+	return code == 301 || code == 302 || code == 307 || code == 308
 }
 
 // RedirectHostListResponse is the response for listing redirect hosts

--- a/api/internal/model/redirect_host_test.go
+++ b/api/internal/model/redirect_host_test.go
@@ -1,0 +1,94 @@
+package model
+
+import "testing"
+
+func TestValidateRedirectHost(t *testing.T) {
+	valid := &RedirectHost{
+		DomainNames:       []string{"example.com", "*.example.net"},
+		ForwardScheme:     "https",
+		ForwardDomainName: "target.example.com",
+		ForwardPath:       "/new-path?source=legacy",
+		RedirectCode:      308,
+	}
+	if err := ValidateRedirectHost(valid); err != nil {
+		t.Fatalf("valid redirect host rejected: %v", err)
+	}
+
+	tests := []struct {
+		name   string
+		mutate func(*RedirectHost)
+	}{
+		{"domain directive injection", func(h *RedirectHost) { h.DomainNames = []string{"example.com; listen 9000"} }},
+		{"domain newline injection", func(h *RedirectHost) { h.DomainNames = []string{"example.com\nserver {}"} }},
+		{"invalid scheme", func(h *RedirectHost) { h.ForwardScheme = "https; return 200" }},
+		{"target directive injection", func(h *RedirectHost) { h.ForwardDomainName = "target.example.com; proxy_pass http://internal" }},
+		{"target contains URL", func(h *RedirectHost) { h.ForwardDomainName = "https://target.example.com" }},
+		{"target wildcard", func(h *RedirectHost) { h.ForwardDomainName = "*.example.com" }},
+		{"target invalid port", func(h *RedirectHost) { h.ForwardDomainName = "example.com:65536" }},
+		{"target nonnumeric port", func(h *RedirectHost) { h.ForwardDomainName = "example.com:+443" }},
+		{"target bare IPv6", func(h *RedirectHost) { h.ForwardDomainName = "2001:db8::1" }},
+		{"path directive injection", func(h *RedirectHost) { h.ForwardPath = "/ok; } location /internal {" }},
+		{"path newline injection", func(h *RedirectHost) { h.ForwardPath = "/ok\nreturn 200" }},
+		{"path control character", func(h *RedirectHost) { h.ForwardPath = "/ok\x00bad" }},
+		{"path nginx variable injection", func(h *RedirectHost) { h.ForwardPath = "/?token=$http_authorization" }},
+		{"path without leading slash", func(h *RedirectHost) { h.ForwardPath = "relative" }},
+		{"invalid redirect code", func(h *RedirectHost) { h.RedirectCode = 200 }},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			host := *valid
+			host.DomainNames = append([]string(nil), valid.DomainNames...)
+			tt.mutate(&host)
+			if err := ValidateRedirectHost(&host); err == nil {
+				t.Fatal("expected validation error")
+			}
+		})
+	}
+}
+
+func TestValidateRedirectHostAcceptsCompatibleTargetsAndPaths(t *testing.T) {
+	tests := []struct {
+		name   string
+		target string
+		path   string
+	}{
+		{name: "hostname with port", target: "nas.example.com:5001", path: "/"},
+		{name: "IPv4 with port", target: "192.0.2.10:8443", path: "/"},
+		{name: "absolute FQDN", target: "example.com.", path: "/"},
+		{name: "bracketed IPv6", target: "[2001:db8::1]", path: "/"},
+		{name: "bracketed IPv6 with port", target: "[2001:db8::1]:8443", path: "/"},
+		{name: "URL fragment", target: "target.example.com", path: "/docs#install"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			host := &RedirectHost{
+				DomainNames:       []string{"redirect.example.com"},
+				ForwardScheme:     "https",
+				ForwardDomainName: tt.target,
+				ForwardPath:       tt.path,
+				RedirectCode:      301,
+			}
+			if err := ValidateRedirectHost(host); err != nil {
+				t.Fatalf("compatible redirect rejected: %v", err)
+			}
+		})
+	}
+}
+
+func TestRedirectHostRequestValidationUsesDefaults(t *testing.T) {
+	create := &CreateRedirectHostRequest{
+		DomainNames:       []string{"example.com"},
+		ForwardDomainName: "target.example.com",
+	}
+	if err := create.Validate(); err != nil {
+		t.Fatalf("default create request rejected: %v", err)
+	}
+
+	badScheme := "http; return 200"
+	update := &UpdateRedirectHostRequest{ForwardScheme: &badScheme}
+	if err := update.Validate(); err == nil {
+		t.Fatal("expected unsafe partial update to be rejected")
+	}
+}

--- a/api/internal/nginx/bulk_regen.go
+++ b/api/internal/nginx/bulk_regen.go
@@ -122,6 +122,15 @@ func (m *Manager) RegenerateConfigsAtomicWithRedirects(ctx context.Context, rend
 		return nil
 	}
 	return m.executeWithLock(ctx, func() error {
+		invalidRedirects := make(map[*model.RedirectHost]error)
+		for _, rh := range redirectHosts {
+			if rh.Enabled {
+				if err := model.ValidateRedirectHost(rh); err != nil {
+					invalidRedirects[rh] = &InvalidRedirectHostConfigError{HostID: rh.ID, Err: err}
+				}
+			}
+		}
+
 		snap := newFileSnapshot()
 		for _, r := range renders {
 			for _, p := range m.hostRenderPaths(r) {
@@ -129,7 +138,11 @@ func (m *Manager) RegenerateConfigsAtomicWithRedirects(ctx context.Context, rend
 			}
 		}
 		for _, rh := range redirectHosts {
-			snap.capture(filepath.Join(m.configPath, GetRedirectConfigFilename(rh)))
+			// Unsafe stale configs must stay removed even if another host later
+			// causes the bulk operation to roll back.
+			if _, invalid := invalidRedirects[rh]; !invalid {
+				snap.capture(filepath.Join(m.configPath, GetRedirectConfigFilename(rh)))
+			}
 		}
 
 		rollback := func(cause error) error {
@@ -175,8 +188,23 @@ func (m *Manager) RegenerateConfigsAtomicWithRedirects(ctx context.Context, rend
 		}
 
 		for _, rh := range redirectHosts {
+			if validationErr, invalid := invalidRedirects[rh]; invalid {
+				if skipErr := m.skipInvalidRedirectConfig(ctx, rh, validationErr); skipErr != nil {
+					return rollback(skipErr)
+				}
+				continue
+			}
 			if rh.Enabled {
 				if err := m.GenerateRedirectConfig(ctx, rh); err != nil {
+					if isInvalidRedirectHostConfig(err) {
+						// Do not roll back unrelated proxy/redirect hosts because one
+						// legacy row is unsafe. Remove only that row's stale config so
+						// it cannot remain active, then continue the atomic fan-out.
+						if skipErr := m.skipInvalidRedirectConfig(ctx, rh, err); skipErr != nil {
+							return rollback(skipErr)
+						}
+						continue
+					}
 					return rollback(fmt.Errorf("failed to generate redirect config for host %s: %w", rh.ID, err))
 				}
 			} else if err := m.RemoveRedirectConfig(ctx, rh); err != nil {
@@ -208,9 +236,19 @@ func (m *Manager) RegenerateConfigsAtomicWithRedirects(ctx context.Context, rend
 // form leaves an invalid config on disk when -t fails.
 func (m *Manager) GenerateRedirectConfigAndReload(ctx context.Context, host *model.RedirectHost) error {
 	return m.executeWithLock(ctx, func() error {
+		var validationErr error
+		if host.Enabled {
+			if err := model.ValidateRedirectHost(host); err != nil {
+				validationErr = &InvalidRedirectHostConfigError{HostID: host.ID, Err: err}
+			}
+		}
+
 		configFile := filepath.Join(m.configPath, GetRedirectConfigFilename(host))
 		snap := newFileSnapshot()
-		snap.capture(configFile)
+		// Never restore a stale unsafe config after an unrelated reload failure.
+		if validationErr == nil {
+			snap.capture(configFile)
+		}
 
 		rollback := func(cause error) error {
 			log.Printf("[WARN] Nginx test failed for redirect host %s, rolling back: %v", host.ID, cause)
@@ -221,9 +259,19 @@ func (m *Manager) GenerateRedirectConfigAndReload(ctx context.Context, host *mod
 			return cause
 		}
 
-		if host.Enabled {
+		if validationErr != nil {
+			if skipErr := m.skipInvalidRedirectConfig(ctx, host, validationErr); skipErr != nil {
+				return rollback(skipErr)
+			}
+		} else if host.Enabled {
 			if err := m.GenerateRedirectConfig(ctx, host); err != nil {
-				return rollback(fmt.Errorf("failed to generate redirect config: %w", err))
+				if isInvalidRedirectHostConfig(err) {
+					if skipErr := m.skipInvalidRedirectConfig(ctx, host, err); skipErr != nil {
+						return rollback(skipErr)
+					}
+				} else {
+					return rollback(fmt.Errorf("failed to generate redirect config: %w", err))
+				}
 			}
 		} else {
 			if err := m.RemoveRedirectConfig(ctx, host); err != nil {

--- a/api/internal/nginx/redirect_config.go
+++ b/api/internal/nginx/redirect_config.go
@@ -3,6 +3,7 @@ package nginx
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -19,6 +20,34 @@ type RedirectHostConfigData struct {
 	HTTPPort   string
 	HTTPSPort  string
 	EnableIPv6 bool
+}
+
+// InvalidRedirectHostConfigError distinguishes an unsafe legacy/restored row
+// from operational render failures. Batch callers skip only this row while
+// still failing on I/O, template, and nginx errors.
+type InvalidRedirectHostConfigError struct {
+	HostID string
+	Err    error
+}
+
+func (e *InvalidRedirectHostConfigError) Error() string {
+	return fmt.Sprintf("invalid redirect host %q: %v", e.HostID, e.Err)
+}
+
+func (e *InvalidRedirectHostConfigError) Unwrap() error { return e.Err }
+
+func isInvalidRedirectHostConfig(err error) bool {
+	var validationErr *InvalidRedirectHostConfigError
+	return errors.As(err, &validationErr)
+}
+
+func (m *Manager) skipInvalidRedirectConfig(ctx context.Context, host *model.RedirectHost, err error) error {
+	log.Printf("[ERROR] [RedirectHost] SKIPPING unsafe redirect host id=%q; its nginx config will be removed: %v",
+		host.ID, err)
+	if removeErr := m.RemoveRedirectConfig(ctx, host); removeErr != nil {
+		return fmt.Errorf("remove config for skipped invalid redirect host %s: %w", host.ID, removeErr)
+	}
+	return nil
 }
 
 // Redirect host config template
@@ -102,6 +131,10 @@ server {
 
 // GenerateRedirectConfig generates nginx config for a redirect host
 func (m *Manager) GenerateRedirectConfig(ctx context.Context, host *model.RedirectHost) error {
+	if err := model.ValidateRedirectHost(host); err != nil {
+		return &InvalidRedirectHostConfigError{HostID: host.ID, Err: err}
+	}
+
 	funcMap := GetRedirectTemplateFuncMap()
 
 	tmpl, err := template.New("redirect_host").Funcs(funcMap).Parse(redirectHostTemplate)
@@ -138,7 +171,7 @@ func (m *Manager) GenerateRedirectConfig(ctx context.Context, host *model.Redire
 	}
 
 	configFile := filepath.Join(m.configPath, GetRedirectConfigFilename(host))
-	
+
 	// Use atomic write to prevent nginx from reading partial config
 	if err := m.writeFileAtomic(configFile, buf.Bytes(), 0644); err != nil {
 		return fmt.Errorf("failed to write redirect config file: %w", err)
@@ -162,9 +195,12 @@ func (m *Manager) RemoveRedirectConfig(ctx context.Context, host *model.Redirect
 	return nil
 }
 
-// GenerateAllRedirectConfigs generates nginx configs for all redirect hosts
+// GenerateAllRedirectConfigs generates nginx configs for all redirect hosts.
+// Invalid enabled rows are removed and skipped individually; operational errors
+// still abort because continuing after an I/O failure could leave a partial set.
 func (m *Manager) GenerateAllRedirectConfigs(ctx context.Context, hosts []model.RedirectHost) error {
-	// Remove all existing redirect_host configs
+	// Clear stale and disabled configs first. Active valid rows are recreated
+	// below, while invalid rows stay absent from the loaded nginx configuration.
 	files, err := filepath.Glob(filepath.Join(m.configPath, "redirect_host_*.conf"))
 	if err != nil {
 		return fmt.Errorf("failed to list redirect config files: %w", err)
@@ -176,9 +212,19 @@ func (m *Manager) GenerateAllRedirectConfigs(ctx context.Context, hosts []model.
 		}
 	}
 
-	// Generate configs for all hosts
-	for _, host := range hosts {
-		if err := m.GenerateRedirectConfig(ctx, &host); err != nil {
+	for i := range hosts {
+		host := &hosts[i]
+		// Disabled rows never reach an nginx directive context.
+		if !host.Enabled {
+			continue
+		}
+		if err := m.GenerateRedirectConfig(ctx, host); err != nil {
+			if isInvalidRedirectHostConfig(err) {
+				if skipErr := m.skipInvalidRedirectConfig(ctx, host, err); skipErr != nil {
+					return skipErr
+				}
+				continue
+			}
 			return fmt.Errorf("failed to generate redirect config for host %s: %w", host.ID, err)
 		}
 	}

--- a/api/internal/nginx/redirect_config_test.go
+++ b/api/internal/nginx/redirect_config_test.go
@@ -1,0 +1,116 @@
+package nginx
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"nginx-proxy-guard/internal/model"
+)
+
+func TestGenerateAllRedirectConfigsSkipsOnlyInvalidEnabledHost(t *testing.T) {
+	configDir := t.TempDir()
+	staleInvalid := filepath.Join(configDir, "redirect_host_invalid.example.com.conf")
+	if err := os.WriteFile(staleInvalid, []byte("# stale invalid config\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	manager := &Manager{configPath: configDir, httpPort: "80", httpsPort: "443"}
+	hosts := []model.RedirectHost{
+		{
+			ID:                "invalid",
+			DomainNames:       []string{"invalid.example.com"},
+			ForwardScheme:     "https",
+			ForwardDomainName: "target.example.com",
+			ForwardPath:       "/$request_uri",
+			RedirectCode:      301,
+			Enabled:           true,
+		},
+		{
+			ID:                "valid",
+			DomainNames:       []string{"valid.example.com"},
+			ForwardScheme:     "https",
+			ForwardDomainName: "target.example.com:8443",
+			ForwardPath:       "/docs#install",
+			RedirectCode:      301,
+			Enabled:           true,
+		},
+		{
+			ID:                "disabled-invalid",
+			DomainNames:       []string{"disabled.example.com; return 200"},
+			ForwardScheme:     "https",
+			ForwardDomainName: "target.example.com",
+			RedirectCode:      301,
+			Enabled:           false,
+		},
+	}
+
+	if err := manager.GenerateAllRedirectConfigs(context.Background(), hosts); err != nil {
+		t.Fatalf("batch generation failed instead of skipping one invalid row: %v", err)
+	}
+	if _, err := os.Stat(staleInvalid); !os.IsNotExist(err) {
+		t.Fatalf("stale invalid config was not removed: %v", err)
+	}
+	validConfig := filepath.Join(configDir, GetRedirectConfigFilename(&hosts[1]))
+	if _, err := os.Stat(validConfig); err != nil {
+		t.Fatalf("valid host was not rendered: %v", err)
+	}
+}
+
+func TestBulkRollbackDoesNotRestoreUnsafeRedirectConfig(t *testing.T) {
+	configDir := t.TempDir()
+	cli := &fakeNginxCLI{testErrs: []error{
+		errors.New("nginx: [emerg] invalid directive in generated config"),
+		nil, // rollback re-test
+	}}
+	manager := &Manager{configPath: configDir, httpPort: "80", httpsPort: "443", cli: cli}
+	invalid := &model.RedirectHost{
+		ID: "invalid", DomainNames: []string{"invalid.example.com"}, Enabled: true,
+		ForwardScheme: "https", ForwardDomainName: "target.example.com", ForwardPath: "/$request_uri", RedirectCode: 301,
+	}
+	invalidConfig := filepath.Join(configDir, GetRedirectConfigFilename(invalid))
+	if err := os.WriteFile(invalidConfig, []byte("# stale unsafe config\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := manager.RegenerateConfigsAtomicWithRedirects(context.Background(), nil, []*model.RedirectHost{invalid}, true)
+	if err == nil {
+		t.Fatal("expected nginx test failure")
+	}
+	if _, statErr := os.Stat(invalidConfig); !os.IsNotExist(statErr) {
+		t.Fatalf("rollback restored an unsafe redirect config: %v", statErr)
+	}
+}
+
+func TestBulkRegenerationSkipsInvalidRedirectWithoutRollingBackOthers(t *testing.T) {
+	configDir := t.TempDir()
+	cli := &fakeNginxCLI{}
+	manager := &Manager{configPath: configDir, httpPort: "80", httpsPort: "443", cli: cli}
+	valid := &model.RedirectHost{
+		ID: "valid", DomainNames: []string{"valid.example.com"}, Enabled: true,
+		ForwardScheme: "https", ForwardDomainName: "target.example.com", RedirectCode: 301,
+	}
+	invalid := &model.RedirectHost{
+		ID: "invalid", DomainNames: []string{"invalid.example.com"}, Enabled: true,
+		ForwardScheme: "https", ForwardDomainName: "target.example.com", ForwardPath: "/$request_uri", RedirectCode: 301,
+	}
+	invalidConfig := filepath.Join(configDir, GetRedirectConfigFilename(invalid))
+	if err := os.WriteFile(invalidConfig, []byte("# stale invalid config\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := manager.RegenerateConfigsAtomicWithRedirects(context.Background(), nil, []*model.RedirectHost{invalid, valid}, true); err != nil {
+		t.Fatalf("bulk regeneration rolled back because of one invalid redirect: %v", err)
+	}
+	if _, err := os.Stat(invalidConfig); !os.IsNotExist(err) {
+		t.Fatalf("invalid redirect config remains active: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(configDir, GetRedirectConfigFilename(valid))); err != nil {
+		t.Fatalf("valid redirect was not regenerated: %v", err)
+	}
+	if cli.reloadCalls != 1 {
+		t.Fatalf("reload calls = %d, want 1", cli.reloadCalls)
+	}
+}

--- a/api/internal/repository/backup_import_proxy.go
+++ b/api/internal/repository/backup_import_proxy.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"log"
 
 	"github.com/lib/pq"
 	"nginx-proxy-guard/internal/model"
@@ -353,6 +354,21 @@ func (r *BackupRepository) importUpstream(ctx context.Context, tx *sql.Tx, proxy
 }
 
 func (r *BackupRepository) importRedirectHost(ctx context.Context, tx *sql.Tx, rh *model.RedirectHostExport) error {
+	if err := model.ValidateRedirectHost(&model.RedirectHost{
+		DomainNames:       rh.RedirectHost.DomainNames,
+		ForwardScheme:     rh.RedirectHost.ForwardScheme,
+		ForwardDomainName: rh.RedirectHost.ForwardDomainName,
+		ForwardPath:       rh.RedirectHost.ForwardPath,
+		RedirectCode:      rh.RedirectHost.RedirectCode,
+	}); err != nil {
+		// Old releases allowed unrestricted values here. Do not make an otherwise
+		// usable full backup impossible to restore; omit only the unsafe redirect
+		// row and make the loss highly visible to the operator.
+		log.Printf("[ERROR] [Backup] SKIPPING unsafe redirect host during restore (domains=%q): %v",
+			rh.RedirectHost.DomainNames, err)
+		return nil
+	}
+
 	meta, _ := json.Marshal(rh.RedirectHost.Meta)
 
 	query := `

--- a/api/internal/repository/backup_import_redirect_test.go
+++ b/api/internal/repository/backup_import_redirect_test.go
@@ -1,0 +1,25 @@
+package repository
+
+import (
+	"context"
+	"testing"
+
+	"nginx-proxy-guard/internal/model"
+)
+
+func TestImportRedirectHostSkipsInvalidLegacyRowBeforeDatabaseWrite(t *testing.T) {
+	repo := &BackupRepository{}
+	exported := &model.RedirectHostExport{}
+	exported.RedirectHost.DomainNames = []string{"legacy.example.com"}
+	exported.RedirectHost.ForwardScheme = "https"
+	exported.RedirectHost.ForwardDomainName = "target.example.com"
+	exported.RedirectHost.ForwardPath = "/$http_authorization"
+	exported.RedirectHost.RedirectCode = 301
+	exported.RedirectHost.Enabled = true
+
+	// A nil transaction is intentional: an unsafe row must be skipped before
+	// any DB call, allowing the surrounding backup transaction to continue.
+	if err := repo.importRedirectHost(context.Background(), nil, exported); err != nil {
+		t.Fatalf("invalid legacy redirect aborted backup import: %v", err)
+	}
+}

--- a/api/internal/repository/redirect_host.go
+++ b/api/internal/repository/redirect_host.go
@@ -22,6 +22,10 @@ func NewRedirectHostRepository(db *database.DB) *RedirectHostRepository {
 }
 
 func (r *RedirectHostRepository) Create(ctx context.Context, req *model.CreateRedirectHostRequest) (*model.RedirectHost, error) {
+	if err := req.Validate(); err != nil {
+		return nil, err
+	}
+
 	forwardScheme := "auto"
 	if req.ForwardScheme != "" {
 		forwardScheme = req.ForwardScheme
@@ -177,6 +181,10 @@ func (r *RedirectHostRepository) Update(ctx context.Context, id string, req *mod
 	}
 	if req.BlockExploits != nil {
 		existing.BlockExploits = *req.BlockExploits
+	}
+
+	if err := model.ValidateRedirectHost(existing); err != nil {
+		return nil, err
 	}
 
 	metaJSON, _ := json.Marshal(existing.Meta)

--- a/test/e2e/fixtures/test-data.ts
+++ b/test/e2e/fixtures/test-data.ts
@@ -170,13 +170,13 @@ export const TEST_PROXY_HOST = {
 export const TEST_REDIRECT_HOST = {
   valid: {
     domain: 'redirect-e2e-{timestamp}.example.local',
-    forwardDomain: 'https://target.example.com',
+    forwardDomain: 'target.example.com',
     redirectCode: 301 as const,
     preservePath: true,
   },
   temporary: {
     domain: 'temp-redirect-e2e-{timestamp}.example.local',
-    forwardDomain: 'https://temp-target.example.com',
+    forwardDomain: 'temp-target.example.com',
     redirectCode: 302 as const,
     preservePath: false,
   },

--- a/test/e2e/specs/redirect-host/crud.spec.ts
+++ b/test/e2e/specs/redirect-host/crud.spec.ts
@@ -48,7 +48,7 @@ test.describe('Redirect Host CRUD', () => {
 
       await formPage.fillConfig({
         domain: testDomain,
-        forwardDomain: 'https://example.com',
+        forwardDomain: 'example.com',
         redirectCode: 301,
         preservePath: true,
       });
@@ -103,7 +103,7 @@ test.describe('Redirect Host CRUD', () => {
 
       await listPage.clickAddHost();
       await formPage.fillDomain('should-not-be-saved.example.local');
-      await formPage.fillForwardDomain('https://example.com');
+      await formPage.fillForwardDomain('example.com');
       await formPage.cancel();
 
       await formPage.expectClosed();
@@ -152,7 +152,7 @@ test.describe('Redirect Host CRUD', () => {
       await listPage.goto();
       await listPage.clickHost(testDomain);
 
-      const newTarget = 'https://new-target.example.com';
+      const newTarget = 'new-target.example.com';
       await formPage.fillForwardDomain(newTarget);
       await formPage.save();
 
@@ -252,7 +252,7 @@ test.describe('Redirect Host CRUD', () => {
 
       const testDomain = TestDataFactory.generateDomain('preserve-path-test');
       await formPage.fillDomain(testDomain);
-      await formPage.fillForwardDomain('https://example.com');
+      await formPage.fillForwardDomain('example.com');
       await formPage.togglePreservePath(true);
       await formPage.save();
 

--- a/test/e2e/utils/test-data-factory.ts
+++ b/test/e2e/utils/test-data-factory.ts
@@ -166,7 +166,7 @@ export class TestDataFactory {
   static createRedirectHost(overrides: Partial<CreateRedirectHostData> = {}): CreateRedirectHostData {
     return {
       domain_names: [this.generateDomain('redirect-e2e')],
-      forward_domain_name: 'https://target.example.com',
+      forward_domain_name: 'target.example.com',
       redirect_code: 301,
       preserve_path: true,
       enabled: true,


### PR DESCRIPTION
## 변경 내용

- Redirect Host의 `domain_names`, `forward_scheme`, `forward_domain_name`, `forward_path`, `redirect_code`를 중앙 validator로 검증합니다.
- Create/Update API뿐 아니라 repository의 최종 병합 결과와 Nginx 렌더링 직전에도 동일한 검증을 적용합니다.
- `forward_domain_name`은 URL authority에 맞게 다음 정상 형식을 허용합니다.
  - hostname 및 IPv4
  - `hostname:port`, `IPv4:port`
  - 절대 FQDN(`example.com.`)
  - 대괄호 IPv6 및 대괄호 IPv6+port
- 포트는 숫자 `1..65535` 범위로 별도 검증하고, URL로 잘못 렌더링되는 bare IPv6 및 scheme이 포함된 target은 거부합니다.
- `forward_path`의 안전한 `#fragment`는 허용하되, Nginx 지시어 구분자·제어문자·공백·`$` 변수 참조는 계속 차단합니다.
- 일괄 재생성 및 인증서 fan-out에서는 잘못된 활성 행만 건너뛰고 해당 stale 설정을 제거한 뒤 큰 오류 로그를 남깁니다. 다른 Proxy/Redirect Host는 계속 재생성합니다.
- 비활성 Redirect Host는 렌더링 문맥에 닿지 않으므로 검증 실패로 전체 동기화를 막지 않고 stale 설정만 제거합니다.
- 백업 복원에서는 구버전의 잘못된 Redirect Host 한 행만 생략하고 오류 로그를 남기며, 나머지 프록시 호스트·인증서·접근목록·설정의 트랜잭션은 계속 복원합니다.
- 기존 E2E fixture에서 잘못 사용하던 `https://target...` 값을 hostname-only target으로 수정했습니다.

## 이 수정이 필요한 이유

Redirect Host 값은 Nginx의 `server_name`과 `return` 지시어에 직접 삽입됩니다. 입력값에 세미콜론, 개행, 중괄호 또는 Nginx 변수를 포함할 수 있으면 `redirect:write` 권한을 가진 사용자가 생성되는 설정의 문맥을 벗어나 추가 지시어를 삽입하거나 요청 헤더·쿠키 값을 외부 redirect에 포함시킬 수 있습니다.

`nginx -t`는 설정이 문법적으로 유효한지만 확인하므로, 문법적으로 올바른 악성 지시어를 보안상 차단하지 못합니다. 따라서 템플릿에 값을 전달하기 전에 허용 가능한 값만 통과시키는 검증이 필요합니다.

동시에 Redirect Host에는 별도의 port 컬럼이 없으므로 `nas.example.com:5001` 같은 target은 기존의 정상 표현입니다. 이 PR은 host와 port를 분리해 각각 검증하여 보안 경계를 유지하면서 기존 설치와의 호환성을 보존합니다.

검증을 API handler에만 두면 내부 repository 호출, 기존 DB 데이터 같은 경로가 우회할 수 있습니다. 반대로 구버전의 잘못된 행 하나 때문에 전체 인증서 fan-out이나 전체 백업 복원을 중단하면 장애 범위가 불필요하게 커집니다. 따라서 저장 전에는 fail-closed하고, 이미 존재하는 legacy 데이터의 일괄 처리에서는 해당 행만 제거·생략하고 명확한 오류를 기록합니다.

## 주요 회귀 테스트

- hostname/IPv4 + port 허용
- 절대 FQDN 허용
- 대괄호 IPv6 및 IPv6+port 허용
- `#fragment` 경로 허용
- 잘못된 port, bare IPv6, scheme 포함 target 거부
- Nginx 변수 및 directive escape 공격 거부
- 일괄 재생성에서 invalid/disabled 행이 정상 행을 막지 않음
- 인증서 bulk regeneration에서 invalid redirect 때문에 다른 호스트를 rollback하지 않음
- 이후 다른 Nginx 오류가 발생해도 unsafe stale redirect 설정을 rollback으로 되살리지 않음
- 백업 복원에서 invalid legacy redirect를 DB 쓰기 전에 건너뜀

## 검증

- `go test ./internal/model ./internal/nginx ./internal/handler ./internal/repository` ✅
- `go test ./cmd/... ./internal/... ./pkg/...` ✅
- `go vet ./cmd/... ./internal/... ./pkg/...` ✅
- 수정한 E2E TypeScript 파일 3개의 syntax/transpile 검사 ✅
- `npm audit` 취약점 0건 ✅
- `git diff --check` ✅

전체 E2E `tsc --noEmit`은 이번 변경과 무관한 기존 타입 오류 3건(`fixtures/auth.fixture.ts`, `playwright.config.ts`, `utils/api-helper.ts`) 때문에 실패합니다. 실제 브라우저 E2E는 실행 중인 API/PostgreSQL 환경이 필요해 이번 검증 범위에서 제외했습니다.