### PR TITLE
fix(api): fail closed when SSO role mapping has no fallback

### DIFF
--- a/api/internal/model/sso_test.go
+++ b/api/internal/model/sso_test.go
@@ -165,13 +165,14 @@ func TestValidateRefusesJITWithoutAllowlist(t *testing.T) {
 		}
 	})
 
-	t.Run("JIT without a role is refused", func(t *testing.T) {
+	t.Run("JIT cannot reach role sync without a default role", func(t *testing.T) {
 		r := base()
 		r.AllowJIT = true
 		r.AllowedEmailDomains = []string{"example.com"}
 		r.DefaultRoleID = nil
+		r.GroupRoleMappings = []GroupRoleMapping{{Group: "npg-admins", RoleID: "role-admin"}}
 		if err := r.Validate(true); err == nil {
-			t.Fatal("expected a missing default role to be refused")
+			t.Fatal("expected JIT provider without a default role to be refused before login")
 		}
 	})
 

--- a/api/internal/service/sso.go
+++ b/api/internal/service/sso.go
@@ -33,6 +33,7 @@ var (
 	ErrSSOStateInvalid  = errors.New("the sign-in request expired or was already used")
 	ErrSSONoAccount     = errors.New("no account is linked to this identity")
 	ErrSSONotAllowed    = errors.New("this identity is not permitted to sign in")
+	ErrSSONoRoleMapping = fmt.Errorf("%w: no group-role mapping matches and no default role is configured", ErrSSONotAllowed)
 	ErrSSOEmailMissing  = errors.New("the provider returned no email address")
 	ErrSSODiscovery     = errors.New("could not reach the identity provider")
 	ErrSSOTokenInvalid  = errors.New("the identity provider's response could not be verified")
@@ -341,18 +342,17 @@ func (s *SSOService) provision(ctx context.Context, p *model.SSOProvider, c *mod
 
 // syncRole re-applies a group mapping on every login, which is what makes
 // revoking a group at the IdP take effect. Providers without mappings leave NPG
-// authoritative. A provider with a default role falls back to it after group
-// removal; a legacy non-JIT provider without one keeps the existing role and
-// emits a warning rather than locking out a previously valid installation.
+// authoritative. An explicitly stated but unmatched group claim falls back to
+// the default role or refuses login when no fallback exists. A missing claim is
+// not evidence of revocation, so the existing role is preserved.
 func (s *SSOService) syncRole(ctx context.Context, p *model.SSOProvider, c *model.SSOClaims, u *model.UserSummary) error {
 	roleID, enforce, err := roleToSync(p, c)
 	if err != nil {
 		return err
 	}
 	if !enforce {
-		if len(p.GroupRoleMappings) > 0 {
-			log.Printf("SSO[%s]: provider %q has group-role mappings but no matching group or default role; "+
-				"preserving the existing role for %q to avoid locking out a previously valid installation",
+		if len(p.GroupRoleMappings) > 0 && !c.GroupsStated {
+			log.Printf("SSO[%s]: provider %q supplied no group claim in the ID token or UserInfo; preserving the existing role for %q and skipping role sync",
 				config.AppVersion, p.Slug, u.Username)
 		}
 		return nil
@@ -395,9 +395,13 @@ func (s *SSOService) syncRole(ctx context.Context, p *model.SSOProvider, c *mode
 // from a repository or role configuration failure.
 func (s *SSOService) syncRoleForLogin(ctx context.Context, p *model.SSOProvider, c *model.SSOClaims, u *model.UserSummary) error {
 	if err := s.syncRole(ctx, p, c, u); err != nil {
+		reason := "role_sync_failed"
+		if errors.Is(err, ErrSSONoRoleMapping) {
+			reason = "role_not_mapped"
+		}
 		log.Printf("SSO[%s]: refusing login for provider %q — role sync failed for %q: %v",
 			config.AppVersion, p.Slug, u.Username, err)
-		s.emitRefusal(ctx, p.Slug, "role_sync_failed")
+		s.emitRefusal(ctx, p.Slug, reason)
 		return err
 	}
 	return nil
@@ -407,15 +411,15 @@ func roleToSync(p *model.SSOProvider, c *model.SSOClaims) (roleID string, enforc
 	if len(p.GroupRoleMappings) == 0 {
 		return "", false, nil
 	}
+	if !c.GroupsStated {
+		return "", false, nil
+	}
 	roleID, fromGroup := p.RoleForClaims(c)
 	if fromGroup {
 		return roleID, true, nil
 	}
 	if strings.TrimSpace(roleID) == "" {
-		// Default roles are required only for JIT providers. Existing non-JIT
-		// installations may legitimately have mappings without a fallback; keep
-		// their current role rather than turning this security fix into a lockout.
-		return "", false, nil
+		return "", false, ErrSSONoRoleMapping
 	}
 	return roleID, true, nil
 }

--- a/api/internal/service/sso_role_sync_test.go
+++ b/api/internal/service/sso_role_sync_test.go
@@ -40,25 +40,54 @@ func TestRoleToSync(t *testing.T) {
 	}
 
 	t.Run("matching group selects mapped role", func(t *testing.T) {
-		roleID, enforce, err := roleToSync(provider, &model.SSOClaims{Groups: []string{"npg-admins"}})
+		roleID, enforce, err := roleToSync(provider, &model.SSOClaims{Groups: []string{"npg-admins"}, GroupsStated: true})
 		if err != nil || !enforce || roleID != "role-admin" {
 			t.Fatalf("got role=%q enforce=%v err=%v", roleID, enforce, err)
 		}
 	})
 
 	t.Run("removed group falls back to default role", func(t *testing.T) {
-		roleID, enforce, err := roleToSync(provider, &model.SSOClaims{Groups: []string{"users"}})
+		roleID, enforce, err := roleToSync(provider, &model.SSOClaims{Groups: []string{"users"}, GroupsStated: true})
 		if err != nil || !enforce || roleID != defaultRole {
 			t.Fatalf("got role=%q enforce=%v err=%v", roleID, enforce, err)
 		}
 	})
 
-	t.Run("removed group without fallback preserves existing role", func(t *testing.T) {
+	t.Run("removed group without fallback refuses login", func(t *testing.T) {
 		withoutDefault := *provider
 		withoutDefault.DefaultRoleID = nil
-		roleID, enforce, err := roleToSync(&withoutDefault, &model.SSOClaims{Groups: []string{"users"}})
-		if err != nil || enforce || roleID != "" {
-			t.Fatalf("got role=%q enforce=%v err=%v, want existing role preserved", roleID, enforce, err)
+		roleID, enforce, err := roleToSync(&withoutDefault, &model.SSOClaims{Groups: []string{"users"}, GroupsStated: true})
+		if !errors.Is(err, ErrSSONoRoleMapping) || !errors.Is(err, ErrSSONotAllowed) || enforce || roleID != "" {
+			t.Fatalf("got role=%q enforce=%v err=%v, want explicit not-allowed mapping refusal", roleID, enforce, err)
+		}
+
+		oldRole := "role-admin"
+		err = (&SSOService{}).syncRole(context.Background(), &withoutDefault,
+			&model.SSOClaims{Groups: []string{"users"}, GroupsStated: true},
+			&model.UserSummary{Username: "former-admin", RoleID: &oldRole, IsSuperuser: true})
+		if !errors.Is(err, ErrSSONoRoleMapping) {
+			t.Fatalf("syncRole error = %v, want ErrSSONoRoleMapping", err)
+		}
+	})
+
+	t.Run("missing group claim preserves role with or without fallback", func(t *testing.T) {
+		providers := []*model.SSOProvider{provider}
+		withoutDefault := *provider
+		withoutDefault.DefaultRoleID = nil
+		providers = append(providers, &withoutDefault)
+
+		for _, p := range providers {
+			roleID, enforce, err := roleToSync(p, &model.SSOClaims{GroupsStated: false})
+			if err != nil || enforce || roleID != "" {
+				t.Fatalf("default=%v: got role=%q enforce=%v err=%v, want existing role preserved", p.DefaultRoleID, roleID, enforce, err)
+			}
+		}
+
+		oldRole := "role-admin"
+		if err := (&SSOService{}).syncRole(context.Background(), provider,
+			&model.SSOClaims{GroupsStated: false},
+			&model.UserSummary{Username: "userinfo-outage", RoleID: &oldRole, IsSuperuser: true}); err != nil {
+			t.Fatalf("missing group claim changed or refused existing role: %v", err)
 		}
 	})
 

--- a/ui/src/i18n/locales/en/settings.json
+++ b/ui/src/i18n/locales/en/settings.json
@@ -1493,7 +1493,7 @@
       "requiredGroupHint": "When set, only members of this group may sign in.",
       "allowJit": "Create an account the first time someone signs in",
       "defaultRole": "Default role",
-      "defaultRoleHint": "The role a newly created account receives",
+      "defaultRoleHint": "Role for newly created accounts and fallback when stated groups match no mapping. Without one, non-JIT sign-in is denied when no mapping matches.",
       "noRole": "None",
       "groupMappings": "Group to role mappings",
       "addMapping": "Add mapping",

--- a/ui/src/i18n/locales/ko/settings.json
+++ b/ui/src/i18n/locales/ko/settings.json
@@ -1506,7 +1506,7 @@
       "requiredGroupHint": "지정하면 이 그룹 구성원만 로그인할 수 있습니다.",
       "allowJit": "처음 로그인하는 사람의 계정을 자동으로 만듭니다",
       "defaultRole": "기본 역할",
-      "defaultRoleHint": "자동 생성된 계정이 받을 역할",
+      "defaultRoleHint": "자동 생성 계정에 부여하고, 전달된 그룹이 어떤 매핑에도 일치하지 않을 때 적용할 역할입니다. 비워 둔 non-JIT 공급자는 매핑 불일치 시 로그인을 거부합니다.",
       "noRole": "선택 안 함",
       "groupMappings": "그룹 → 역할 매핑",
       "addMapping": "매핑 추가",


### PR DESCRIPTION
## 변경 내용

SSO 역할 동기화가 **그룹 클레임 미도착**과 **명시적인 매핑 불일치**를 구분하도록 통일했습니다.

| 조건 | 동작 |
|---|---|
| 그룹 역할 매핑 없음 | NPG의 기존 로컬 역할 유지 |
| `GroupsStated == false` | 기존 역할 유지 + 경고 로그 |
| `GroupsStated == true`이고 그룹 매핑 일치 | 매핑된 역할 적용 |
| `GroupsStated == true`, 일치 없음, 기본 역할 있음 | 기본 역할로 동기화 |
| `GroupsStated == true`, 일치 없음, 기본 역할 없음 | 로그인 거부 (`ErrSSONoRoleMapping`) |

추가로:

- 역할 매핑 거부를 `ErrSSONotAllowed`로 분류하고 refusal reason `role_not_mapped`를 기록합니다.
- `sso.fields.defaultRoleHint`의 영어·한국어 설명을 수정해 기본 역할이 JIT 생성뿐 아니라 명시적인 그룹 매핑 불일치 때의 fallback임을 알립니다.
- JIT provider는 기존 `Validate()`에서 기본 역할이 없으면 저장되지 않는다는 경계를 회귀 테스트로 고정합니다.

## 이 수정이 필요한 이유

non-JIT provider는 그룹 역할 매핑을 사용하면서 `DefaultRoleID`를 비워 둘 수 있습니다. 사용자가 과거 관리자 그룹으로 고권한 역할을 받은 뒤 IdP가 해당 그룹을 명시적으로 제거했는데도 기존 역할을 보존하면, 철회 후 새 관리자 세션이 발급되는 fail-open이 됩니다.

반대로 그룹 클레임 자체가 오지 않은 것은 권한 철회의 증거가 아닙니다. Authelia 등 일부 provider는 그룹을 UserInfo에서만 제공하고, NPG는 호환성을 위해 UserInfo 조회 실패를 fatal로 처리하지 않습니다. 이때 기본 역할로 강등하거나 로그인을 거부하면 일시적인 UserInfo 장애가 영구 역할 변경 또는 전체 로그인 장애로 확대됩니다.

따라서 권한 변경은 IdP가 그룹 목록을 실제로 명시한 경우에만 수행합니다.

## 호환성 및 잠금 동작

- 그룹 클레임이 ID token과 UserInfo 모두에서 누락되면 DB 역할을 변경하지 않고 로그인을 계속하며 경고를 기록합니다.
- 명시된 그룹이 어느 매핑에도 일치하지 않고 기본 역할도 없는 non-JIT provider만 fail-closed 대상입니다.
- JIT provider는 기본 역할 없이 저장할 수 없으므로 no-default 거부 분기에 정상적으로 도달하지 않습니다.
- 명시적인 no-default 매핑 불일치는 역할 선택 전에 거부되므로 마지막 superuser 강등 가드까지 도달하지 않습니다. 기본 역할로의 강등은 기존 마지막 superuser 가드를 그대로 거칩니다.
- 운영자는 최소 권한 기본 역할을 지정하거나 IdP 그룹 매핑을 복구할 수 있고, 로컬 계정 복구 경로도 유지됩니다.

## UI 안내

기존 문구는 기본 역할을 “새로 생성되는 계정의 역할”로만 설명해 non-JIT 운영자가 fallback을 설정할 이유를 알 수 없었습니다. ko/en 문구에 다음을 명시했습니다.

- 새 계정 생성 시 부여되는 역할
- 전달된 그룹이 어떤 매핑에도 일치하지 않을 때의 fallback
- non-JIT에서 비워 두면 명시적인 매핑 불일치 시 로그인이 거부됨

## 회귀 테스트

- 그룹 클레임 미도착 + 기본 역할 있음 → 기존 역할 유지
- 그룹 클레임 미도착 + 기본 역할 없음 → 기존 역할 유지
- 그룹 명시 + 매핑 일치 → 매핑 역할 적용
- 그룹 명시 + 불일치 + 기본 역할 있음 → 기본 역할 적용
- 그룹 명시 + 불일치 + 기본 역할 없음 → 로그인 거부
- 과거 admin/superuser 역할도 명시적인 no-default 불일치에서는 보존되지 않음
- JIT provider + 기본 역할 없음 → provider validation 단계에서 거부

## 검증

- RED: 클레임 미도착 테스트가 기존 코드에서 `role-viewer`, `enforce=true`를 반환하며 실패하는 것을 확인
- `go test ./cmd/... ./internal/... ./pkg/...`
- `go vet ./cmd/... ./internal/... ./pkg/...`
- UI `npm ci --ignore-scripts`
- UI production build
- `npm audit --omit=dev` — 취약점 0건
- `git diff --check`

UI 전체 lint는 upstream v2.45.0과 동일한 기존 결과(3 errors, 10 warnings)이며, 이번 변경 파일에서 추가된 오류는 없습니다.
