### PR TITLE
fix(auth): enforce SSO group revocation

### DIFF
--- a/api/internal/model/sso.go
+++ b/api/internal/model/sso.go
@@ -257,6 +257,9 @@ type SSOClaims struct {
 	Name                string
 	Username            string
 	Groups              []string
+	// GroupsStated distinguishes a missing group claim (which UserInfo may fill)
+	// from an explicitly empty claim (which is authoritative revocation).
+	GroupsStated bool
 }
 
 // AllowedByList reports whether the identity passes the provider's allowlist.
@@ -290,6 +293,12 @@ func (p *SSOProvider) AllowedByList(c *SSOClaims) bool {
 	if !listed {
 		return false
 	}
+	return p.MeetsRequiredGroup(c)
+}
+
+// MeetsRequiredGroup applies the provider's required-group gate to every SSO
+// login, including identities that were linked during an earlier login.
+func (p *SSOProvider) MeetsRequiredGroup(c *SSOClaims) bool {
 	if p.RequiredGroup == "" {
 		return true
 	}

--- a/api/internal/model/sso_test.go
+++ b/api/internal/model/sso_test.go
@@ -89,6 +89,20 @@ func TestAllowedByList(t *testing.T) {
 	}
 }
 
+func TestMeetsRequiredGroup(t *testing.T) {
+	p := &SSOProvider{RequiredGroup: "npg-admins"}
+	if !p.MeetsRequiredGroup(&SSOClaims{Groups: []string{"users", "NPG-ADMINS"}}) {
+		t.Fatal("expected case-insensitive required group match")
+	}
+	if p.MeetsRequiredGroup(&SSOClaims{Groups: []string{"users"}}) {
+		t.Fatal("expected missing required group to be rejected")
+	}
+	p.RequiredGroup = ""
+	if !p.MeetsRequiredGroup(&SSOClaims{}) {
+		t.Fatal("provider without a required group should allow the identity")
+	}
+}
+
 func TestRoleForClaims(t *testing.T) {
 	def := "role-default"
 	p := &SSOProvider{

--- a/api/internal/service/sso.go
+++ b/api/internal/service/sso.go
@@ -206,6 +206,16 @@ func (s *SSOService) CompleteLogin(ctx context.Context, slug, code, state, callb
 // the stable subject first, then a one-time link by verified email, then
 // creation, then refusal.
 func (s *SSOService) resolveUser(ctx context.Context, p *model.SSOProvider, c *model.SSOClaims) (userID, username string, err error) {
+	// RequiredGroup is an authorization gate, not only a JIT provisioning
+	// filter. Re-check it before resolving an existing identity so removing a
+	// user from the IdP group revokes their next login.
+	if !p.MeetsRequiredGroup(c) {
+		reason, detail := requiredGroupRefusal(c)
+		log.Printf("SSO[%s]: refusing login for provider %q — %s", config.AppVersion, p.Slug, detail)
+		s.emitRefusal(ctx, p.Slug, reason)
+		return "", "", ErrSSONotAllowed
+	}
+
 	if id, err := s.repo.FindUserBySubject(ctx, p.ID, c.Subject); err != nil {
 		return "", "", err
 	} else if id != "" {
@@ -216,7 +226,9 @@ func (s *SSOService) resolveUser(ctx context.Context, p *model.SSOProvider, c *m
 		if u == nil {
 			return "", "", ErrSSONoAccount
 		}
-		s.syncRole(ctx, p, c, u)
+		if err := s.syncRoleForLogin(ctx, p, c, u); err != nil {
+			return "", "", err
+		}
 		return id, u.Username, nil
 	}
 
@@ -240,7 +252,9 @@ func (s *SSOService) resolveUser(ctx context.Context, p *model.SSOProvider, c *m
 				return "", "", ErrSSONoAccount
 			}
 			log.Printf("SSO: linking existing account %q to provider %q by verified email", u.Username, p.Slug)
-			s.syncRole(ctx, p, c, u)
+			if err := s.syncRoleForLogin(ctx, p, c, u); err != nil {
+				return "", "", err
+			}
 			return id, u.Username, nil
 		}
 	}
@@ -326,40 +340,91 @@ func (s *SSOService) provision(ctx context.Context, p *model.SSOProvider, c *mod
 }
 
 // syncRole re-applies a group mapping on every login, which is what makes
-// revoking a group at the IdP take effect. It is a no-op unless the provider
-// actually has mappings — otherwise NPG stays the authority on roles.
-func (s *SSOService) syncRole(ctx context.Context, p *model.SSOProvider, c *model.SSOClaims, u *model.UserSummary) {
-	if len(p.GroupRoleMappings) == 0 {
-		return
+// revoking a group at the IdP take effect. Providers without mappings leave NPG
+// authoritative. A provider with a default role falls back to it after group
+// removal; a legacy non-JIT provider without one keeps the existing role and
+// emits a warning rather than locking out a previously valid installation.
+func (s *SSOService) syncRole(ctx context.Context, p *model.SSOProvider, c *model.SSOClaims, u *model.UserSummary) error {
+	roleID, enforce, err := roleToSync(p, c)
+	if err != nil {
+		return err
 	}
-	roleID, fromGroup := p.RoleForClaims(c)
-	if !fromGroup || roleID == "" {
-		return
+	if !enforce {
+		if len(p.GroupRoleMappings) > 0 {
+			log.Printf("SSO[%s]: provider %q has group-role mappings but no matching group or default role; "+
+				"preserving the existing role for %q to avoid locking out a previously valid installation",
+				config.AppVersion, p.Slug, u.Username)
+		}
+		return nil
 	}
 	if u.RoleID != nil && *u.RoleID == roleID {
-		return
+		return nil
 	}
 	role, err := s.roles.GetByID(ctx, roleID)
-	if err != nil || role == nil {
-		log.Printf("SSO: cannot sync role for %q: mapped role is missing", u.Username)
-		return
+	if err != nil {
+		return fmt.Errorf("sync SSO role for %q: %w", u.Username, err)
 	}
-	// Reuse the #222 invariant: the install must keep at least one superuser, so
-	// a group change must not be able to strand it.
+	if role == nil {
+		return fmt.Errorf("sync SSO role for %q: selected role %q is missing", u.Username, roleID)
+	}
+	// Keep the invariant that the install has a superuser, but fail this login
+	// instead of retaining revoked superuser access.
 	if u.IsSuperuser && !role.IsSuperuser {
-		if n, err := s.roles.CountSuperusers(ctx); err == nil && n <= 1 {
-			log.Printf("SSO: keeping %q as a superuser — demoting the last one would lock the install out", u.Username)
-			return
+		n, err := s.roles.CountSuperusers(ctx)
+		if err != nil {
+			return fmt.Errorf("count superusers before SSO role sync: %w", err)
+		}
+		if n <= 1 {
+			log.Printf("SSO: refusing login for %q — IdP role change would demote the last superuser", u.Username)
+			return ErrSSONotAllowed
 		}
 	}
 	if err := s.users.AssignRole(ctx, u.ID, roleID, role.IsSuperuser); err != nil {
-		log.Printf("SSO: failed to sync role for %q: %v", u.Username, err)
-		return
+		return fmt.Errorf("sync SSO role for %q: %w", u.Username, err)
 	}
 	log.Printf("SSO: %q moved to role %q by group mapping", u.Username, role.Name)
 	if s.audit != nil {
 		_ = s.audit.LogUserRoleAssign(ctx, u.Username, role.Name)
 	}
+	return nil
+}
+
+// syncRoleForLogin makes every fail-closed role-sync path diagnosable. Without
+// this wrapper CompleteLogin returns only #error=failed and does not log the
+// resolveUser error, leaving operators unable to distinguish a revoked mapping
+// from a repository or role configuration failure.
+func (s *SSOService) syncRoleForLogin(ctx context.Context, p *model.SSOProvider, c *model.SSOClaims, u *model.UserSummary) error {
+	if err := s.syncRole(ctx, p, c, u); err != nil {
+		log.Printf("SSO[%s]: refusing login for provider %q — role sync failed for %q: %v",
+			config.AppVersion, p.Slug, u.Username, err)
+		s.emitRefusal(ctx, p.Slug, "role_sync_failed")
+		return err
+	}
+	return nil
+}
+
+func roleToSync(p *model.SSOProvider, c *model.SSOClaims) (roleID string, enforce bool, err error) {
+	if len(p.GroupRoleMappings) == 0 {
+		return "", false, nil
+	}
+	roleID, fromGroup := p.RoleForClaims(c)
+	if fromGroup {
+		return roleID, true, nil
+	}
+	if strings.TrimSpace(roleID) == "" {
+		// Default roles are required only for JIT providers. Existing non-JIT
+		// installations may legitimately have mappings without a fallback; keep
+		// their current role rather than turning this security fix into a lockout.
+		return "", false, nil
+	}
+	return roleID, true, nil
+}
+
+func requiredGroupRefusal(c *model.SSOClaims) (reason, detail string) {
+	if !c.GroupsStated {
+		return "required_group_claim_missing", "the configured group claim was absent from both the id_token and UserInfo"
+	}
+	return "required_group", "the identity is not a member of the configured required group"
 }
 
 // uniqueUsername derives a username from the claims and disambiguates it, since
@@ -511,17 +576,22 @@ func claimsFromMap(raw map[string]any, subject, groupClaim string) *model.SSOCla
 	if u, ok := raw["preferred_username"].(string); ok {
 		c.Username = u
 	}
-	switch v := raw[groupClaim].(type) {
-	case []any:
-		for _, g := range v {
-			if s, ok := g.(string); ok {
-				c.Groups = append(c.Groups, s)
+	if value, ok := raw[groupClaim]; ok {
+		switch v := value.(type) {
+		case []any:
+			c.GroupsStated = true
+			for _, g := range v {
+				if s, ok := g.(string); ok {
+					c.Groups = append(c.Groups, s)
+				}
 			}
+		case []string:
+			c.GroupsStated = true
+			c.Groups = v
+		case string:
+			c.GroupsStated = true
+			c.Groups = []string{v}
 		}
-	case []string:
-		c.Groups = v
-	case string:
-		c.Groups = []string{v}
 	}
 	return c
 }
@@ -582,8 +652,9 @@ func (s *SSOService) mergeUserInfoClaims(ctx context.Context, provider *oidc.Pro
 	if claims.Username == "" {
 		claims.Username = extra.Username
 	}
-	if len(claims.Groups) == 0 {
+	if !claims.GroupsStated && extra.GroupsStated {
 		claims.Groups = extra.Groups
+		claims.GroupsStated = true
 	}
 }
 

--- a/api/internal/service/sso_role_sync_test.go
+++ b/api/internal/service/sso_role_sync_test.go
@@ -1,0 +1,71 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"nginx-proxy-guard/internal/model"
+)
+
+func TestResolveUserEnforcesRequiredGroupBeforeIdentityLookup(t *testing.T) {
+	s := &SSOService{}
+	provider := &model.SSOProvider{Slug: "corp", RequiredGroup: "npg-users"}
+	claims := &model.SSOClaims{Subject: "linked-user", Groups: []string{}, GroupsStated: true}
+
+	_, _, err := s.resolveUser(context.Background(), provider, claims)
+	if !errors.Is(err, ErrSSONotAllowed) {
+		t.Fatalf("resolveUser error = %v, want ErrSSONotAllowed", err)
+	}
+}
+
+func TestRequiredGroupRefusalDistinguishesMissingClaim(t *testing.T) {
+	reason, _ := requiredGroupRefusal(&model.SSOClaims{GroupsStated: false})
+	if reason != "required_group_claim_missing" {
+		t.Fatalf("missing claim reason = %q", reason)
+	}
+	reason, _ = requiredGroupRefusal(&model.SSOClaims{GroupsStated: true})
+	if reason != "required_group" {
+		t.Fatalf("stated empty claim reason = %q", reason)
+	}
+}
+
+func TestRoleToSync(t *testing.T) {
+	defaultRole := "role-viewer"
+	provider := &model.SSOProvider{
+		DefaultRoleID: &defaultRole,
+		GroupRoleMappings: []model.GroupRoleMapping{
+			{Group: "npg-admins", RoleID: "role-admin"},
+		},
+	}
+
+	t.Run("matching group selects mapped role", func(t *testing.T) {
+		roleID, enforce, err := roleToSync(provider, &model.SSOClaims{Groups: []string{"npg-admins"}})
+		if err != nil || !enforce || roleID != "role-admin" {
+			t.Fatalf("got role=%q enforce=%v err=%v", roleID, enforce, err)
+		}
+	})
+
+	t.Run("removed group falls back to default role", func(t *testing.T) {
+		roleID, enforce, err := roleToSync(provider, &model.SSOClaims{Groups: []string{"users"}})
+		if err != nil || !enforce || roleID != defaultRole {
+			t.Fatalf("got role=%q enforce=%v err=%v", roleID, enforce, err)
+		}
+	})
+
+	t.Run("removed group without fallback preserves existing role", func(t *testing.T) {
+		withoutDefault := *provider
+		withoutDefault.DefaultRoleID = nil
+		roleID, enforce, err := roleToSync(&withoutDefault, &model.SSOClaims{Groups: []string{"users"}})
+		if err != nil || enforce || roleID != "" {
+			t.Fatalf("got role=%q enforce=%v err=%v, want existing role preserved", roleID, enforce, err)
+		}
+	})
+
+	t.Run("provider without mappings leaves local role authoritative", func(t *testing.T) {
+		roleID, enforce, err := roleToSync(&model.SSOProvider{DefaultRoleID: &defaultRole}, &model.SSOClaims{})
+		if err != nil || enforce || roleID != "" {
+			t.Fatalf("got role=%q enforce=%v err=%v", roleID, enforce, err)
+		}
+	})
+}

--- a/api/internal/service/sso_userinfo_test.go
+++ b/api/internal/service/sso_userinfo_test.go
@@ -97,6 +97,43 @@ func TestTheIDTokenWinsOverUserInfo(t *testing.T) {
 	}
 }
 
+func TestExplicitEmptyIDTokenGroupsAreNotOverriddenByUserInfo(t *testing.T) {
+	srv := fakeIdP(t, map[string]any{
+		"sub":    "user-1",
+		"groups": []string{"admins"},
+	})
+	ctx := context.Background()
+	provider, _ := oidc.NewProvider(ctx, srv.URL)
+
+	s := &SSOService{}
+	claims := claimsFromMap(map[string]any{"groups": []string{}}, "user-1", "groups")
+	s.mergeUserInfoClaims(ctx, provider, &oauth2.Token{AccessToken: "t"}, claims, "groups")
+
+	if !claims.GroupsStated || len(claims.Groups) != 0 {
+		t.Fatalf("explicit empty ID-token groups were overwritten: %+v", claims.Groups)
+	}
+}
+
+func TestNullIDTokenGroupsCanBeFilledByUserInfo(t *testing.T) {
+	srv := fakeIdP(t, map[string]any{
+		"sub":    "user-1",
+		"groups": []string{"admins"},
+	})
+	ctx := context.Background()
+	provider, _ := oidc.NewProvider(ctx, srv.URL)
+
+	s := &SSOService{}
+	claims := claimsFromMap(map[string]any{"groups": nil}, "user-1", "groups")
+	if claims.GroupsStated {
+		t.Fatal("groups:null must be treated as an absent group claim")
+	}
+	s.mergeUserInfoClaims(ctx, provider, &oauth2.Token{AccessToken: "t"}, claims, "groups")
+
+	if !claims.GroupsStated || len(claims.Groups) != 1 || claims.Groups[0] != "admins" {
+		t.Fatalf("UserInfo groups were not used after groups:null: %+v", claims.Groups)
+	}
+}
+
 // Required by the spec: a response about a different subject is not about this
 // user. Applying it would hand one account another's identity.
 func TestUserInfoForAnotherSubjectIsIgnored(t *testing.T) {


### PR DESCRIPTION
## 변경 내용

- 이미 연결된 SSO 사용자도 로그인할 때마다 `required_group`을 다시 확인합니다.
- IdP 그룹 역할 매핑이 더 이상 일치하지 않으면 provider의 기본 역할로 즉시 강등합니다.
- 그룹 매핑은 있지만 기본 역할이 없는 기존 non-JIT 공급자는 잠금 방지를 위해 기존 역할을 유지하고 명시적인 경고 로그를 남깁니다.
- 역할 조회·할당 또는 superuser 수 확인이 실패하면 기존 권한으로 세션을 발급하지 않고 fail-closed 처리합니다.
- 마지막 superuser를 자동 강등해야 하는 상황에서는 권한을 유지한 채 로그인시키는 대신 로그인을 거부합니다.
- ID token에 명시된 빈 그룹 목록이 UserInfo의 오래된 그룹 정보로 덮어써지지 않도록 claim 출처를 구분합니다.
- `groups: null` 또는 잘못된 타입은 그룹 claim이 없는 것으로 취급하여 UserInfo의 정상 그룹 정보를 사용할 수 있게 합니다.
- required group 거부와 역할 동기화 실패에 운영 로그 및 batched refusal 이벤트를 추가합니다.
- required group의 실제 `resolveUser` 게이트, 그룹 제거 후 기본 역할 강등, fallback 부재, null/empty group claim, UserInfo stale-group 상황에 대한 회귀 테스트를 추가합니다.

## 이 수정이 필요한 이유

기존 구현은 신규 계정 생성 시에는 `required_group`을 확인하지만, 이미 SSO identity가 연결된 사용자는 subject 조회 분기에서 곧바로 로그인시켰습니다. 따라서 IdP에서 사용자를 필수 그룹에서 제거해도 NPG 접근 권한이 철회되지 않았습니다.

또한 그룹-역할 매핑은 일치하는 그룹이 있을 때만 역할을 변경했습니다. 관리자가 IdP의 관리자 그룹에서 제거되면 일치하는 매핑이 없어졌지만, 기존 NPG 관리자 역할은 그대로 유지됐습니다. 역할 동기화 중 DB 오류가 발생해도 기존 역할로 로그인이 계속되는 fail-open 동작도 있었습니다.

이 PR은 IdP 그룹 설정을 로그인 시점의 권한 원본으로 취급합니다.

- 필수 그룹 제거 → 로그인 거부
- 관리자 그룹 제거 + 기본 역할 존재 → 기본 역할로 강등 후 로그인
- 관리자 그룹 제거 + 기본 역할 없음 → 기존 역할 유지 및 경고 로그(non-JIT 기존 설치 호환)
- 역할 동기화 실패 → 세션 발급 거부

ID token이 `groups: []`를 명시한 경우는 실제 그룹 철회로 보존합니다. 해당 빈 목록을 UserInfo의 stale 그룹으로 덮어쓰면 철회된 권한이 다시 살아날 수 있기 때문입니다. 반면 `groups: null` 또는 비목록·비문자열 값은 claim 부재로 취급하여, 그룹을 UserInfo에만 제공하는 정상 공급자와의 호환성을 유지합니다.

필수 그룹 claim 자체가 ID token과 UserInfo 어디에도 없는 경우에는 일반적인 그룹 불일치와 구분되는 `required_group_claim_missing` 진단을 기록합니다. 역할 조회·할당 등 동기화 실패도 `role_sync_failed` 이벤트와 오류 로그를 남깁니다.

## 검증

- `go test ./internal/model ./internal/service` ✅
- `go test ./cmd/... ./internal/... ./pkg/...` ✅
- `go vet ./cmd/... ./internal/... ./pkg/...` ✅
- `git diff --check` ✅

통합 테스트 디렉터리는 실행 중인 API와 PostgreSQL 서비스가 필요한 환경 의존 테스트이므로 위 명령의 범위에서 제외했습니다.