### PR TITLE
fix(api): allow disabling unsafe legacy redirects

### DIFF
--- a/api/internal/model/redirect_host.go
+++ b/api/internal/model/redirect_host.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+	"reflect"
 	"strconv"
 	"strings"
 	"time"
@@ -84,6 +85,32 @@ func ValidateRedirectHost(host *RedirectHost) error {
 		return fmt.Errorf("redirect_code must be one of 301, 302, 307 or 308")
 	}
 	return nil
+}
+
+// ValidateRedirectHostUpdate validates the merged update while allowing one
+// narrow recovery action for unsafe legacy rows: an enabled row may be changed
+// to disabled when Enabled is the only effective change. Requests may repeat
+// existing values (as the UI's full edit form does), but every actual edit or
+// re-enable must pass the normal full-host validation.
+func ValidateRedirectHostUpdate(existing, updated *RedirectHost, req *UpdateRedirectHostRequest) error {
+	err := ValidateRedirectHost(updated)
+	if err == nil {
+		return nil
+	}
+	if isDisableOnlyRedirectHostUpdate(existing, updated, req) {
+		return nil
+	}
+	return err
+}
+
+func isDisableOnlyRedirectHostUpdate(existing, updated *RedirectHost, req *UpdateRedirectHostRequest) bool {
+	if existing == nil || updated == nil || req == nil ||
+		!existing.Enabled || updated.Enabled || req.Enabled == nil || *req.Enabled {
+		return false
+	}
+	existingWithUpdatedEnabled := *existing
+	existingWithUpdatedEnabled.Enabled = updated.Enabled
+	return reflect.DeepEqual(&existingWithUpdatedEnabled, updated)
 }
 
 // Validate applies defaults and validates a complete create request.

--- a/api/internal/model/redirect_host_test.go
+++ b/api/internal/model/redirect_host_test.go
@@ -92,3 +92,82 @@ func TestRedirectHostRequestValidationUsesDefaults(t *testing.T) {
 		t.Fatal("expected unsafe partial update to be rejected")
 	}
 }
+
+func TestValidateRedirectHostUpdateAllowsOnlyDisablingInvalidLegacyHost(t *testing.T) {
+	legacy := &RedirectHost{
+		DomainNames:       []string{"legacy.example.com"},
+		ForwardScheme:     "https",
+		ForwardDomainName: "target.example.com",
+		ForwardPath:       "/$http_authorization",
+		RedirectCode:      301,
+		Enabled:           true,
+	}
+	if err := ValidateRedirectHost(legacy); err == nil {
+		t.Fatal("test fixture must be invalid")
+	}
+
+	disabled := *legacy
+	disabled.Enabled = false
+	if err := ValidateRedirectHostUpdate(legacy, &disabled, &UpdateRedirectHostRequest{Enabled: boolPtr(false)}); err != nil {
+		t.Fatalf("disable-only transition rejected: %v", err)
+	}
+	if err := ValidateRedirectHostUpdate(legacy, &disabled, &UpdateRedirectHostRequest{
+		DomainNames:       append([]string(nil), legacy.DomainNames...),
+		ForwardScheme:     stringPtr(legacy.ForwardScheme),
+		ForwardDomainName: stringPtr(legacy.ForwardDomainName),
+		ForwardPath:       stringPtr(legacy.ForwardPath),
+		RedirectCode:      intPtr(legacy.RedirectCode),
+		Enabled:           boolPtr(false),
+	}); err != nil {
+		t.Fatalf("full-form disable with unchanged values rejected: %v", err)
+	}
+
+	tests := []struct {
+		name     string
+		existing *RedirectHost
+		updated  *RedirectHost
+		request  *UpdateRedirectHostRequest
+	}{
+		{
+			name:     "unsafe edit while disabling",
+			existing: legacy,
+			updated: func() *RedirectHost {
+				host := disabled
+				host.ForwardPath = "/$request_uri"
+				return &host
+			}(),
+			request: &UpdateRedirectHostRequest{Enabled: boolPtr(false), ForwardPath: stringPtr("/$request_uri")},
+		},
+		{
+			name:     "changed merged value hidden from request",
+			existing: legacy,
+			updated: func() *RedirectHost {
+				host := disabled
+				host.ForwardPath = "/$request_uri"
+				return &host
+			}(),
+			request: &UpdateRedirectHostRequest{Enabled: boolPtr(false)},
+		},
+		{
+			name: "re-enable invalid disabled host",
+			existing: func() *RedirectHost {
+				host := disabled
+				return &host
+			}(),
+			updated: legacy,
+			request: &UpdateRedirectHostRequest{Enabled: boolPtr(true)},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := ValidateRedirectHostUpdate(tt.existing, tt.updated, tt.request); err == nil {
+				t.Fatal("expected invalid legacy update to be rejected")
+			}
+		})
+	}
+}
+
+func boolPtr(value bool) *bool       { return &value }
+func intPtr(value int) *int          { return &value }
+func stringPtr(value string) *string { return &value }

