### PR TITLE
fix(nginx): apply redirect config sync at startup

### DIFF
--- a/api/internal/bootstrap/startup.go
+++ b/api/internal/bootstrap/startup.go
@@ -116,10 +116,10 @@ func runStartup(ctx context.Context, c *Container) error {
 	redirectHosts, _, err := c.Repositories.RedirectHost.List(ctx, 1, config.MaxWAFRulesLimit)
 	if err != nil {
 		log.Printf("[Startup] Warning: failed to list redirect hosts: %v", err)
-	} else if err := c.Nginx.GenerateAllRedirectConfigs(ctx, redirectHosts); err != nil {
-		log.Printf("[Startup] Warning: failed to sync redirect host configs: %v", err)
+	} else if err := c.Nginx.GenerateAllRedirectConfigsAndReload(ctx, redirectHosts); err != nil {
+		log.Printf("[Startup] ERROR: failed to sync and apply redirect host configs; running nginx may still have stale redirects: %v", err)
 	} else {
-		log.Println("[Startup] Redirect host configs synced successfully")
+		log.Println("[Startup] Redirect host configs synced and applied successfully")
 	}
 
 	// Regenerate default server config.

--- a/api/internal/nginx/redirect_config.go
+++ b/api/internal/nginx/redirect_config.go
@@ -231,3 +231,24 @@ func (m *Manager) GenerateAllRedirectConfigs(ctx context.Context, hosts []model.
 
 	return nil
 }
+
+// GenerateAllRedirectConfigsAndReload reconciles every redirect config and
+// applies the resulting set to the running nginx instance. Generation and the
+// test/reload are serialized under the global nginx lock so another config
+// operation cannot interleave between the file sweep and reload.
+//
+// Unlike normal user-driven updates, this startup reconciliation deliberately
+// does not restore swept files when applying the new set fails: an old file may
+// belong to an unsafe legacy redirect row. Keeping it absent on disk ensures a
+// later successful reload cannot reactivate it.
+func (m *Manager) GenerateAllRedirectConfigsAndReload(ctx context.Context, hosts []model.RedirectHost) error {
+	return m.executeWithLock(ctx, func() error {
+		if err := m.GenerateAllRedirectConfigs(ctx, hosts); err != nil {
+			return err
+		}
+		if err := m.testAndReloadNginxWithRetry(ctx); err != nil {
+			return fmt.Errorf("failed to apply redirect config sync to nginx: %w", err)
+		}
+		return nil
+	})
+}

--- a/api/internal/nginx/redirect_config_test.go
+++ b/api/internal/nginx/redirect_config_test.go
@@ -59,6 +59,47 @@ func TestGenerateAllRedirectConfigsSkipsOnlyInvalidEnabledHost(t *testing.T) {
 	}
 }
 
+func TestGenerateAllRedirectConfigsAndReloadAppliesStaleRemoval(t *testing.T) {
+	configDir := t.TempDir()
+	stale := filepath.Join(configDir, "redirect_host_legacy.example.com.conf")
+	if err := os.WriteFile(stale, []byte("# stale legacy config\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cli := &fakeNginxCLI{}
+	manager := &Manager{configPath: configDir, httpPort: "80", httpsPort: "443", cli: cli}
+	if err := manager.GenerateAllRedirectConfigsAndReload(context.Background(), nil); err != nil {
+		t.Fatalf("startup redirect sync failed: %v", err)
+	}
+	if _, err := os.Stat(stale); !os.IsNotExist(err) {
+		t.Fatalf("stale redirect config was not removed: %v", err)
+	}
+	if cli.testCalls != 1 || cli.reloadCalls != 1 {
+		t.Fatalf("nginx calls = test:%d reload:%d, want test:1 reload:1", cli.testCalls, cli.reloadCalls)
+	}
+}
+
+func TestGenerateAllRedirectConfigsAndReloadReturnsApplyFailure(t *testing.T) {
+	configDir := t.TempDir()
+	stale := filepath.Join(configDir, "redirect_host_unsafe.example.com.conf")
+	if err := os.WriteFile(stale, []byte("# stale unsafe config\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cli := &fakeNginxCLI{reloadErrs: []error{errors.New("reload failed: permission denied")}}
+	manager := &Manager{configPath: configDir, httpPort: "80", httpsPort: "443", cli: cli}
+	err := manager.GenerateAllRedirectConfigsAndReload(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected reload failure")
+	}
+	if cli.testCalls != 1 || cli.reloadCalls != 1 {
+		t.Fatalf("nginx calls = test:%d reload:%d, want test:1 reload:1", cli.testCalls, cli.reloadCalls)
+	}
+	if _, statErr := os.Stat(stale); !os.IsNotExist(statErr) {
+		t.Fatalf("failed apply restored an unsafe stale config: %v", statErr)
+	}
+}
+
 func TestBulkRollbackDoesNotRestoreUnsafeRedirectConfig(t *testing.T) {
 	configDir := t.TempDir()
 	cli := &fakeNginxCLI{testErrs: []error{


### PR DESCRIPTION
## 변경 내용

- 시작 시 Redirect Host 전체 설정을 재생성한 뒤 같은 Nginx 전역 lock 안에서 `nginx -t`와 reload를 수행합니다.
- transient Docker/Nginx 오류에는 기존 지수 backoff 재시도 경로를 사용합니다.
- 적용 실패를 일반 경고가 아니라 stale redirect가 런타임에 남을 수 있다는 명확한 오류로 기록합니다.
- unsafe legacy 설정 파일은 삭제 후 적용 실패가 발생해도 다시 복원하지 않습니다.

## 이 수정이 필요한 이유

Nginx는 설정 파일을 시작 또는 reload 시 메모리에 읽습니다. 파일을 디스크에서 삭제하는 것만으로 이미 실행 중인 worker의 설정은 바뀌지 않습니다.

기존 시작 경로는 `GenerateAllRedirectConfigs`로 위험한 legacy Redirect Host 파일을 삭제하면서도 Nginx를 reload하지 않았습니다. API와 Nginx가 별도 컨테이너인 환경에서 API만 업그레이드·재시작하면 파일은 사라져도 기존 주입 설정이 Nginx worker 메모리에서 계속 동작할 수 있었습니다.

## 호환성 및 실패 처리

- 정상 시작 시 설정 생성 뒤 한 번의 test/reload가 추가됩니다.
- Nginx 테스트가 실패하면 reload하지 않으며 원인을 크게 기록합니다.
- 기존 unsafe 파일은 보안상 rollback으로 되살리지 않습니다. 이후 성공한 동기화/reload가 안전한 디스크 상태를 적용할 수 있습니다.
- 사용자 API의 단일 Redirect Host atomic update 동작은 변경하지 않습니다.

## 검증

- 회귀 테스트: stale Redirect config 삭제 후 Nginx test/reload가 각각 1회 실행됨
- 회귀 테스트: reload 실패가 호출자에게 반환되고 unsafe stale config가 복원되지 않음
- `go test ./cmd/... ./internal/... ./pkg/...`
- `go vet ./cmd/... ./internal/... ./pkg/...`
- `git diff --check`
- 공통 UI production build 및 `npm audit --omit=dev` (취약점 0건)