--- a/api/internal/repository/redirect_host.go
+++ b/api/internal/repository/redirect_host.go
@@ -147,6 +147,7 @@ func (r *RedirectHostRepository) Update(ctx context.Context, id string, req *mod
 	if existing == nil {
 		return nil, nil
 	}
+	previous := *existing
 
 	// Apply updates
 	if len(req.DomainNames) > 0 {
@@ -183,7 +184,7 @@ func (r *RedirectHostRepository) Update(ctx context.Context, id string, req *mod
 		existing.BlockExploits = *req.BlockExploits
 	}
 
-	if err := model.ValidateRedirectHost(existing); err != nil {
+	if err := model.ValidateRedirectHostUpdate(&previous, existing, req); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
## 변경 내용

- 기존 DB에 남아 있는 unsafe legacy Redirect Host에 대해 `enabled=false`만 수행하는 안전한 전환을 허용합니다.
- 이 예외는 `enabled`가 유일한 실질적 변경인 요청으로 제한합니다. UI의 전체 편집 폼처럼 기존 값을 그대로 반복 전송하는 요청도 지원합니다.
- 같은 요청에서 target/path/domain 등 실제 값이 달라지면 기존과 동일하게 전체 검증으로 거부합니다.
- invalid legacy 행의 재활성화 및 새로운 unsafe 값 저장은 계속 거부합니다.
- 저장 후 기존 handler 경로가 해당 Nginx 설정을 제거하고 test/reload합니다.

## 이 수정이 필요한 이유

부분 요청 검증은 `enabled=false`를 허용하지만 repository는 기존 값을 병합한 후 전체 객체를 검증합니다. 구버전에서 저장된 unsafe target/path가 있으면 운영자가 비활성화만 요청해도 기존 값 때문에 저장이 거부되고, 설정 제거 및 Nginx reload까지 도달하지 못했습니다.

`proxy:write` 권한만 가진 운영자는 `proxy:delete`가 필요한 삭제도 할 수 없어 UI에서 위험 설정을 즉시 끄지 못할 수 있습니다.

## 보안 경계와 호환성

- 예외는 기존 행을 비활성화하며 병합 결과가 `Enabled` 외에는 동일한 경우에만 적용합니다.
- disable 요청에 다른 실질적 필드 변경을 섞어 validation을 우회할 수 없습니다.
- 이미 안전한 행의 일반 수정 동작은 변하지 않습니다.
- 위험 값은 disabled 상태로 DB에 남을 수 있지만 Nginx 렌더 대상에서 제거되며, 값을 안전하게 수정하기 전에는 다시 활성화할 수 없습니다.

## 검증

- 회귀 테스트: 최소 `enabled=false` 요청과 기존 값을 반복하는 UI 전체 폼 요청 모두 unsafe legacy 행을 비활성화할 수 있음
- 회귀 테스트: 비활성화와 함께 unsafe 값을 변경하거나 invalid 행을 재활성화하면 계속 거부됨
- 관련 model/repository/nginx 테스트
- `go test ./cmd/... ./internal/... ./pkg/...`
- `go vet ./cmd/... ./internal/... ./pkg/...`
- `git diff --check`
- 공통 UI production build 및 `npm audit --omit=dev` (취약점 0건)
